### PR TITLE
Prevent FFmpeg conversion from hanging

### DIFF
--- a/services/OpenAiTranscriptionService.cs
+++ b/services/OpenAiTranscriptionService.cs
@@ -136,11 +136,14 @@ namespace YandexSpeech.services
                 };
 
                 process.Start();
-                await process.WaitForExitAsync();
+
+                var standardErrorTask = process.StandardError.ReadToEndAsync();
+                var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+                await Task.WhenAll(process.WaitForExitAsync(), standardErrorTask, standardOutputTask);
 
                 if (process.ExitCode != 0)
                 {
-                    var error = await process.StandardError.ReadToEndAsync();
+                    var error = await standardErrorTask;
                     throw new InvalidOperationException($"FFmpeg conversion failed (exit code {process.ExitCode}): {error}");
                 }
 


### PR DESCRIPTION
## Summary
- drain the FFmpeg process output streams while waiting for completion to avoid deadlocks

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b77e3a188331ad3c3c6518438e84