### PR TITLE
Implement segment processing workflow for OpenAI transcriptions

### DIFF
--- a/Controllers/OpenAiTranscriptionController.cs
+++ b/Controllers/OpenAiTranscriptionController.cs
@@ -121,6 +121,7 @@ namespace YandexSpeech.Controllers
 
             var task = await _dbContext.OpenAiTranscriptionTasks
                 .Include(t => t.Steps)
+                .Include(t => t.Segments)
                 .FirstOrDefaultAsync(t => t.Id == id && t.CreatedBy == userId);
 
             if (task == null)
@@ -181,7 +182,9 @@ namespace YandexSpeech.Controllers
                 Done = task.Done,
                 Error = task.Error,
                 CreatedAt = task.CreatedAt,
-                ModifiedAt = task.ModifiedAt
+                ModifiedAt = task.ModifiedAt,
+                SegmentsTotal = task.SegmentsTotal,
+                SegmentsProcessed = task.SegmentsProcessed
             };
         }
 
@@ -198,6 +201,7 @@ namespace YandexSpeech.Controllers
                 CreatedAt = task.CreatedAt,
                 ModifiedAt = task.ModifiedAt,
                 RecognizedText = task.RecognizedText,
+                ProcessedText = task.ProcessedText,
                 MarkdownText = task.MarkdownText
             };
 
@@ -214,6 +218,21 @@ namespace YandexSpeech.Controllers
                     Error = step.Error
                 })
                 .ToList() ?? new List<OpenAiTranscriptionStepDto>();
+
+            dto.Segments = task.Segments?
+                .OrderBy(s => s.Order)
+                .Select(segment => new OpenAiRecognizedSegmentDto
+                {
+                    SegmentId = segment.SegmentId,
+                    Order = segment.Order,
+                    Text = segment.Text,
+                    ProcessedText = segment.ProcessedText,
+                    IsProcessed = segment.IsProcessed,
+                    IsProcessing = segment.IsProcessing,
+                    StartSeconds = segment.StartSeconds,
+                    EndSeconds = segment.EndSeconds
+                })
+                .ToList() ?? new List<OpenAiRecognizedSegmentDto>();
 
             return dto;
         }

--- a/Migrations/20251001000000_openai_segments.Designer.cs
+++ b/Migrations/20251001000000_openai_segments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using YandexSpeech;
 
@@ -11,9 +12,11 @@ using YandexSpeech;
 namespace YandexSpeech.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class MyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251001000000_openai_segments")]
+    partial class openai_segments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20251001000000_openai_segments.cs
+++ b/Migrations/20251001000000_openai_segments.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace YandexSpeech.Migrations
+{
+    /// <inheritdoc />
+    public partial class openai_segments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProcessedText",
+                table: "OpenAiTranscriptionTasks",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SegmentsJson",
+                table: "OpenAiTranscriptionTasks",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SegmentsProcessed",
+                table: "OpenAiTranscriptionTasks",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SegmentsTotal",
+                table: "OpenAiTranscriptionTasks",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "OpenAiRecognizedSegments",
+                columns: table => new
+                {
+                    SegmentId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TaskId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    Text = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ProcessedText = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IsProcessed = table.Column<bool>(type: "bit", nullable: false),
+                    IsProcessing = table.Column<bool>(type: "bit", nullable: false),
+                    StartSeconds = table.Column<double>(type: "float", nullable: true),
+                    EndSeconds = table.Column<double>(type: "float", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OpenAiRecognizedSegments", x => x.SegmentId);
+                    table.ForeignKey(
+                        name: "FK_OpenAiRecognizedSegments_OpenAiTranscriptionTasks_TaskId",
+                        column: x => x.TaskId,
+                        principalTable: "OpenAiTranscriptionTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OpenAiRecognizedSegments_TaskId",
+                table: "OpenAiRecognizedSegments",
+                column: "TaskId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OpenAiRecognizedSegments");
+
+            migrationBuilder.DropColumn(
+                name: "ProcessedText",
+                table: "OpenAiTranscriptionTasks");
+
+            migrationBuilder.DropColumn(
+                name: "SegmentsJson",
+                table: "OpenAiTranscriptionTasks");
+
+            migrationBuilder.DropColumn(
+                name: "SegmentsProcessed",
+                table: "OpenAiTranscriptionTasks");
+
+            migrationBuilder.DropColumn(
+                name: "SegmentsTotal",
+                table: "OpenAiTranscriptionTasks");
+        }
+    }
+}

