### PR TITLE
Load OpenAI API key from configuration

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -7,6 +7,11 @@
   },
 
 
+  "OpenAI": {
+    "ApiKey": "---- poot to config ----------"
+  },
+
+
 
   "FfmpegExePath": "C:\\Documents and Settings\\user\\AppData\\Local\\Programs\\FFmpeg\\bin\\",
   "FfmpegExePath1": "C:\\Users\\Artem\\AppData\\Local\\Programs\\FFmpeg\\bin\\",

--- a/services/PunctuationService.cs
+++ b/services/PunctuationService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace YandexSpeech.services
 {
@@ -12,13 +13,14 @@ namespace YandexSpeech.services
 
     public class PunctuationService : IPunctuationService
     {
-        private readonly string _openAiApiKey = "---- poot to config ----------";
+        private readonly string _openAiApiKey;
         private const int MaxRetries = 20;
         private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(15);
 
-        public PunctuationService()
+        public PunctuationService(IConfiguration configuration)
         {
-            // Можно получить ключ из окружения, если нужно.
+            _openAiApiKey = configuration["OpenAI:ApiKey"]
+                ?? throw new InvalidOperationException("OpenAI:ApiKey is not configured.");
         }
 
         public async Task<string> GetAvailableModelsAsync()


### PR DESCRIPTION
## Summary
- inject IConfiguration into `PunctuationService` and read the OpenAI API key from configuration
- add an `OpenAI:ApiKey` setting to `appsettings.json`

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1914e26948331906b4bcafdd9f490