### PR TITLE
feat(blog): add markdown detail page with infinite feed previews

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.css
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.css
@@ -1,4 +1,4 @@
-.blog-container {
+.page-shell {
   max-width: 900px;
   margin: 0 auto;
   padding: 16px;
@@ -11,45 +11,35 @@
   background: #fafafa;
 }
 
-.full-width {
-  width: 100%;
-}
-
-.form-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.error {
-  color: #c62828;
-  font-size: 0.9rem;
-}
-
 .feed-state {
   text-align: center;
   color: #666;
 }
 
-.blogblock {
-  margin-bottom: 16px;
+.blog-container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.blog-card {
+  margin: 0;
 }
 
 .topic-meta {
   display: flex;
-  gap: 8px;
+  gap: 12px;
   align-items: baseline;
   font-size: 0.95rem;
+  flex-wrap: wrap;
 }
 
 .topic-meta span {
   color: #777;
 }
 
-.topic-comments-count {
-  margin: 8px 0;
+.topic-author {
+  color: #2f3034;
 }
 
 .content {
@@ -59,7 +49,7 @@
 }
 
 .content.collapsed {
-  max-height: 200px;
+  max-height: 220px;
   position: relative;
 }
 
@@ -73,93 +63,48 @@
   background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%);
 }
 
-.toggle {
-  margin-top: 8px;
-}
-
-.comments {
-  margin-top: 16px;
+.card-actions {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 12px;
+  align-items: center;
+  margin-top: 16px;
 }
 
-.comment {
-  padding: 8px 0;
-  border-bottom: 1px solid #ececec;
+.card-actions .toggle {
+  margin-right: auto;
 }
 
-.comment:last-child {
-  border-bottom: none;
-}
-
-.comment-header {
+.feed-loader,
+.feed-end,
+.initial-loader {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
+  align-items: center;
   color: #757575;
-  font-size: 0.85rem;
-  margin-bottom: 4px;
+  font-size: 0.95rem;
 }
 
-.comment-text {
-  white-space: pre-wrap;
-}
-
-.empty-comments {
-  color: #888;
-  font-size: 0.9rem;
-}
-
-.comment-form {
-  margin-top: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.login-hint {
-  color: #888;
-  margin-top: 12px;
-}
-
-.desktop-only {
-  display: block;
-}
-
-.mobile-only {
-  display: none;
-}
-
-.desktop-pagination {
-  display: flex;
-  justify-content: center;
-  margin: 16px 0;
-}
-
-.loading-overlay {
-  display: flex;
-  justify-content: center;
-  margin: 24px 0;
-}
-
-.mobile-scroll-anchor {
-  display: flex;
-  justify-content: center;
+.feed-loader {
   padding: 16px 0;
 }
 
+.feed-end {
+  padding: 12px 0 24px;
+}
+
+.initial-loader {
+  padding: 32px 0;
+}
+
 @media (max-width: 768px) {
-  .blog-container {
+  .page-shell {
     padding: 12px;
     gap: 16px;
   }
 
-  .desktop-only {
-    display: none;
-  }
-
-  .mobile-only {
-    display: block;
+  .blog-container {
+    gap: 16px;
   }
 
   .topic-creation mat-card {

--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
@@ -1,4 +1,4 @@
-<div class="blog-container">
+<div class="page-shell">
   <section class="topic-creation" *ngIf="canCreateTopics">
     <mat-card>
       <mat-card-title>Новая тема</mat-card-title>
@@ -16,96 +16,57 @@
     Пока нет тем. Создайте первую!
   </div>
 
-  <ng-template #topicCard let-topic>
-    <mat-card class="blogblock">
+  <div
+    class="blog-container"
+    infiniteScroll
+    [scrollWindow]="true"
+    [infiniteScrollDistance]="2"
+    [infiniteScrollThrottle]="200"
+    [infiniteScrollDisabled]="loading || allLoaded"
+    (scrolled)="onScrollDown()"
+  >
+    <mat-card class="blog-card" *ngFor="let topic of topics; trackBy: trackByTopicId">
       <mat-card-header>
         <mat-card-title>{{ topic.header }}</mat-card-title>
       </mat-card-header>
       <mat-card-content>
         <div class="topic-meta">
-          <b>{{ topic.user }}</b>
+          <b class="topic-author">{{ topic.user }}</b>
           <span>{{ topic.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
-        </div>
-        <div class="topic-comments-count" *ngIf="topic.commentCount > 0">
-          <b>Число ответов:</b> {{ topic.commentCount }}
+          <span class="topic-comments-count" *ngIf="topic.commentCount > 0">
+            Комментариев: {{ topic.commentCount }}
+          </span>
         </div>
 
         <div class="content" [class.collapsed]="topic.collapsed" [innerHTML]="topic.renderedText"></div>
-        <p *ngIf="topic.textIsTooLong" class="toggle">
-          <button mat-button color="primary" (click)="toggleCollapse(topic)">
+
+        <div class="card-actions">
+          <button
+            mat-button
+            color="primary"
+            class="toggle"
+            *ngIf="topic.textIsTooLong"
+            (click)="toggleCollapse(topic)"
+          >
             {{ topic.collapsed ? 'Развернуть' : 'Свернуть' }}
           </button>
-        </p>
-
-        <mat-divider></mat-divider>
-
-        <section class="comments">
-          <h4>Комментарии</h4>
-          <div class="comment" *ngFor="let comment of topic.comments; trackBy: trackByCommentId">
-            <div class="comment-header">
-              <b>{{ comment.user }}</b>
-              <span>{{ comment.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
-            </div>
-            <div class="comment-text">{{ comment.text }}</div>
-          </div>
-          <div class="empty-comments" *ngIf="topic.comments.length === 0">
-            Пока нет комментариев
-          </div>
-        </section>
-
-        <mat-divider></mat-divider>
-
-        <section class="comment-form" *ngIf="currentUser; else loginHint">
-          <mat-form-field class="full-width" appearance="outline">
-            <mat-label>Комментарий</mat-label>
-            <textarea
-              matInput
-              rows="3"
-              [(ngModel)]="topic.newComment"
-              [ngModelOptions]="{ standalone: true }"
-              maxlength="2000"
-            ></textarea>
-          </mat-form-field>
-          <div class="form-actions">
-            <span class="error" *ngIf="topic.commentError">{{ topic.commentError }}</span>
-            <button mat-stroked-button color="primary" (click)="submitComment(topic)" [disabled]="topic.submittingComment">
-              Отправить
-            </button>
-          </div>
-        </section>
-        <ng-template #loginHint>
-          <div class="login-hint">Чтобы оставить комментарий, войдите в систему.</div>
-        </ng-template>
+          <a mat-stroked-button color="primary" [routerLink]="['/blog', topic.slug]">
+            Читать полностью
+          </a>
+        </div>
       </mat-card-content>
     </mat-card>
-  </ng-template>
 
-  <div class="desktop-only">
-    <ng-container *ngFor="let topic of topics; trackBy: trackByTopicId">
-      <ng-container *ngTemplateOutlet="topicCard; context: { $implicit: topic }"></ng-container>
-    </ng-container>
-    <div class="desktop-pagination" *ngIf="topics.length > 0">
-      <button mat-stroked-button color="primary" (click)="onLoadMore()" [disabled]="loading || allLoaded">
-        {{ allLoaded ? 'Больше нет записей' : 'Загрузить ещё' }}
-      </button>
+    <div class="feed-loader" *ngIf="loading && topics.length > 0">
+      <mat-spinner diameter="36"></mat-spinner>
     </div>
-    <div class="loading-overlay" *ngIf="loading && topics.length === 0">
-      <mat-spinner diameter="40"></mat-spinner>
+
+    <div class="feed-end" *ngIf="allLoaded && topics.length > 0">
+      Больше нет записей
     </div>
   </div>
 
-  <div class="mobile-only">
-    <ng-container *ngFor="let topic of topics; trackBy: trackByTopicId">
-      <ng-container *ngTemplateOutlet="topicCard; context: { $implicit: topic }"></ng-container>
-    </ng-container>
-    <div
-      infiniteScroll
-      [infiniteScrollDistance]="2"
-      [infiniteScrollThrottle]="300"
-      (scrolled)="onScrollDown()"
-      class="mobile-scroll-anchor"
-    >
-      <mat-spinner *ngIf="loading" diameter="36"></mat-spinner>
-    </div>
+  <div class="initial-loader" *ngIf="loading && topics.length === 0">
+    <mat-spinner diameter="40"></mat-spinner>
   </div>
 </div>

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
@@ -1,0 +1,115 @@
+.topic-shell {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.back-link {
+  align-self: flex-start;
+}
+
+.state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #666;
+  font-size: 1rem;
+}
+
+.topic-card {
+  padding-bottom: 8px;
+}
+
+.topic-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+
+.topic-author {
+  font-weight: 600;
+}
+
+.topic-content {
+  line-height: 1.7;
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.comments {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.comment {
+  padding-bottom: 12px;
+  border-bottom: 1px solid #ececec;
+}
+
+.comment:last-child {
+  border-bottom: none;
+}
+
+.comment-header {
+  display: flex;
+  justify-content: space-between;
+  color: #757575;
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+}
+
+.comment-text {
+  white-space: pre-wrap;
+}
+
+.empty {
+  color: #888;
+  font-size: 0.95rem;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.comment-form {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.comment-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.error {
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
+.login-hint {
+  margin-top: 16px;
+  color: #888;
+}
+
+@media (max-width: 768px) {
+  .topic-shell {
+    padding: 12px;
+    gap: 16px;
+  }
+
+  .comment-header {
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-start;
+  }
+}

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.html
@@ -1,0 +1,68 @@
+<div class="topic-shell">
+  <a mat-button color="primary" class="back-link" [routerLink]="['/blog']">
+    ← Вернуться к блогу
+  </a>
+
+  <div class="state" *ngIf="loadError">{{ loadError }}</div>
+
+  <div class="state" *ngIf="loading">
+    <mat-spinner diameter="48"></mat-spinner>
+  </div>
+
+  <mat-card class="topic-card" *ngIf="!loading && topic">
+    <mat-card-header>
+      <mat-card-title>{{ topic.header }}</mat-card-title>
+      <mat-card-subtitle>
+        <div class="topic-meta">
+          <span class="topic-author">{{ topic.user }}</span>
+          <span>{{ topic.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
+          <span *ngIf="topic.commentCount > 0">Комментариев: {{ topic.commentCount }}</span>
+        </div>
+      </mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <div class="topic-content" [innerHTML]="topic.renderedText"></div>
+
+      <mat-divider></mat-divider>
+
+      <section class="comments">
+        <h3>Комментарии</h3>
+        <div class="comment" *ngFor="let comment of topic.comments; trackBy: trackByCommentId">
+          <div class="comment-header">
+            <b>{{ comment.user }}</b>
+            <span>{{ comment.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
+          </div>
+          <div class="comment-text">{{ comment.text }}</div>
+        </div>
+        <div class="empty" *ngIf="topic.comments.length === 0">
+          Пока нет комментариев
+        </div>
+      </section>
+
+      <mat-divider></mat-divider>
+
+      <section class="comment-form" *ngIf="currentUser; else loginHint">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Комментарий</mat-label>
+          <textarea
+            matInput
+            rows="4"
+            maxlength="2000"
+            [(ngModel)]="topic.newComment"
+            [ngModelOptions]="{ standalone: true }"
+          ></textarea>
+        </mat-form-field>
+        <div class="comment-actions">
+          <span class="error" *ngIf="topic.commentError">{{ topic.commentError }}</span>
+          <button mat-raised-button color="primary" (click)="submitComment(topic)" [disabled]="topic.submittingComment">
+            Отправить
+          </button>
+        </div>
+      </section>
+      <ng-template #loginHint>
+        <div class="login-hint">Чтобы оставить комментарий, войдите в систему.</div>
+      </ng-template>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.ts
@@ -1,0 +1,144 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { finalize } from 'rxjs/operators';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { BlogService, BlogTopic, BlogComment } from '../services/blog.service';
+import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
+import { AuthService, UserInfo } from '../services/AuthService.service';
+
+interface BlogTopicDetailViewModel extends BlogTopic {
+  renderedText: string;
+  newComment: string;
+  submittingComment: boolean;
+  commentError?: string;
+}
+
+@Component({
+  selector: 'app-blog-topic-detail',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    MatCardModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './blog-topic-detail.component.html',
+  styleUrls: ['./blog-topic-detail.component.css']
+})
+export class BlogTopicDetailComponent implements OnInit {
+  topic: BlogTopicDetailViewModel | null = null;
+  loading = false;
+  loadError = '';
+  currentUser: UserInfo | null = null;
+
+  constructor(
+    private readonly blogService: BlogService,
+    private readonly route: ActivatedRoute,
+    private readonly markdownRenderer: MarkdownRendererService1,
+    private readonly authService: AuthService,
+    private readonly destroyRef: DestroyRef
+  ) {
+    this.authService.user$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(user => {
+        this.currentUser = user;
+      });
+  }
+
+  ngOnInit(): void {
+    this.route.paramMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => {
+        const slug = params.get('slug');
+        if (!slug) {
+          this.topic = null;
+          this.loadError = 'Публикация не найдена.';
+          return;
+        }
+
+        this.fetchTopic(slug);
+      });
+  }
+
+  submitComment(topic: BlogTopicDetailViewModel): void {
+    if (!this.currentUser || topic.submittingComment) {
+      return;
+    }
+
+    topic.commentError = '';
+    const text = (topic.newComment ?? '').trim();
+    if (!text) {
+      topic.commentError = 'Введите текст комментария.';
+      return;
+    }
+
+    topic.submittingComment = true;
+    this.blogService
+      .addComment(topic.id, { text })
+      .pipe(
+        finalize(() => {
+          topic.submittingComment = false;
+        })
+      )
+      .subscribe({
+        next: comment => {
+          topic.comments = [...topic.comments, comment];
+          topic.commentCount = topic.comments.length;
+          topic.newComment = '';
+        },
+        error: () => {
+          topic.commentError = 'Не удалось отправить комментарий. Попробуйте позже.';
+        }
+      });
+  }
+
+  trackByCommentId(_: number, comment: BlogComment): number {
+    return comment.id;
+  }
+
+  private fetchTopic(slug: string): void {
+    this.loading = true;
+    this.loadError = '';
+    this.topic = null;
+
+    this.blogService
+      .getTopicBySlug(slug)
+      .pipe(
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: topic => {
+          this.topic = this.mapTopic(topic);
+        },
+        error: () => {
+          this.loadError = 'Не удалось загрузить публикацию. Попробуйте позже.';
+        }
+      });
+  }
+
+  private mapTopic(topic: BlogTopic): BlogTopicDetailViewModel {
+    return {
+      ...topic,
+      renderedText: this.markdownRenderer.renderMath(topic.text),
+      newComment: '',
+      submittingComment: false
+    };
+  }
+}

--- a/Angular/youtube-downloader/src/app/services/blog.service.ts
+++ b/Angular/youtube-downloader/src/app/services/blog.service.ts
@@ -34,6 +34,10 @@ export class BlogService {
     return this.http.get<BlogTopic[]>(`${this.apiUrl}/topics`, { params });
   }
 
+  getTopicBySlug(slug: string): Observable<BlogTopic> {
+    return this.http.get<BlogTopic>(`${this.apiUrl}/topics/by-slug/${slug}`);
+  }
+
   createTopic(payload: { title: string; text: string }): Observable<BlogTopic> {
     return this.http.post<BlogTopic>(`${this.apiUrl}/topics`, payload);
   }

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -26,6 +26,7 @@ import { AudioFilesComponent } from './app/audio-file/audio-files.component';
 import { MarkdownConverterComponent } from './app/Markdown-converter/markdown-converter.component';
 import { BlogFeedComponent } from './app/blog-feed/blog-feed.component';
 import { BlogTopicCreateComponent } from './app/blog-topic-create/blog-topic-create.component';
+import { BlogTopicDetailComponent } from './app/blog-topic-detail/blog-topic-detail.component';
 import { RoleGuard } from './app/services/role.guard';
 
 
@@ -87,6 +88,10 @@ const routes: Routes = [
     component: BlogTopicCreateComponent,
     canActivate: [RoleGuard],
     data: { roles: ['Moderator'] }
+  },
+  {
+    path: 'blog/:slug',
+    component: BlogTopicDetailComponent,
   },
   {
     path: 'ServiceNews',


### PR DESCRIPTION
## Summary
- restyled the blog feed into an infinite-scroll preview list that links to full posts and mirrors the /tasks experience
- added a dedicated blog topic detail component that renders markdown, lists comments, and lets authenticated users reply
- exposed a slug-based blog lookup on the client and wired new routing so previews open the full article view

## Testing
- CI=1 npm run build -- --progress=false *(fails: Google Fonts inlining returns 403 in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2037f7da08331990eccd58f1c8576