--- a/dbcontext.cs
+++ b/dbcontext.cs
@@ -37,6 +37,7 @@ namespace YandexSpeech
 
         public DbSet<OpenAiTranscriptionTask> OpenAiTranscriptionTasks { get; set; }
         public DbSet<OpenAiTranscriptionStep> OpenAiTranscriptionSteps { get; set; }
+        public DbSet<OpenAiRecognizedSegment> OpenAiRecognizedSegments { get; set; }
 
 
         // Новая таблица

--- a/models/DB/OpenAiRecognizedSegment.cs
+++ b/models/DB/OpenAiRecognizedSegment.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace YandexSpeech.models.DB
+{
+    [Table("OpenAiRecognizedSegments")]
+    public class OpenAiRecognizedSegment
+    {
+        [Key]
+        public int SegmentId { get; set; }
+
+        [Required]
+        public string TaskId { get; set; } = default!;
+
+        [ForeignKey(nameof(TaskId))]
+        public OpenAiTranscriptionTask Task { get; set; } = default!;
+
+        public int Order { get; set; }
+
+        [Required]
+        public string Text { get; set; } = default!;
+
+        public string? ProcessedText { get; set; }
+
+        public bool IsProcessed { get; set; }
+
+        public bool IsProcessing { get; set; }
+
+        public double? StartSeconds { get; set; }
+
+        public double? EndSeconds { get; set; }
+    }
+}

--- a/models/DB/OpenAiTranscriptionTask.cs
+++ b/models/DB/OpenAiTranscriptionTask.cs
@@ -10,6 +10,8 @@ namespace YandexSpeech.models.DB
         Created = 0,
         Converting = 10,
         Transcribing = 20,
+        Segmenting = 25,
+        ProcessingSegments = 27,
         Formatting = 30,
         Done = 900,
         Error = 999
@@ -36,6 +38,10 @@ namespace YandexSpeech.models.DB
 
         public string? RecognizedText { get; set; }
 
+        public string? SegmentsJson { get; set; }
+
+        public string? ProcessedText { get; set; }
+
         public string? MarkdownText { get; set; }
 
         public OpenAiTranscriptionStatus Status { get; set; } = OpenAiTranscriptionStatus.Created;
@@ -51,8 +57,15 @@ namespace YandexSpeech.models.DB
         [Required]
         public string CreatedBy { get; set; } = null!;
 
+        public int SegmentsTotal { get; set; }
+
+        public int SegmentsProcessed { get; set; }
+
         public virtual ICollection<OpenAiTranscriptionStep> Steps { get; set; }
             = new List<OpenAiTranscriptionStep>();
+
+        public virtual ICollection<OpenAiRecognizedSegment> Segments { get; set; }
+            = new List<OpenAiRecognizedSegment>();
     }
 
     [Table("OpenAiTranscriptionSteps")]

--- a/models/DTO/OpenAiTranscriptionDtos.cs
+++ b/models/DTO/OpenAiTranscriptionDtos.cs
@@ -22,16 +22,44 @@ namespace YandexSpeech.models.DTO
         public DateTime CreatedAt { get; set; }
 
         public DateTime ModifiedAt { get; set; }
+
+        public int SegmentsTotal { get; set; }
+
+        public int SegmentsProcessed { get; set; }
     }
 
     public class OpenAiTranscriptionTaskDetailsDto : OpenAiTranscriptionTaskDto
     {
         public string? RecognizedText { get; set; }
 
+        public string? ProcessedText { get; set; }
+
         public string? MarkdownText { get; set; }
 
         public IReadOnlyList<OpenAiTranscriptionStepDto> Steps { get; set; }
             = Array.Empty<OpenAiTranscriptionStepDto>();
+
+        public IReadOnlyList<OpenAiRecognizedSegmentDto> Segments { get; set; }
+            = Array.Empty<OpenAiRecognizedSegmentDto>();
+    }
+
+    public class OpenAiRecognizedSegmentDto
+    {
+        public int SegmentId { get; set; }
+
+        public int Order { get; set; }
+
+        public string Text { get; set; } = string.Empty;
+
+        public string? ProcessedText { get; set; }
+
+        public bool IsProcessed { get; set; }
+
+        public bool IsProcessing { get; set; }
+
+        public double? StartSeconds { get; set; }
+
+        public double? EndSeconds { get; set; }
     }
 
     public class OpenAiTranscriptionStepDto

