### PR TITLE
feat(blog): enable topic and comment moderation on frontend

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.css
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.css
@@ -75,6 +75,19 @@
   margin-right: auto;
 }
 
+.moderation-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.action-error {
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
 .feed-loader,
 .feed-end,
 .initial-loader {

--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
@@ -53,6 +53,20 @@
           <a mat-stroked-button color="primary" [routerLink]="['/blog', topic.slug]">
             Читать полностью
           </a>
+          <div class="moderation-actions" *ngIf="isModerator">
+            <span class="action-error" *ngIf="topic.actionError">{{ topic.actionError }}</span>
+            <button mat-stroked-button color="primary" (click)="editTopic(topic)">
+              Редактировать
+            </button>
+            <button
+              mat-stroked-button
+              color="warn"
+              (click)="deleteTopic(topic)"
+              [disabled]="topic.deleting"
+            >
+              {{ topic.deleting ? 'Удаление…' : 'Удалить' }}
+            </button>
+          </div>
         </div>
       </mat-card-content>
     </mat-card>

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
@@ -58,6 +58,21 @@
   font-size: 0.9rem;
 }
 
+.load-state {
+  margin: 24px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  color: #666;
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.load-state.error {
+  color: #c62828;
+}
+
 @media (max-width: 768px) {
   .create-topic-container {
     padding: 12px;

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
@@ -1,10 +1,30 @@
 <div class="create-topic-container">
   <mat-card>
     <mat-card-header>
-      <mat-card-title>Новая тема</mat-card-title>
+      <mat-card-title>
+        {{ isEditMode ? 'Редактирование темы' : 'Новая тема' }}
+      </mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <form [formGroup]="topicForm" (ngSubmit)="onSubmit()">
+      <div class="load-state" *ngIf="loadingTopic">
+        <mat-spinner diameter="40"></mat-spinner>
+      </div>
+      <div class="load-state error" *ngIf="loadError">
+        <span>{{ loadError }}</span>
+        <button
+          mat-stroked-button
+          type="button"
+          (click)="retryLoad()"
+          *ngIf="isEditMode"
+        >
+          Повторить
+        </button>
+      </div>
+      <form
+        *ngIf="!loadingTopic && (!isEditMode || !loadError)"
+        [formGroup]="topicForm"
+        (ngSubmit)="onSubmit()"
+      >
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Заголовок</mat-label>
           <input matInput formControlName="title" maxlength="256" />
@@ -38,7 +58,7 @@
           </button>
           <span class="error" *ngIf="submitError">{{ submitError }}</span>
           <button mat-flat-button color="primary" type="submit" [disabled]="submitting">
-            Опубликовать
+            {{ isEditMode ? 'Сохранить' : 'Опубликовать' }}
           </button>
         </div>
       </form>

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
@@ -1,13 +1,15 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { LMarkdownEditorModule } from 'ngx-markdown-editor';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { finalize } from 'rxjs/operators';
 import { BlogService } from '../services/blog.service';
 import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
@@ -23,12 +25,13 @@ import { MarkdownRendererService1 } from '../task-result/markdown-renderer.servi
     MatInputModule,
     MatButtonModule,
     MatSnackBarModule,
+    MatProgressSpinnerModule,
     LMarkdownEditorModule
   ],
   templateUrl: './blog-topic-create.component.html',
   styleUrls: ['./blog-topic-create.component.css']
 })
-export class BlogTopicCreateComponent {
+export class BlogTopicCreateComponent implements OnInit {
   private readonly titleMaxLength = 256;
   private readonly textMaxLength = 10000;
 
@@ -48,18 +51,46 @@ export class BlogTopicCreateComponent {
 
   submitting = false;
   submitError = '';
+  loadingTopic = false;
+  loadError = '';
+  private mode: 'create' | 'edit' = 'create';
+  private topicId: number | null = null;
+  private topicSlug: string | null = null;
 
   constructor(
     private readonly fb: FormBuilder,
     private readonly blogService: BlogService,
     private readonly router: Router,
+    private readonly route: ActivatedRoute,
     private readonly snackBar: MatSnackBar,
-    private readonly markdownRenderer: MarkdownRendererService1
+    private readonly markdownRenderer: MarkdownRendererService1,
+    private readonly destroyRef: DestroyRef
   ) {
     this.topicForm = this.fb.group({
       title: ['', [Validators.required, Validators.maxLength(this.titleMaxLength)]],
       text: ['', [Validators.required, Validators.maxLength(this.textMaxLength)]]
     });
+  }
+
+  ngOnInit(): void {
+    this.route.paramMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => {
+        const slug = params.get('slug');
+        if (slug) {
+          this.mode = 'edit';
+          this.topicSlug = slug;
+          this.fetchTopic(slug);
+        } else {
+          this.mode = 'create';
+          this.topicId = null;
+          this.topicSlug = null;
+          this.loadError = '';
+          this.loadingTopic = false;
+          this.topicForm.enable();
+          this.topicForm.reset({ title: '', text: '' });
+        }
+      });
   }
 
   get titleLength(): number {
@@ -71,6 +102,11 @@ export class BlogTopicCreateComponent {
   }
 
   onCancel(): void {
+    if (this.isEditMode && this.topicSlug) {
+      this.router.navigate(['/blog', this.topicSlug]);
+      return;
+    }
+
     this.router.navigate(['/blog']);
   }
 
@@ -94,18 +130,69 @@ export class BlogTopicCreateComponent {
       return;
     }
 
+    if (this.isEditMode && this.topicId === null) {
+      this.submitError = 'Тема для редактирования не загружена.';
+      return;
+    }
+
     this.submitting = true;
 
-    this.blogService
-      .createTopic({ title: rawTitle, text: rawText })
+    const request$ = this.isEditMode && this.topicId !== null
+      ? this.blogService.updateTopic(this.topicId, { title: rawTitle, text: rawText })
+      : this.blogService.createTopic({ title: rawTitle, text: rawText });
+
+    request$
       .pipe(finalize(() => (this.submitting = false)))
       .subscribe({
-        next: () => {
-          this.snackBar.open('Тема опубликована', undefined, { duration: 3000 });
-          this.router.navigate(['/blog']);
+        next: topic => {
+          const message = this.isEditMode ? 'Тема обновлена' : 'Тема опубликована';
+          this.snackBar.open(message, undefined, { duration: 3000 });
+          this.topicSlug = topic.slug;
+          const targetSlug = topic.slug ?? this.topicSlug;
+          this.router.navigate(['/blog', targetSlug]);
         },
         error: () => {
-          this.submitError = 'Не удалось создать тему. Попробуйте позже.';
+          this.submitError = this.isEditMode
+            ? 'Не удалось сохранить изменения. Попробуйте позже.'
+            : 'Не удалось создать тему. Попробуйте позже.';
+        }
+      });
+  }
+
+  retryLoad(): void {
+    if (this.topicSlug) {
+      this.fetchTopic(this.topicSlug);
+    }
+  }
+
+  get isEditMode(): boolean {
+    return this.mode === 'edit';
+  }
+
+  private fetchTopic(slug: string): void {
+    this.loadingTopic = true;
+    this.loadError = '';
+    this.topicForm.disable();
+
+    this.blogService
+      .getTopicBySlug(slug)
+      .pipe(
+        finalize(() => {
+          this.loadingTopic = false;
+          if (!this.loadError) {
+            this.topicForm.enable();
+          }
+        })
+      )
+      .subscribe({
+        next: topic => {
+          this.topicId = topic.id;
+          this.topicSlug = topic.slug;
+          this.topicForm.setValue({ title: topic.header, text: topic.text });
+        },
+        error: () => {
+          this.loadError = 'Не удалось загрузить тему для редактирования.';
+          this.topicForm.reset({ title: '', text: '' });
         }
       });
   }

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
@@ -40,6 +40,18 @@
   overflow-wrap: anywhere;
 }
 
+.topic-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 16px 0;
+}
+
+.actions-spacer {
+  flex: 1 1 auto;
+}
+
 .comments {
   margin-top: 24px;
   display: flex;
@@ -66,6 +78,26 @@
 
 .comment-text {
   white-space: pre-wrap;
+}
+
+.comment-controls,
+.comment-edit-actions {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.comment-edit-section {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.controls-spacer {
+  flex: 1 1 auto;
 }
 
 .empty {

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.html
@@ -24,6 +24,22 @@
     <mat-card-content>
       <div class="topic-content" [innerHTML]="topic.renderedText"></div>
 
+      <div class="topic-actions" *ngIf="isModerator">
+        <span class="error" *ngIf="topic.topicActionError">{{ topic.topicActionError }}</span>
+        <span class="actions-spacer"></span>
+        <button mat-stroked-button color="primary" (click)="editTopic(topic)">
+          Редактировать тему
+        </button>
+        <button
+          mat-stroked-button
+          color="warn"
+          (click)="deleteTopic(topic)"
+          [disabled]="topic.deletingTopic"
+        >
+          {{ topic.deletingTopic ? 'Удаление…' : 'Удалить тему' }}
+        </button>
+      </div>
+
       <mat-divider></mat-divider>
 
       <section class="comments">
@@ -33,7 +49,65 @@
             <b>{{ comment.user }}</b>
             <span>{{ comment.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
           </div>
-          <div class="comment-text">{{ comment.text }}</div>
+          <ng-container *ngIf="comment.editing; else viewComment">
+            <div class="comment-edit-section">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Текст комментария</mat-label>
+                <textarea
+                  matInput
+                  rows="4"
+                  maxlength="2000"
+                  [(ngModel)]="comment.editText"
+                  [ngModelOptions]="{ standalone: true }"
+                ></textarea>
+              </mat-form-field>
+              <div class="comment-edit-actions">
+                <span class="error" *ngIf="comment.actionError">{{ comment.actionError }}</span>
+                <span class="controls-spacer"></span>
+                <button
+                  mat-flat-button
+                  color="primary"
+                  (click)="saveComment(topic, comment)"
+                  [disabled]="comment.submittingEdit"
+                >
+                  Сохранить
+                </button>
+                <button
+                  mat-button
+                  type="button"
+                  (click)="cancelEditComment(comment)"
+                  [disabled]="comment.submittingEdit"
+                >
+                  Отмена
+                </button>
+              </div>
+            </div>
+          </ng-container>
+          <ng-template #viewComment>
+            <div class="comment-text">{{ comment.text }}</div>
+            <div class="comment-controls" *ngIf="canEditComment(comment) || canDeleteComment(comment)">
+              <span class="error" *ngIf="comment.actionError">{{ comment.actionError }}</span>
+              <span class="controls-spacer"></span>
+              <button
+                mat-button
+                color="primary"
+                *ngIf="canEditComment(comment)"
+                (click)="startEditComment(comment)"
+                [disabled]="comment.editing"
+              >
+                Редактировать
+              </button>
+              <button
+                mat-button
+                color="warn"
+                *ngIf="canDeleteComment(comment)"
+                (click)="deleteComment(topic, comment)"
+                [disabled]="comment.deleting"
+              >
+                {{ comment.deleting ? 'Удаление…' : 'Удалить' }}
+              </button>
+            </div>
+          </ng-template>
         </div>
         <div class="empty" *ngIf="topic.comments.length === 0">
           Пока нет комментариев

--- a/Angular/youtube-downloader/src/app/services/blog.service.ts
+++ b/Angular/youtube-downloader/src/app/services/blog.service.ts
@@ -42,7 +42,26 @@ export class BlogService {
     return this.http.post<BlogTopic>(`${this.apiUrl}/topics`, payload);
   }
 
+  updateTopic(topicId: number, payload: { title: string; text: string }): Observable<BlogTopic> {
+    return this.http.put<BlogTopic>(`${this.apiUrl}/topics/${topicId}`, payload);
+  }
+
+  deleteTopic(topicId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/topics/${topicId}`);
+  }
+
   addComment(topicId: number, payload: { text: string }): Observable<BlogComment> {
     return this.http.post<BlogComment>(`${this.apiUrl}/topics/${topicId}/comments`, payload);
+  }
+
+  updateComment(topicId: number, commentId: number, payload: { text: string }): Observable<BlogComment> {
+    return this.http.put<BlogComment>(
+      `${this.apiUrl}/topics/${topicId}/comments/${commentId}`,
+      payload
+    );
+  }
+
+  deleteComment(topicId: number, commentId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/topics/${topicId}/comments/${commentId}`);
   }
 }

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -90,6 +90,12 @@ const routes: Routes = [
     data: { roles: ['Moderator'] }
   },
   {
+    path: 'blog/:slug/edit',
+    component: BlogTopicCreateComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Moderator'] }
+  },
+  {
     path: 'blog/:slug',
     component: BlogTopicDetailComponent,
   },


### PR DESCRIPTION
## Summary
- allow moderators to edit or delete topics directly from the feed and detail pages and surface errors in the UI
- enable inline editing and removal of comments for moderators or comment authors and provide topic deletion controls
- add edit-mode handling to the topic editor, including loading states, and register a dedicated route for editing

## Testing
- npm run build -- --configuration production --no-progress --optimization=false

------
https://chatgpt.com/codex/tasks/task_e_68d2221439348331ad557ccd95f1c731