### PR TITLE
Remove transcription upload size limit

### DIFF
--- a/Controllers/OpenAiTranscriptionController.cs
+++ b/Controllers/OpenAiTranscriptionController.cs
@@ -43,8 +43,11 @@ namespace YandexSpeech.Controllers
         }
 
         [HttpPost]
-        [RequestSizeLimit(200_000_000)]
-        [RequestFormLimits(MultipartBodyLengthLimit = 200_000_000)]
+        [DisableRequestSizeLimit]
+        [RequestFormLimits(
+            MultipartBodyLengthLimit = long.MaxValue,
+            ValueLengthLimit = int.MaxValue,
+            MultipartHeadersLengthLimit = int.MaxValue)]
         public async Task<ActionResult<OpenAiTranscriptionTaskDto>> Upload([FromForm] IFormFile file)
         {
             if (file == null || file.Length == 0)


### PR DESCRIPTION
## Summary
- remove the 200 MB request size cap on OpenAI transcription uploads
- allow multipart form uploads to use the framework maximum limits

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d29f3c39248331b3a5b6d7b3ace303