### PR TITLE
Increase upload request size limits

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,8 +14,26 @@ using YoutubeDownload.Services;
 using YoutubeExplode;
 using System.IO;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.Http.Features;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = long.MaxValue;
+    options.ValueLengthLimit = int.MaxValue;
+    options.MultipartHeadersLengthLimit = int.MaxValue;
+});
+
+builder.Services.Configure<IISServerOptions>(options =>
+{
+    options.MaxRequestBodySize = long.MaxValue;
+});
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = long.MaxValue;
+});
 
 // 1. Настройка CORS
 builder.Services.AddCors(opts =>


### PR DESCRIPTION
## Summary
- configure form and server request body limits to accept very large transcription uploads
- ensure Kestrel and IIS hosts allow maximum-sized bodies for transcription requests

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3beff02748331bb45c6a982f43736