### PR TITLE
Add moderator topic creation page with markdown editor

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
@@ -3,32 +3,10 @@
     <mat-card>
       <mat-card-title>Новая тема</mat-card-title>
       <mat-card-content>
-        <form [formGroup]="topicForm" (ngSubmit)="submitTopic()">
-          <mat-form-field class="full-width" appearance="outline">
-            <mat-label>Заголовок</mat-label>
-            <input matInput formControlName="title" maxlength="256" />
-            <mat-hint align="end">{{ topicForm.value.title?.length || 0 }}/256</mat-hint>
-            <mat-error *ngIf="topicForm.controls['title'].hasError('required')">
-              Укажите заголовок
-            </mat-error>
-          </mat-form-field>
-
-          <mat-form-field class="full-width" appearance="outline">
-            <mat-label>Текст</mat-label>
-            <textarea matInput formControlName="text" rows="6" maxlength="10000"></textarea>
-            <mat-hint align="end">{{ topicForm.value.text?.length || 0 }}/10000</mat-hint>
-            <mat-error *ngIf="topicForm.controls['text'].hasError('required')">
-              Укажите текст темы
-            </mat-error>
-          </mat-form-field>
-
-          <div class="form-actions">
-            <span class="error" *ngIf="topicError">{{ topicError }}</span>
-            <button mat-flat-button color="primary" type="submit" [disabled]="topicSubmitting">
-              Опубликовать
-            </button>
-          </div>
-        </form>
+        <p>Используйте редактор с поддержкой Markdown и LaTeX, чтобы оформить новую публикацию.</p>
+        <button mat-flat-button color="primary" [routerLink]="['/blog/new']">
+          Открыть редактор
+        </button>
       </mat-card-content>
     </mat-card>
   </section>
@@ -52,7 +30,7 @@
           <b>Число ответов:</b> {{ topic.commentCount }}
         </div>
 
-        <div class="content" [class.collapsed]="topic.collapsed" [innerHTML]="topic.text"></div>
+        <div class="content" [class.collapsed]="topic.collapsed" [innerHTML]="topic.renderedText"></div>
         <p *ngIf="topic.textIsTooLong" class="toggle">
           <button mat-button color="primary" (click)="toggleCollapse(topic)">
             {{ topic.collapsed ? 'Развернуть' : 'Свернуть' }}

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
@@ -1,0 +1,69 @@
+.create-topic-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.editor-section {
+  margin-top: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  padding: 12px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.editor-section.invalid {
+  border-color: #f44336;
+}
+
+.editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: #424242;
+}
+
+.editor-header label {
+  font-weight: 500;
+}
+
+.char-counter {
+  color: #757575;
+  font-size: 0.85rem;
+}
+
+.editor-error {
+  color: #c62828;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  margin-top: 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.error {
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .create-topic-container {
+    padding: 12px;
+  }
+
+  .editor-section {
+    padding: 8px;
+  }
+}

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
@@ -1,0 +1,47 @@
+<div class="create-topic-container">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Новая тема</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <form [formGroup]="topicForm" (ngSubmit)="onSubmit()">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Заголовок</mat-label>
+          <input matInput formControlName="title" maxlength="256" />
+          <mat-hint align="end">{{ titleLength }}/256</mat-hint>
+          <mat-error *ngIf="topicForm.controls['title'].hasError('required')">
+            Укажите заголовок
+          </mat-error>
+        </mat-form-field>
+
+        <div class="editor-section" [class.invalid]="topicForm.controls['text'].invalid && topicForm.controls['text'].touched">
+          <div class="editor-header">
+            <label for="topic-text">Текст</label>
+            <span class="char-counter">{{ textLength }}/10000</span>
+          </div>
+          <md-editor
+            id="topic-text"
+            formControlName="text"
+            preview="vertical"
+            height="'420px'"
+            [options]="editorOptions"
+            [preRender]="preRender"
+          ></md-editor>
+          <div class="editor-error" *ngIf="topicForm.controls['text'].hasError('required') && topicForm.controls['text'].touched">
+            Укажите текст темы
+          </div>
+        </div>
+
+        <div class="form-actions">
+          <button mat-stroked-button type="button" (click)="onCancel()" [disabled]="submitting">
+            Отмена
+          </button>
+          <span class="error" *ngIf="submitError">{{ submitError }}</span>
+          <button mat-flat-button color="primary" type="submit" [disabled]="submitting">
+            Опубликовать
+          </button>
+        </div>
+      </form>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
@@ -1,0 +1,112 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { LMarkdownEditorModule } from 'ngx-markdown-editor';
+import { finalize } from 'rxjs/operators';
+import { BlogService } from '../services/blog.service';
+import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
+
+@Component({
+  selector: 'app-blog-topic-create',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    LMarkdownEditorModule
+  ],
+  templateUrl: './blog-topic-create.component.html',
+  styleUrls: ['./blog-topic-create.component.css']
+})
+export class BlogTopicCreateComponent {
+  private readonly titleMaxLength = 256;
+  private readonly textMaxLength = 10000;
+
+  readonly topicForm: FormGroup;
+
+  readonly editorOptions = {
+    placeholder: 'Опишите тему с использованием Markdown и LaTeX',
+    katex: true,
+    theme: 'github',
+    lineNumbers: true,
+    dragDrop: true,
+    showPreviewPanel: true,
+    hideIcons: [] as string[]
+  };
+
+  readonly preRender = (content: string): string => this.markdownRenderer.renderMath(content ?? '');
+
+  submitting = false;
+  submitError = '';
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly blogService: BlogService,
+    private readonly router: Router,
+    private readonly snackBar: MatSnackBar,
+    private readonly markdownRenderer: MarkdownRendererService1
+  ) {
+    this.topicForm = this.fb.group({
+      title: ['', [Validators.required, Validators.maxLength(this.titleMaxLength)]],
+      text: ['', [Validators.required, Validators.maxLength(this.textMaxLength)]]
+    });
+  }
+
+  get titleLength(): number {
+    return this.topicForm.value.title?.length ?? 0;
+  }
+
+  get textLength(): number {
+    return this.topicForm.value.text?.length ?? 0;
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/blog']);
+  }
+
+  onSubmit(): void {
+    if (this.submitting) {
+      return;
+    }
+
+    this.submitError = '';
+
+    if (this.topicForm.invalid) {
+      this.topicForm.markAllAsTouched();
+      return;
+    }
+
+    const rawTitle = (this.topicForm.value.title ?? '').trim();
+    const rawText = (this.topicForm.value.text ?? '').trim();
+
+    if (!rawTitle || !rawText) {
+      this.submitError = 'Заполните заголовок и текст темы.';
+      return;
+    }
+
+    this.submitting = true;
+
+    this.blogService
+      .createTopic({ title: rawTitle, text: rawText })
+      .pipe(finalize(() => (this.submitting = false)))
+      .subscribe({
+        next: () => {
+          this.snackBar.open('Тема опубликована', undefined, { duration: 3000 });
+          this.router.navigate(['/blog']);
+        },
+        error: () => {
+          this.submitError = 'Не удалось создать тему. Попробуйте позже.';
+        }
+      });
+  }
+}