--- a/services/CaptionProcessor.cs
+++ b/services/CaptionProcessor.cs
@@ -1,9 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using YoutubeExplode.Videos.ClosedCaptions;
-
-
 
 public class CaptionSegment
 {
@@ -11,6 +9,14 @@ public class CaptionSegment
     public int WordCount { get; set; }
     public double Time { get; set; } // В секундах
     public double PauseBeforeNext { get; set; } // В секундах
+    public double? EndTime { get; set; }
+}
+
+public class CaptionSegmentBlock
+{
+    public int StartIndex { get; set; }
+    public int EndIndex { get; set; }
+    public string Text { get; set; }
 }
 
 public class CaptionProcessor
@@ -24,150 +30,55 @@ public class CaptionProcessor
         if (captions == null || captions.Count == 0)
             return new List<string>();
 
-        // Шаг 1: Преобразование списка ClosedCaption в список CaptionSegment
-        var segments = new List<CaptionSegment>();
+        var segments = BuildSegmentsFromCaptions(captions);
+        return SegmentCaptionSegments(segments, maxWordsInSegment, windowSize, pauseThreshold);
+    }
 
+    public List<string> SegmentCaptionSegments(
+        List<CaptionSegment> segments,
+        int maxWordsInSegment = 50,
+        int windowSize = 5,
+        double pauseThreshold = 1.0)
+    {
+        return SegmentCaptionSegmentsDetailed(segments, maxWordsInSegment, windowSize, pauseThreshold)
+            .Select(block => block.Text)
+            .ToList();
+    }
 
