### PR TITLE
Add OpenAI transcription upload and tracking

### DIFF
--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { YoutubeDownloaderComponent } from './youtube-downloader/youtube-downloader.component';
 import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks.component';
+import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
+  { path: 'transcriptions', component: OpenAiTranscriptionComponent },
 ];
 
 @NgModule({

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -3,11 +3,13 @@ import { YoutubeDownloaderComponent } from './youtube-downloader/youtube-downloa
 import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks.component';
 import { SubtitlesTasksComponent } from './subtitles-task/subtitles-tasks.component';
 import { MarkdownConverterComponent } from './Markdown-converter/markdown-converter.component';
+import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
 
 export const appRoutes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: SubtitlesTasksComponent },
+  { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
-  
+
 ];

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -1,0 +1,199 @@
+.transcription-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 16px;
+}
+
+.upload-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.upload-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.file-name {
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.upload-hint {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.tasks-card,
+.details-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px 12px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error {
+  color: #d32f2f;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.details-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.status-chip {
+  font-size: 0.85rem;
+  padding: 4px 12px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-done {
+  background-color: rgba(76, 175, 80, 0.1);
+  color: #2e7d32;
+}
+
+.status-error {
+  background-color: rgba(244, 67, 54, 0.12);
+  color: #c62828;
+}
+
+.status-progress {
+  background-color: rgba(63, 81, 181, 0.12);
+  color: #283593;
+}
+
+.status-pending {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.steps-section h3,
+.result-block h3 {
+  margin-top: 0;
+}
+
+.steps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.steps-list li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px;
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.steps-list li.step-completed {
+  background-color: rgba(76, 175, 80, 0.08);
+}
+
+.steps-list li.step-progress {
+  background-color: rgba(33, 150, 243, 0.08);
+}
+
+.steps-list li.step-error {
+  background-color: rgba(244, 67, 54, 0.08);
+}
+
+.step-icon {
+  font-size: 24px;
+}
+
+.step-info {
+  flex: 1;
+}
+
+.step-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.step-meta {
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.step-error {
+  margin-top: 4px;
+  color: #c62828;
+}
+
+.result-block pre {
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 16px;
+  white-space: pre-wrap;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.tasks-card a.active {
+  background: rgba(63, 81, 181, 0.08);
+}
+
+.placeholder-card {
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  text-align: center;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .tasks-card {
+    flex: 0 0 320px;
+  }
+
+  .details-card {
+    flex: 1;
+  }
+}

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -1,0 +1,117 @@
+<div class="transcription-page">
+  <mat-card class="upload-card">
+    <h2>Новая расшифровка</h2>
+    <p class="upload-hint">
+      Загрузите аудио или видео файл, чтобы отправить его в обработку через OpenAI.
+    </p>
+    <div class="upload-controls">
+      <input
+        type="file"
+        (change)="onFileSelected($event)"
+        accept="audio/*,video/*"
+      />
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="upload()"
+        [disabled]="!selectedFile || uploading"
+      >
+        <mat-icon>cloud_upload</mat-icon>
+        <span>Отправить</span>
+      </button>
+    </div>
+    <div class="file-name" *ngIf="selectedFile">
+      Выбран файл: <strong>{{ selectedFile.name }}</strong>
+    </div>
+    <mat-progress-bar *ngIf="uploading" mode="indeterminate"></mat-progress-bar>
+    <div class="error" *ngIf="uploadError">{{ uploadError }}</div>
+  </mat-card>
+
+  <div class="layout">
+    <mat-card class="tasks-card">
+      <div class="card-header">
+        <h2>Мои расшифровки</h2>
+        <button mat-icon-button (click)="loadTasks()" [disabled]="uploading">
+          <mat-icon>refresh</mat-icon>
+        </button>
+      </div>
+      <div class="error" *ngIf="listError">{{ listError }}</div>
+      <mat-nav-list *ngIf="tasks.length; else emptyTasks">
+        <a
+          mat-list-item
+          *ngFor="let task of tasks; trackBy: trackTask"
+          (click)="selectTask(task)"
+          [class.active]="task.id === selectedTaskId"
+        >
+          <mat-icon matListItemIcon>{{ getTaskIcon(task) }}</mat-icon>
+          <span matListItemTitle>{{ task.displayName }}</span>
+          <span matListItemLine>
+            {{ getStatusText(task.status) }} · {{ task.modifiedAt | localTime }}
+          </span>
+        </a>
+      </mat-nav-list>
+      <ng-template #emptyTasks>
+        <div class="empty-state">Здесь появятся ваши распознанные файлы.</div>
+      </ng-template>
+    </mat-card>
+
+    <mat-card class="details-card" *ngIf="selectedTaskId; else selectPrompt">
+      <ng-container *ngIf="detailsLoading; else taskDetails">
+        <div class="loading-state">
+          <mat-progress-spinner mode="indeterminate" diameter="40"></mat-progress-spinner>
+          <p>Загружаем данные задачи…</p>
+        </div>
+      </ng-container>
+
+      <ng-template #taskDetails>
+        <ng-container *ngIf="selectedTask; else detailsErrorBlock">
+          <div class="details-header">
+            <h2>{{ selectedTask.displayName }}</h2>
+            <span class="status-chip" [ngClass]="getStatusClass(selectedTask.status)">
+              {{ getStatusText(selectedTask.status) }}
+            </span>
+          </div>
+
+          <div class="error" *ngIf="selectedTask.error">{{ selectedTask.error }}</div>
+
+          <section class="steps-section" *ngIf="selectedTask.steps.length">
+            <h3>Прогресс</h3>
+            <ul class="steps-list">
+              <li *ngFor="let step of selectedTask.steps; trackBy: trackStep" [class]="getStepClass(step.status)">
+                <mat-icon class="step-icon">{{ getStepIcon(step.status) }}</mat-icon>
+                <div class="step-info">
+                  <div class="step-title">{{ getStatusText(step.step) }}</div>
+                  <div class="step-meta">
+                    <span>{{ getStepStatusText(step.status) }}</span>
+                    <span *ngIf="step.startedAt">· {{ step.startedAt | localTime }}</span>
+                  </div>
+                  <div class="step-error" *ngIf="step.error">{{ step.error }}</div>
+                </div>
+              </li>
+            </ul>
+          </section>
+
+          <section class="result-block" *ngIf="selectedTask.recognizedText">
+            <h3>Распознанный текст</h3>
+            <pre>{{ selectedTask.recognizedText }}</pre>
+          </section>
+
+          <section class="result-block" *ngIf="selectedTask.markdownText">
+            <h3>Форматированный Markdown</h3>
+            <pre>{{ selectedTask.markdownText }}</pre>
+          </section>
+        </ng-container>
+      </ng-template>
+
+      <ng-template #detailsErrorBlock>
+        <div class="error" *ngIf="detailsError">{{ detailsError }}</div>
+      </ng-template>
+    </mat-card>
+
+    <ng-template #selectPrompt>
+      <mat-card class="details-card placeholder-card">
+        <p>Выберите задачу из списка, чтобы просмотреть прогресс и результат.</p>
+      </mat-card>
+    </ng-template>
+  </div>
+</div>

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -1,0 +1,276 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subscription, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import {
+  OpenAiTranscriptionService,
+  OpenAiTranscriptionStatus,
+  OpenAiTranscriptionTaskDetailsDto,
+  OpenAiTranscriptionTaskDto,
+  OpenAiTranscriptionStepDto,
+  OpenAiTranscriptionStepStatus,
+} from '../services/openai-transcription.service';
+import { LocalTimePipe } from '../pipe/local-time.pipe';
+
+@Component({
+  selector: 'app-openai-transcriptions',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatListModule,
+    MatProgressBarModule,
+    MatProgressSpinnerModule,
+    LocalTimePipe,
+  ],
+  templateUrl: './openai-transcription.component.html',
+  styleUrls: ['./openai-transcription.component.css'],
+})
+export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
+  tasks: OpenAiTranscriptionTaskDto[] = [];
+  selectedTaskId: string | null = null;
+  selectedTask: OpenAiTranscriptionTaskDetailsDto | null = null;
+
+  selectedFile: File | null = null;
+  uploading = false;
+  uploadError: string | null = null;
+  listError: string | null = null;
+  detailsError: string | null = null;
+  detailsLoading = false;
+
+  readonly OpenAiTranscriptionStatus = OpenAiTranscriptionStatus;
+  readonly OpenAiTranscriptionStepStatus = OpenAiTranscriptionStepStatus;
+
+  private pollSubscription?: Subscription;
+
+  constructor(private readonly transcriptionService: OpenAiTranscriptionService) {}
+
+  ngOnInit(): void {
+    this.loadTasks(true);
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedFile = input.files && input.files.length > 0 ? input.files[0] : null;
+  }
+
+  upload(): void {
+    if (!this.selectedFile || this.uploading) {
+      return;
+    }
+
+    this.uploading = true;
+    this.uploadError = null;
+
+    this.transcriptionService.upload(this.selectedFile).subscribe({
+      next: (task) => {
+        this.uploading = false;
+        this.selectedFile = null;
+        this.tasks = [task, ...this.tasks.filter((t) => t.id !== task.id)];
+        this.selectTaskById(task.id);
+      },
+      error: (error) => {
+        this.uploading = false;
+        this.uploadError = this.extractError(error) ?? 'Не удалось загрузить файл.';
+      },
+    });
+  }
+
+  loadTasks(selectFirstAvailable = false): void {
+    this.listError = null;
+    this.transcriptionService.list().subscribe({
+      next: (tasks) => {
+        this.tasks = tasks;
+
+        if (!this.selectedTaskId && selectFirstAvailable && tasks.length > 0) {
+          this.selectTask(tasks[0]);
+          return;
+        }
+
+        if (this.selectedTaskId && !tasks.some((task) => task.id === this.selectedTaskId)) {
+          this.stopPolling();
+          this.selectedTaskId = null;
+          this.selectedTask = null;
+          if (selectFirstAvailable && tasks.length > 0) {
+            this.selectTask(tasks[0]);
+          }
+        }
+      },
+      error: (error) => {
+        this.listError = this.extractError(error) ?? 'Не удалось получить список задач.';
+      },
+    });
+  }
+
+  selectTask(task: OpenAiTranscriptionTaskDto): void {
+    this.selectTaskById(task.id);
+  }
+
+  private selectTaskById(taskId: string): void {
+    if (this.selectedTaskId === taskId && this.selectedTask) {
+      return;
+    }
+
+    this.selectedTaskId = taskId;
+    this.selectedTask = null;
+    this.detailsError = null;
+    this.startPolling();
+  }
+
+  private startPolling(): void {
+    if (!this.selectedTaskId) {
+      return;
+    }
+
+    this.stopPolling();
+    this.detailsLoading = true;
+
+    this.pollSubscription = timer(0, 5000)
+      .pipe(switchMap(() => this.transcriptionService.getTask(this.selectedTaskId!)))
+      .subscribe({
+        next: (task) => {
+          this.detailsLoading = false;
+          this.detailsError = null;
+          this.applyTaskUpdate(task);
+          if (task.done || task.status === OpenAiTranscriptionStatus.Error) {
+            this.stopPolling();
+          }
+        },
+        error: (error) => {
+          this.detailsLoading = false;
+          this.detailsError = this.extractError(error) ?? 'Не удалось получить информацию о задаче.';
+          this.stopPolling();
+        },
+      });
+  }
+
+  private stopPolling(): void {
+    if (this.pollSubscription) {
+      this.pollSubscription.unsubscribe();
+      this.pollSubscription = undefined;
+    }
+  }
+
+  private applyTaskUpdate(task: OpenAiTranscriptionTaskDetailsDto): void {
+    this.selectedTask = task;
+
+    this.tasks = this.tasks.map((existing) =>
+      existing.id === task.id
+        ? {
+            ...existing,
+            status: task.status,
+            done: task.done,
+            error: task.error,
+            modifiedAt: task.modifiedAt,
+          }
+        : existing
+    );
+  }
+
+  getStatusText(status: OpenAiTranscriptionStatus | null | undefined): string {
+    return this.transcriptionService.getStatusText(status);
+  }
+
+  getStepStatusText(status: OpenAiTranscriptionStepStatus): string {
+    return this.transcriptionService.getStepStatusText(status);
+  }
+
+  getTaskIcon(task: OpenAiTranscriptionTaskDto): string {
+    if (task.status === OpenAiTranscriptionStatus.Error) {
+      return 'error';
+    }
+
+    if (task.done) {
+      return 'check_circle';
+    }
+
+    return 'graphic_eq';
+  }
+
+  getStepIcon(status: OpenAiTranscriptionStepStatus): string {
+    switch (status) {
+      case OpenAiTranscriptionStepStatus.Completed:
+        return 'check_circle';
+      case OpenAiTranscriptionStepStatus.InProgress:
+        return 'schedule';
+      case OpenAiTranscriptionStepStatus.Error:
+        return 'error';
+      default:
+        return 'radio_button_unchecked';
+    }
+  }
+
+  getStepClass(status: OpenAiTranscriptionStepStatus): string {
+    switch (status) {
+      case OpenAiTranscriptionStepStatus.Completed:
+        return 'step-completed';
+      case OpenAiTranscriptionStepStatus.InProgress:
+        return 'step-progress';
+      case OpenAiTranscriptionStepStatus.Error:
+        return 'step-error';
+      default:
+        return 'step-pending';
+    }
+  }
+
+  getStatusClass(status: OpenAiTranscriptionStatus): string {
+    switch (status) {
+      case OpenAiTranscriptionStatus.Done:
+        return 'status-done';
+      case OpenAiTranscriptionStatus.Error:
+        return 'status-error';
+      case OpenAiTranscriptionStatus.Converting:
+      case OpenAiTranscriptionStatus.Transcribing:
+      case OpenAiTranscriptionStatus.Formatting:
+        return 'status-progress';
+      default:
+        return 'status-pending';
+    }
+  }
+
+  trackTask(_: number, task: OpenAiTranscriptionTaskDto): string {
+    return task.id;
+  }
+
+  trackStep(_: number, step: OpenAiTranscriptionStepDto): number {
+    return step.id;
+  }
+
+  private extractError(error: unknown): string | null {
+    if (!error) {
+      return null;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      const anyError = error as { error?: unknown; message?: string };
+      if (anyError.error) {
+        if (typeof anyError.error === 'string') {
+          return anyError.error;
+        }
+        if (typeof anyError.error === 'object') {
+          const nested = anyError.error as { message?: string; title?: string };
+          return nested.message || nested.title || null;
+        }
+      }
+      return anyError.message ?? null;
+    }
+
+    return null;
+  }
+}

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -9,6 +9,10 @@
       <mat-icon matListItemIcon>subtitles</mat-icon>
       <span matListItemTitle>Скрипториум</span>
     </a>
+    <a mat-list-item (click)="navigate('/transcriptions')">
+      <mat-icon matListItemIcon>record_voice_over</mat-icon>
+      <span matListItemTitle>OpenAI расшифровки</span>
+    </a>
     <a mat-list-item (click)="navigate('/down')">
       <mat-icon matListItemIcon>download-icons</mat-icon>
       <span matListItemTitle>Скачать ролик</span>
@@ -42,6 +46,10 @@
     <a mat-list-item (click)="navigate('/tasks')">
       <mat-icon matListItemIcon>subtitles</mat-icon>
       <span matListItemTitle>Скрипториум</span>
+    </a>
+    <a mat-list-item (click)="navigate('/transcriptions')">
+      <mat-icon matListItemIcon>record_voice_over</mat-icon>
+      <span matListItemTitle>OpenAI расшифровки</span>
     </a>
     <a mat-list-item (click)="navigate('/markdown-converter')">
       <mat-icon matListItemIcon>sync_alt</mat-icon>

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -30,6 +30,7 @@ import { BlogTopicDetailComponent } from './app/blog-topic-detail/blog-topic-det
 import { RoleGuard } from './app/services/role.guard';
 import { ProfileComponent } from './app/profile/profile.component';
 import { AuthGuard } from './app/services/auth.guard';
+import { OpenAiTranscriptionComponent } from './app/openai-transcription/openai-transcription.component';
 
 
 
@@ -50,6 +51,12 @@ const routes: Routes = [
   {
     path: 'audio',
     component: AudioFilesComponent, // главная страница
+  },
+
+  {
+    path: 'transcriptions',
+    component: OpenAiTranscriptionComponent,
+    canActivate: [AuthGuard],
   },
 
 

--- a/Controllers/OpenAiTranscriptionController.cs
+++ b/Controllers/OpenAiTranscriptionController.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using YandexSpeech.models.DB;
+using YandexSpeech.models.DTO;
+using YandexSpeech.services;
+
+namespace YandexSpeech.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class OpenAiTranscriptionController : ControllerBase
+    {
+        private readonly IOpenAiTranscriptionService _transcriptionService;
+        private readonly MyDbContext _dbContext;
+        private readonly IWebHostEnvironment _environment;
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<OpenAiTranscriptionController> _logger;
+
+        public OpenAiTranscriptionController(
+            IOpenAiTranscriptionService transcriptionService,
+            MyDbContext dbContext,
+            IWebHostEnvironment environment,
+            IServiceScopeFactory scopeFactory,
+            ILogger<OpenAiTranscriptionController> logger)
+        {
+            _transcriptionService = transcriptionService;
+            _dbContext = dbContext;
+            _environment = environment;
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        [HttpPost]
+        [RequestSizeLimit(200_000_000)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 200_000_000)]
+        public async Task<ActionResult<OpenAiTranscriptionTaskDto>> Upload([FromForm] IFormFile file)
+        {
+            if (file == null || file.Length == 0)
+            {
+                return BadRequest("File not provided.");
+            }
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var uploadsDirectory = Path.Combine(_environment.ContentRootPath, "App_Data", "transcriptions");
+            Directory.CreateDirectory(uploadsDirectory);
+
+            var sanitizedName = SanitizeFileName(file.FileName);
+            var storedFileName = $"{DateTime.UtcNow:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}__{sanitizedName}";
+            var storedFilePath = Path.Combine(uploadsDirectory, storedFileName);
+
+            await using (var stream = System.IO.File.Create(storedFilePath))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            var task = await _transcriptionService.StartTranscriptionAsync(storedFilePath, userId);
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var scopedService = scope.ServiceProvider.GetRequiredService<IOpenAiTranscriptionService>();
+                    await scopedService.ContinueTranscriptionAsync(task.Id);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to continue OpenAI transcription task {TaskId}", task.Id);
+                }
+            });
+
+            return CreatedAtAction(nameof(GetById), new { id = task.Id }, MapToDto(task));
+        }
+
+        [HttpGet]
+        public async Task<ActionResult> List()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var tasks = await _dbContext.OpenAiTranscriptionTasks
+                .Where(t => t.CreatedBy == userId)
+                .OrderByDescending(t => t.CreatedAt)
+                .ToListAsync();
+
+            var result = tasks.Select(MapToDto).ToList();
+            return Ok(result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<OpenAiTranscriptionTaskDetailsDto>> GetById(string id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var task = await _dbContext.OpenAiTranscriptionTasks
+                .Include(t => t.Steps)
+                .FirstOrDefaultAsync(t => t.Id == id && t.CreatedBy == userId);
+
+            if (task == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(MapToDetailsDto(task));
+        }
+
+        private static string SanitizeFileName(string fileName)
+        {
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var cleaned = new string((fileName ?? string.Empty).Where(c => !invalidChars.Contains(c)).ToArray());
+            if (string.IsNullOrWhiteSpace(cleaned))
+            {
+                return "audio";
+            }
+
+            var extension = Path.GetExtension(cleaned);
+            var nameWithoutExtension = Path.GetFileNameWithoutExtension(cleaned);
+
+            if (nameWithoutExtension.Length > 80)
+            {
+                nameWithoutExtension = nameWithoutExtension[..80];
+            }
+
+            return string.IsNullOrEmpty(extension)
+                ? nameWithoutExtension
+                : $"{nameWithoutExtension}{extension}";
+        }
+
+        private static string ResolveDisplayName(string storedPath)
+        {
+            var fileName = Path.GetFileName(storedPath);
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return "Unknown file";
+            }
+
+            var separatorIndex = fileName.IndexOf("__", StringComparison.Ordinal);
+            if (separatorIndex >= 0 && separatorIndex + 2 < fileName.Length)
+            {
+                return fileName[(separatorIndex + 2)..];
+            }
+
+            return fileName;
+        }
+
+        private static OpenAiTranscriptionTaskDto MapToDto(OpenAiTranscriptionTask task)
+        {
+            return new OpenAiTranscriptionTaskDto
+            {
+                Id = task.Id,
+                FileName = Path.GetFileName(task.SourceFilePath) ?? task.SourceFilePath,
+                DisplayName = ResolveDisplayName(task.SourceFilePath),
+                Status = task.Status,
+                Done = task.Done,
+                Error = task.Error,
+                CreatedAt = task.CreatedAt,
+                ModifiedAt = task.ModifiedAt
+            };
+        }
+
+        private static OpenAiTranscriptionTaskDetailsDto MapToDetailsDto(OpenAiTranscriptionTask task)
+        {
+            var dto = new OpenAiTranscriptionTaskDetailsDto
+            {
+                Id = task.Id,
+                FileName = Path.GetFileName(task.SourceFilePath) ?? task.SourceFilePath,
+                DisplayName = ResolveDisplayName(task.SourceFilePath),
+                Status = task.Status,
+                Done = task.Done,
+                Error = task.Error,
+                CreatedAt = task.CreatedAt,
+                ModifiedAt = task.ModifiedAt,
+                RecognizedText = task.RecognizedText,
+                MarkdownText = task.MarkdownText
+            };
+
+            dto.Steps = task.Steps?
+                .OrderBy(s => s.StartedAt)
+                .ThenBy(s => s.Id)
+                .Select(step => new OpenAiTranscriptionStepDto
+                {
+                    Id = step.Id,
+                    Step = step.Step,
+                    Status = step.Status,
+                    StartedAt = step.StartedAt,
+                    FinishedAt = step.FinishedAt,
+                    Error = step.Error
+                })
+                .ToList() ?? new List<OpenAiTranscriptionStepDto>();
+
+            return dto;
+        }
+    }
+}

--- a/models/DTO/OpenAiTranscriptionDtos.cs
+++ b/models/DTO/OpenAiTranscriptionDtos.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using YandexSpeech.models.DB;
+
+namespace YandexSpeech.models.DTO
+{
+    public class OpenAiTranscriptionTaskDto
+    {
+        public string Id { get; set; } = null!;
+
+        public string FileName { get; set; } = null!;
+
+        public string DisplayName { get; set; } = null!;
+
+        public OpenAiTranscriptionStatus Status { get; set; }
+            = OpenAiTranscriptionStatus.Created;
+
+        public bool Done { get; set; }
+
+        public string? Error { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime ModifiedAt { get; set; }
+    }
+
+    public class OpenAiTranscriptionTaskDetailsDto : OpenAiTranscriptionTaskDto
+    {
+        public string? RecognizedText { get; set; }
+
+        public string? MarkdownText { get; set; }
+
+        public IReadOnlyList<OpenAiTranscriptionStepDto> Steps { get; set; }
+            = Array.Empty<OpenAiTranscriptionStepDto>();
+    }
+
+    public class OpenAiTranscriptionStepDto
+    {
+        public int Id { get; set; }
+
+        public OpenAiTranscriptionStatus Step { get; set; }
+
+        public OpenAiTranscriptionStepStatus Status { get; set; }
+
+        public DateTime StartedAt { get; set; }
+
+        public DateTime? FinishedAt { get; set; }
+
+        public string? Error { get; set; }
+    }
+}

--- a/services/OpenAiTranscriptionService.cs
+++ b/services/OpenAiTranscriptionService.cs
@@ -62,7 +62,6 @@ namespace YandexSpeech.services
             _dbContext.OpenAiTranscriptionTasks.Add(task);
             await _dbContext.SaveChangesAsync();
 
-            await ContinueTranscriptionAsync(task.Id);
             return task;
         }
 


### PR DESCRIPTION
## Summary
- add a dedicated controller and DTOs for OpenAI transcription tasks with background continuation and per-user history endpoints
- introduce an Angular service and standalone page to upload files, monitor progress, and display recognized results
- expose the new workflow through updated routes, navigation links, and adjustments to the transcription service lifecycle

## Testing
- npx ng build --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68d28e483b148331af1b03cca510c3f6