### PR TITLE
Align side menu icons

### DIFF
--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.css
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.css
@@ -7,6 +7,35 @@ mat-nav-list {
   padding-top: 8px;
 }
 
-mat-list-item {
+a[mat-list-item] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  font-size: 16px;
+  text-decoration: none;
   cursor: pointer;
+  border-radius: 8px;
+}
+
+a[mat-list-item]:hover {
+  background-color: rgba(72, 119, 166, 0.12);
+}
+
+mat-icon[matListItemIcon] {
+  font-size: 20px;
+  color: #4877a6;
+}
+
+span[matListItemTitle] {
+  color: #2b2b2b;
+}
+
+a[mat-list-item].active span[matListItemTitle] {
+  color: #4877a6;
+  font-weight: 600;
+}
+
+a[mat-list-item].active mat-icon[matListItemIcon] {
+  color: #4877a6;
 }

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -2,19 +2,24 @@
 <mat-nav-list>
   <ng-container *ngIf="user$ | async as user; else guestMenu">
     <a mat-list-item (click)="navigate('/recognition')">
-      <mat-icon>home</mat-icon><span>Распознавание</span>
+      <mat-icon matListItemIcon>home</mat-icon>
+      <span matListItemTitle>Распознавание</span>
     </a>
     <a mat-list-item (click)="navigate('/tasks')">
-      <mat-icon>subtitles</mat-icon><span>Скрипториум</span>
+      <mat-icon matListItemIcon>subtitles</mat-icon>
+      <span matListItemTitle>Скрипториум</span>
     </a>
     <a mat-list-item (click)="navigate('/down')">
-      <mat-icon>download-icons</mat-icon><span>Скачать ролик</span>
+      <mat-icon matListItemIcon>download-icons</mat-icon>
+      <span matListItemTitle>Скачать ролик</span>
     </a>
     <a mat-list-item (click)="navigate('/markdown-converter')">
-      <mat-icon>sync_alt</mat-icon><span>Конвертер Markdown </span>
+      <mat-icon matListItemIcon>sync_alt</mat-icon>
+      <span matListItemTitle>Конвертер Markdown </span>
     </a>
     <a mat-list-item (click)="navigate('/blog')">
-      <mat-icon>article</mat-icon><span>Блоги</span>
+      <mat-icon matListItemIcon>article</mat-icon>
+      <span matListItemTitle>Блоги</span>
     </a>
     <mat-divider></mat-divider>
     <a mat-list-item (click)="onLogout()">
@@ -23,20 +28,25 @@
   </ng-container>
   <ng-template #guestMenu>
     <a mat-list-item (click)="navigate('/recognition')">
-      <mat-icon>home</mat-icon><span>Распознавание</span>
+      <mat-icon matListItemIcon>home</mat-icon>
+      <span matListItemTitle>Распознавание</span>
     </a>
     <a mat-list-item (click)="navigate('/tasks')">
-      <mat-icon>subtitles</mat-icon><span>Скрипториум</span>
+      <mat-icon matListItemIcon>subtitles</mat-icon>
+      <span matListItemTitle>Скрипториум</span>
     </a>
     <a mat-list-item (click)="navigate('/markdown-converter')">
-      <mat-icon>sync_alt</mat-icon><span>Конвертер Markdown</span>
+      <mat-icon matListItemIcon>sync_alt</mat-icon>
+      <span matListItemTitle>Конвертер Markdown</span>
     </a>
     <a mat-list-item (click)="navigate('/blog')">
-      <mat-icon>article</mat-icon><span>Блоги</span>
+      <mat-icon matListItemIcon>article</mat-icon>
+      <span matListItemTitle>Блоги</span>
     </a>
     <mat-divider></mat-divider>
     <a mat-list-item (click)="navigate('/login')">
-      <mat-icon>login</mat-icon><span>Войти</span>
+      <mat-icon matListItemIcon>login</mat-icon>
+      <span matListItemTitle>Войти</span>
     </a>
   </ng-template>
 </mat-nav-list>


### PR DESCRIPTION
## Summary
- align the side menu markup with `matListItemIcon`/`matListItemTitle` to ensure icons line up with text
- add styling for anchor items, icons, and titles to match the referenced layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1f1fd71c4833186eae4dbacd7c7ef