+    public List<CaptionSegmentBlock> SegmentCaptionSegmentsDetailed(
+        List<CaptionSegment> segments,
+        int maxWordsInSegment = 50,
+        int windowSize = 5,
+        double pauseThreshold = 1.0)
+    {
+        var result = new List<CaptionSegmentBlock>();
 
-        for (int i = 0; i < captions.Count; i++)
-        {
-            var current = captions[i];
-          /*  int wordCount = CountWords(current.Text);
+        if (segments == null || segments.Count == 0)
+            return result;
 
-            double pause = 0.0;
-            if (i < captions.Count - 1)
-            {
-                var next = captions[i + 1];
-                var endCurrent = current.Offset;// + current.Parts.Max(x => x.Offset);
-
-                if (current.Parts.Any())
-                    endCurrent += current.Parts.Max(x => x.Offset);
-                else
-                {
-                    if (segments.Any())
-                    {
-                        segments[segments.Count - 1].PauseBeforeNext += current.Duration.TotalSeconds;
-                        //  segments[segments.Count - 1].Text += ' '+current.Text;
-                    }
-                    continue;
-                }
-
-                var pauseSpan = next.Offset - endCurrent;
-                pause = pauseSpan.TotalSeconds;
-            }*/
-
-
-            if (current.Parts.Count == 0 && current.Text.Split(' ').Length >2 )
-            {
-                segments.Add(new CaptionSegment
-                {
-                    Text = current.Text,
-                    WordCount = 1,
-                    Time = current.Offset.TotalSeconds + current.Duration.TotalSeconds,
-                    PauseBeforeNext = 0
-                });
-            }
-            else
-            foreach (var d in current.Parts)
-                segments.Add(new CaptionSegment
-                {
-                    Text = d.Text,
-                    WordCount = 1,
-                    Time = current.Offset.TotalSeconds + d.Offset.TotalSeconds,
-                    PauseBeforeNext = 0
-                });
-        }
-
-        for (int i = 0; i < segments.Count-1; i++)
+        for (int i = 0; i < segments.Count - 1; i++)
         {
             segments[i].PauseBeforeNext = segments[i + 1].Time - segments[i].Time;
-            /*
-            if (segments[i].PauseBeforeNext > 1.5)
-                segments[i].Text += '|';
-            else
-            if (segments[i].PauseBeforeNext > 0.7)
-                segments[i].Text += '.';
-            */
         }
 
-
-
-
-
-
-
-            /*
-            try
-            {
-
-                for (int i = 0; i < captions.Count; i++)
-                {
-                    var current = captions[i];
-                    int wordCount = CountWords(current.Text);
-
-                    double pause = 0.0;
-                    if (i < captions.Count - 1)
-                    {
-                        var next = captions[i + 1];
-                        var endCurrent = current.Offset;// + current.Parts.Max(x => x.Offset);
-
-                        if (current.Parts.Any())
-                            endCurrent += current.Parts.Max(x => x.Offset);
-                        else
-                        {
-                            if (segments.Any())
-                            {
-                                segments[segments.Count - 1].PauseBeforeNext += current.Duration.TotalSeconds;
-                              //  segments[segments.Count - 1].Text += ' '+current.Text;
-                            }
-                            continue;
-                        }
-
-                        var pauseSpan = next.Offset - endCurrent;
-                        pause = pauseSpan.TotalSeconds;
-                    }
-
-                    segments.Add(new CaptionSegment
-                    {
-                        Text = current.Text,
-                        WordCount = wordCount,
-                        PauseBeforeNext = pause
-                    });
-                }
-            }
-            catch (Exception ex)
-            {
-
-            }
-            */
-
-            // Шаг 2: Сегментация с использованием окна вокруг maxWordsInSegment
-            var result = new List<string>();
         int start = 0;
-
-     //   File.WriteAllText("c:/amd/11.txt", string.Join(' ', segments.Select(x => x.Text)));
-
-        double maxPause = 0;
-
-        int maxPauseIndex = 0;
-
         while (start < segments.Count)
         {
-           
+            int end;
 
-            int end = start;
-            int currentWordCount = 0;
-
-            if (segments.Count - start < maxWordsInSegment)
-                end = segments.Count;
-
+            if (segments.Count - start <= maxWordsInSegment)
+            {
+                end = segments.Count - 1;
+            }
             else
             {
+                var searchStart = Math.Max(start + maxWordsInSegment - windowSize, start);
+                var searchEnd = Math.Min(start + maxWordsInSegment + windowSize, segments.Count - 1);
 
-                var searchStart = start + maxWordsInSegment - windowSize;
-                var searchEnd = start + maxWordsInSegment + windowSize;
+                double maxPause = double.MinValue;
+                int maxPauseIndex = searchStart;
 
-                for (int i = searchStart; i < searchEnd && i < segments.Count; i++)
+                for (int i = searchStart; i <= searchEnd; i++)
                 {
                     if (segments[i].PauseBeforeNext > maxPause)
                     {
@@ -176,22 +87,69 @@ public class CaptionProcessor
                     }
                 }
 
-                end = maxPauseIndex;
-
+                end = Math.Max(maxPauseIndex, start);
             }
 
-            // Собираем текст сегмента
-            var segmentText = string.Join(" ", segments.Skip(start).Take(end - start+1).Select(s => s.Text));
-            result.Add(segmentText.Replace("  "," "));
+            var count = end - start + 1;
+            if (count <= 0)
+            {
+                end = start;
+                count = 1;
+            }
 
-            maxPause = 0;
+            var text = string.Join(" ", segments.Skip(start).Take(count).Select(s => s.Text))
+                .Replace("  ", " ")
+                .Trim();
 
-            // Обновляем стартовую позицию
-            start = end;
+            result.Add(new CaptionSegmentBlock
+            {
+                StartIndex = start,
+                EndIndex = end,
+                Text = text
+            });
+
+            start = end + 1;
         }
-        /*
-        File.WriteAllText("c:/amd/112.txt", string.Join(' ', result));*/
+
         return result;
+    }
+
+    private static List<CaptionSegment> BuildSegmentsFromCaptions(List<ClosedCaption> captions)
+    {
+        var segments = new List<CaptionSegment>();
+
+        for (int i = 0; i < captions.Count; i++)
+        {
+            var current = captions[i];
+
+            if (current.Parts.Count == 0 && current.Text.Split(' ').Length > 2)
+            {
+                segments.Add(new CaptionSegment
+                {
+                    Text = current.Text,
+                    WordCount = 1,
+                    Time = current.Offset.TotalSeconds + current.Duration.TotalSeconds,
+                    EndTime = current.Offset.TotalSeconds + current.Duration.TotalSeconds,
+                    PauseBeforeNext = 0
+                });
+            }
+            else
+            {
+                foreach (var part in current.Parts)
+                {
+                    segments.Add(new CaptionSegment
+                    {
+                        Text = part.Text,
+                        WordCount = 1,
+                        Time = current.Offset.TotalSeconds + part.Offset.TotalSeconds,
+                        EndTime = current.Offset.TotalSeconds + part.Offset.TotalSeconds,
+                        PauseBeforeNext = 0
+                    });
+                }
+            }
+        }
+
+        return segments;
     }
 
     private int CountWords(string text)
@@ -199,7 +157,6 @@ public class CaptionProcessor
         if (string.IsNullOrWhiteSpace(text))
             return 0;
 
-        // Простый подсчет слов, разделенных пробелами
         return text.Split(new[] { ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries).Length;
     }
 }


### PR DESCRIPTION
## Summary
- update the OpenAI transcription pipeline to preserve timecoded output, split Whisper results into blocks, and process each block before formatting
- extend database models, DTOs, and controller responses to track segment metadata and expose recognized segments
- add EF migration and helper updates to store OpenAI segment records alongside the existing caption segmentation logic

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d38185b27483319078e88dc8686b1c