### PR TITLE
Load speech service secrets from configuration

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -38,5 +38,18 @@
     }
   },
 
+  "YSpeech": {
+    "YandexPassportOauthToken": "1111",
+    "ApiKey": "111",
+    "ServiceAccountId": "111",
+    "FolderId": "11",
+    "AccessKey": "11",
+    "SecretKey": "111-",
+    "AwsAccessKey": "111",
+    "AwsSecretKey": "111",
+    "S3ServiceUrl": "https://storage.yandexcloud.net",
+    "DefaultBucketName": "ruticker"
+  },
+
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- read YSpeechService secrets from the dedicated YSpeech configuration section
- move the Yandex speech credentials into appsettings.json

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d190eefcd083319d5bbb1e61772ff6