### PR TITLE
Refine Angular dist copy destinations

### DIFF
--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -59,13 +59,11 @@
           AfterTargets="Build"
           BeforeTargets="Publish">
     <ItemGroup>
-      <AngularDistFiles Include="$(AngularDistDir)**/*.*">
-        <RelativeOutputPath>$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\\','/'))</RelativeOutputPath>
-      </AngularDistFiles>
+      <AngularDistFiles Include="$(AngularDistDir)**/*.*" />
     </ItemGroup>
     <RemoveDir Directories="$(ProjectDir)wwwroot" />
     <Copy SourceFiles="@(AngularDistFiles)"
-          DestinationFiles="@(AngularDistFiles->'$(ProjectDir)wwwroot/%(AngularDistFiles.RelativeOutputPath)')"
+          DestinationFiles="@(AngularDistFiles->'$(ProjectDir)wwwroot\\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 
@@ -74,13 +72,11 @@
           DependsOnTargets="BuildAngularApp"
           AfterTargets="Publish">
     <ItemGroup>
-      <AngularDistFiles Include="$(AngularDistDir)**/*.*">
-        <RelativeOutputPath>$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\\','/'))</RelativeOutputPath>
-      </AngularDistFiles>
+      <AngularDistFiles Include="$(AngularDistDir)**/*.*" />
     </ItemGroup>
     <RemoveDir Directories="$(PublishDir)wwwroot" />
     <Copy SourceFiles="@(AngularDistFiles)"
-          DestinationFiles="@(AngularDistFiles->'$(PublishDir)wwwroot/%(AngularDistFiles.RelativeOutputPath)')"
+          DestinationFiles="@(AngularDistFiles->'$(PublishDir)wwwroot\\%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- rely on built-in RecursiveDir/Filename metadata when composing copy destinations so files land inside wwwroot subfolders

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2569ed92c83318f9b75924242ffdd