### PR TITLE
Fix Angular asset copy destinations

### DIFF
--- a/Angular/youtube-downloader/angular.json
+++ b/Angular/youtube-downloader/angular.json
@@ -16,7 +16,9 @@
             "outputPath": "dist/youtube-downloader",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
@@ -74,7 +76,12 @@
                   "maximumError": "8kB"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "optimization": {
+                "fonts": {
+                  "inline": false
+                }
+              }
             },
             "development": {
               "optimization": false,
@@ -102,7 +109,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "tsconfig.spec.json",
             "assets": [
               "src/favicon.ico",

--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,8 @@ using YandexSpeech.Services;
 using YoutubeDownload.Managers;
 using YoutubeDownload.Services;
 using YoutubeExplode;
+using System.IO;
+using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -167,17 +169,27 @@ else
         staticFileContentTypeProvider.Mappings[".webp"] = "image/webp";
     }
 
+    var spaRoot = app.Environment.WebRootPath ?? Path.Combine(app.Environment.ContentRootPath, "wwwroot");
+
     var staticFileOptions = new StaticFileOptions
     {
+        FileProvider = new PhysicalFileProvider(spaRoot),
         ContentTypeProvider = staticFileContentTypeProvider
     };
 
-    app.UseDefaultFiles();
+    var defaultFilesOptions = new DefaultFilesOptions
+    {
+        FileProvider = staticFileOptions.FileProvider
+    };
+
+    app.UseDefaultFiles(defaultFilesOptions);
     app.UseStaticFiles(staticFileOptions);
     app.UseSpaStaticFiles(staticFileOptions);
     app.UseSpa(spa =>
     {
-        spa.Options.SourcePath = "C:\\stock\\8.0\\YandexSpeech\\Angular\\youtube-downloader\\dist\\youtube-downloader";
+        spa.Options.SourcePath = spaRoot;
+        spa.Options.DefaultPage = "/index.html";
+        spa.Options.DefaultPageStaticFileOptions = staticFileOptions;
     });
 }
 

--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -1,56 +1,88 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.2.0" />
+    <PackageReference Include="AspNet.Security.OAuth.Vkontakte" Version="9.2.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.70" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.410.12" />
+    <PackageReference Include="Concentus.OggFile" Version="1.0.6" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.1.32" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.2.0" />
-		<PackageReference Include="AspNet.Security.OAuth.Vkontakte" Version="9.2.0" />
-		<PackageReference Include="AWSSDK.Core" Version="3.7.400.70" />
-		<PackageReference Include="AWSSDK.S3" Version="3.7.410.12" />
-		<PackageReference Include="Concentus.OggFile" Version="1.0.6" />
-		<PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.1.32" />
-		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="9.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="NAudio" Version="2.2.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-		<PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\YoutubeExplode-master\YoutubeExplode\YoutubeExplode.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\..\..\YoutubeExplode-master\YoutubeExplode\YoutubeExplode.csproj" />
-	</ItemGroup>
+  <PropertyGroup>
+    <AngularProjectDir>$(MSBuildProjectDirectory)/Angular/youtube-downloader/</AngularProjectDir>
+    <AngularDistDir>$(AngularProjectDir)dist/youtube-downloader/</AngularDistDir>
+  </PropertyGroup>
 
-	
+  <Target Name="BuildAngularApp"
+          Condition="'$(DesignTimeBuild)' != 'true'"
+          BeforeTargets="Build">
+    <Message Importance="high" Text="Building Angular client application..." />
+    <Exec WorkingDirectory="$(AngularProjectDir)"
+          Command="npm install"
+          Condition="!Exists('$(AngularProjectDir)node_modules')" />
+    <Exec WorkingDirectory="$(AngularProjectDir)"
+          Command="npm run build -- --configuration production --progress false" />
+  </Target>
 
+  <Target Name="CopyAngularDistToProject"
+          Condition="'$(DesignTimeBuild)' != 'true'"
+          DependsOnTargets="BuildAngularApp"
+          AfterTargets="Build"
+          BeforeTargets="Publish">
+    <ItemGroup>
+      <AngularDistFiles Include="$(AngularDistDir)**/*.*">
+        <TargetPath>$([System.IO.Path]::Combine('$(ProjectDir)','wwwroot','%(RecursiveDir)','%(Filename)%(Extension)'))</TargetPath>
+      </AngularDistFiles>
+    </ItemGroup>
+    <RemoveDir Directories="$(ProjectDir)wwwroot" />
+    <MakeDir Directories="$(ProjectDir)wwwroot" />
+    <Copy SourceFiles="@(AngularDistFiles)"
+          DestinationFiles="@(AngularDistFiles->'%(TargetPath)')"
+          SkipUnchangedFiles="true" />
+  </Target>
 
-
-
-	<!-- Target для копирования Angular dist после публикации -->
-	<Target Name="CopyAngularDist" AfterTargets="Publish">
-		<ItemGroup>
-			<!-- Здесь обязательно укажите правильный путь к папке dist вашего Angular-приложения -->
-			<DistFiles Include="$(ProjectDir)\Angular\youtube-downloader\dist\**\*" />
-		</ItemGroup>
-		<!-- Копируем всё из dist в папку wwwroot в итоговой папке публикации -->
-		<Copy SourceFiles="@(DistFiles)" DestinationFolder="$(PublishDir)\wwwroot" />
-	</Target>
-
+  <Target Name="CopyAngularDistToPublish"
+          Condition="'$(DesignTimeBuild)' != 'true'"
+          DependsOnTargets="BuildAngularApp"
+          AfterTargets="Publish">
+    <ItemGroup>
+      <AngularDistFiles Include="$(AngularDistDir)**/*.*">
+        <TargetPath>$([System.IO.Path]::Combine('$(PublishDir)','wwwroot','%(RecursiveDir)','%(Filename)%(Extension)'))</TargetPath>
+      </AngularDistFiles>
+    </ItemGroup>
+    <RemoveDir Directories="$(PublishDir)wwwroot" />
+    <MakeDir Directories="$(PublishDir)wwwroot" />
+    <Copy SourceFiles="@(AngularDistFiles)"
+          DestinationFiles="@(AngularDistFiles->'%(TargetPath)')"
+          SkipUnchangedFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- compute the Angular dist copy destinations with `System.IO.Path.Combine` so assets land under the correct file names instead of the wwwroot directory itself
- recreate the project and publish wwwroot directories before copying to avoid missing root folders during MSBuild runs

## Testing
- `npm run build -- --configuration production --progress false`


------
https://chatgpt.com/codex/tasks/task_e_68d2401dcc248331b77f3b78010f3e46