### PR TITLE
Fix transcription step progression for OpenAI tasks

### DIFF
--- a/services/OpenAiTranscriptionService.cs
+++ b/services/OpenAiTranscriptionService.cs
@@ -81,12 +81,13 @@ namespace YandexSpeech.services
                     switch (task.Status)
                     {
                         case OpenAiTranscriptionStatus.Created:
+                        case OpenAiTranscriptionStatus.Converting:
                             await RunConversionStepAsync(task);
                             break;
-                        case OpenAiTranscriptionStatus.Converting:
+                        case OpenAiTranscriptionStatus.Transcribing:
                             await RunTranscriptionStepAsync(task);
                             break;
-                        case OpenAiTranscriptionStatus.Transcribing:
+                        case OpenAiTranscriptionStatus.Formatting:
                             await RunFormattingStepAsync(task);
                             break;
                         default:


### PR DESCRIPTION
## Summary
- ensure transcription tasks rerun the conversion step whenever the status is Created or Converting
- trigger the transcription step only when the task status reaches Transcribing and formatting only when set to Formatting

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2adc83b0c8331b5bd77751c8c5c35