### PR TITLE
Fix blog comment cascade delete behavior

### DIFF
--- a/Migrations/20250901000000_BlogFeed.Designer.cs
+++ b/Migrations/20250901000000_BlogFeed.Designer.cs
@@ -900,7 +900,7 @@ namespace YandexSpeech.Migrations
                     b.HasOne("YandexSpeech.models.DB.ApplicationUser", "CreatedBy")
                         .WithMany()
                         .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("YandexSpeech.models.DB.BlogTopic", "Topic")

--- a/Migrations/20250901000000_BlogFeed.cs
+++ b/Migrations/20250901000000_BlogFeed.cs
@@ -53,7 +53,7 @@ namespace YandexSpeech.Migrations
                         column: x => x.CreatedById,
                         principalTable: "AspNetUsers",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_BlogComments_BlogTopics_TopicId",
                         column: x => x.TopicId,

--- a/Migrations/MyDbContextModelSnapshot.cs
+++ b/Migrations/MyDbContextModelSnapshot.cs
@@ -897,7 +897,7 @@ namespace YandexSpeech.Migrations
                     b.HasOne("YandexSpeech.models.DB.ApplicationUser", "CreatedBy")
                         .WithMany()
                         .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("YandexSpeech.models.DB.BlogTopic", "Topic")

--- a/dbcontext.cs
+++ b/dbcontext.cs
@@ -55,6 +55,12 @@ namespace YandexSpeech
                 .WithOne(c => c.Topic)
                 .HasForeignKey(c => c.TopicId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Entity<BlogComment>()
+                .HasOne(c => c.CreatedBy)
+                .WithMany()
+                .HasForeignKey(c => c.CreatedById)
+                .OnDelete(DeleteBehavior.Restrict);
         }
 
     }


### PR DESCRIPTION
## Summary
- prevent multiple cascade paths by making BlogComment.CreatedBy delete behavior restricted
- configure the DbContext model so the relationship matches the migration metadata

## Testing
- ⚠️ `dotnet ef database update` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f179a1d8833185533041e3f6e45a