### PR TITLE
Use local Whisper model for transcription

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -11,7 +11,11 @@
     "ApiKey": "---- poot to config ----------"
   },
 
-
+  "Whisper": {
+    "ExecutablePath": "whisper",
+    "Model": "medium",
+    "UseGpu": true
+  },
 
   "FfmpegExePath": "C:\\Documents and Settings\\user\\AppData\\Local\\Programs\\FFmpeg\\bin\\",
   "FfmpegExePath1": "C:\\Users\\Artem\\AppData\\Local\\Programs\\FFmpeg\\bin\\",


### PR DESCRIPTION
## Summary
- replace the remote OpenAI transcription call with a local Whisper CLI invocation that supports configurable GPU or CPU execution
- add Whisper configuration options to appsettings for executable path, model, and device selection

## Testing
- ⚠️ `dotnet build` *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c4d693b48331a9d0ff50544ac50c