### PR TITLE
Fix Angular asset copy destinations

### DIFF
--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -65,7 +65,7 @@
     </ItemGroup>
     <RemoveDir Directories="$(ProjectDir)wwwroot" />
     <Copy SourceFiles="@(AngularDistFiles)"
-          DestinationFiles="@(AngularDistFiles->'$(ProjectDir)wwwroot/%(RelativeOutputPath)')"
+          DestinationFiles="@(AngularDistFiles->'$(ProjectDir)wwwroot/%(AngularDistFiles.RelativeOutputPath)')"
           SkipUnchangedFiles="true" />
   </Target>
 
@@ -80,7 +80,7 @@
     </ItemGroup>
     <RemoveDir Directories="$(PublishDir)wwwroot" />
     <Copy SourceFiles="@(AngularDistFiles)"
-          DestinationFiles="@(AngularDistFiles->'$(PublishDir)wwwroot/%(RelativeOutputPath)')"
+          DestinationFiles="@(AngularDistFiles->'$(PublishDir)wwwroot/%(AngularDistFiles.RelativeOutputPath)')"
           SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- ensure the MSBuild copy transform references the AngularDistFiles metadata explicitly so that file destinations include the relative path

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d251fc95488331954d08b865aac602