--- a/Angular/youtube-downloader/src/app/services/role.guard.ts
+++ b/Angular/youtube-downloader/src/app/services/role.guard.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+import { AuthService } from './AuthService.service';
+
+@Injectable({ providedIn: 'root' })
+export class RoleGuard implements CanActivate {
+  constructor(private readonly auth: AuthService, private readonly router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    const roles = (route.data['roles'] as string[] | undefined) ?? [];
+
+    return this.auth.user$.pipe(
+      take(1),
+      map(user => {
+        if (!user) {
+          return this.router.createUrlTree(['/login'], { queryParams: { returnUrl: state.url } });
+        }
+
+        if (roles.length === 0) {
+          return true;
+        }
+
+        const hasRole = user.roles.some(userRole =>
+          roles.some(required => required.toLowerCase() === userRole.toLowerCase())
+        );
+
+        if (hasRole) {
+          return true;
+        }
+
+        return this.router.createUrlTree(['/blog']);
+      })
+    );
+  }
+}

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -21,6 +21,10 @@
       <mat-icon matListItemIcon>article</mat-icon>
       <span matListItemTitle>Блоги</span>
     </a>
+    <a mat-list-item *ngIf="hasRole(user, 'Moderator')" (click)="navigate('/blog/new')">
+      <mat-icon matListItemIcon>post_add</mat-icon>
+      <span matListItemTitle>Новая тема</span>
+    </a>
     <mat-divider></mat-divider>
     <a mat-list-item (click)="onLogout()">
       <mat-icon>logout</mat-icon><span>Выйти ({{user.email}})</span>

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.ts
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.ts
@@ -24,8 +24,12 @@ export class SideMenuComponent {
   user$: Observable<UserInfo | null>;
 
   constructor(private auth: AuthService, private router: Router) {
-    
+
     this.user$ = this.auth.user$;
+  }
+
+  hasRole(user: UserInfo | null, role: string): boolean {
+    return !!user?.roles?.some(r => r.toLowerCase() === role.toLowerCase());
   }
 
   navigate(path: string) {

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -25,6 +25,8 @@ import { EditorPageComponent } from './app/editor-pade/editor-page.component';
 import { AudioFilesComponent } from './app/audio-file/audio-files.component';
 import { MarkdownConverterComponent } from './app/Markdown-converter/markdown-converter.component';
 import { BlogFeedComponent } from './app/blog-feed/blog-feed.component';
+import { BlogTopicCreateComponent } from './app/blog-topic-create/blog-topic-create.component';
+import { RoleGuard } from './app/services/role.guard';
 
 
 
@@ -79,6 +81,12 @@ const routes: Routes = [
   {
     path: 'tasks',
     component: SubtitlesTasksComponent, // страница со списком задач
+  },
+  {
+    path: 'blog/new',
+    component: BlogTopicCreateComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Moderator'] }
   },
   {
     path: 'ServiceNews',

--- a/Program.cs
+++ b/Program.cs
@@ -138,6 +138,8 @@ builder.Services.AddSpaStaticFiles(opts => opts.RootPath = "wwwroot");
 
 var app = builder.Build();
 
+await EnsureRolesAsync(app.Services);
+
 // (пропущена инициализация ролей и IndexNow для краткости)
 
 app.UseRouting();
@@ -168,3 +170,19 @@ else
 }
 
 app.Run();
+
+static async Task EnsureRolesAsync(IServiceProvider services)
+{
+    using var scope = services.CreateScope();
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+    var rolesToEnsure = new[] { "Free", "Moderator" };
+
+    foreach (var roleName in rolesToEnsure)
+    {
+        if (!await roleManager.RoleExistsAsync(roleName))
+        {
+            await roleManager.CreateAsync(new IdentityRole(roleName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a moderator-only blog topic creation page that reuses the existing markdown editor
- guard the new route, expose it from the side menu for moderators, and render markdown content in the blog feed
- seed the "Free" and "Moderator" identity roles during application startup

## Testing
- npm run build *(fails: index html generation cannot fetch fonts in offline container)*
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f622d240833194c69898a22b5234