### PR TITLE
Increase OpenAI client timeouts

### DIFF
--- a/services/OpenAiTranscriptionService.cs
+++ b/services/OpenAiTranscriptionService.cs
@@ -272,7 +272,10 @@ namespace YandexSpeech.services
 
         private async Task<string> TranscribeWithOpenAiAsync(string audioFilePath)
         {
-            using var client = new HttpClient();
+            using var client = new HttpClient
+            {
+                Timeout = TimeSpan.FromMinutes(5)
+            };
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _openAiApiKey);
 
             await using var fileStream = File.OpenRead(audioFilePath);
@@ -303,7 +306,7 @@ namespace YandexSpeech.services
 
         private async Task<string> CreateDialogueMarkdownAsync(string transcription)
         {
-            using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
+            using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _openAiApiKey);
 
             var messages = new[]


### PR DESCRIPTION
## Summary
- extend the HttpClient timeout when calling OpenAI transcription and formatting APIs to avoid premature cancellations

## Testing
- dotnet build *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b98bea148331a9f8d0222e924eb6