### PR TITLE
Add IIS upload limits to published web.config

### DIFF
--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -37,6 +37,12 @@
     <ProjectReference Include="..\..\..\YoutubeExplode-master\YoutubeExplode\YoutubeExplode.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="web.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <PropertyGroup>
     <AngularProjectDir>$(MSBuildProjectDirectory)/Angular/youtube-downloader/</AngularProjectDir>
     <AngularDistDir>$(AngularProjectDir)dist/youtube-downloader/</AngularDistDir>

--- a/web.config
+++ b/web.config
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+      </handlers>
+      <security>
+        <requestFiltering>
+          <requestLimits maxAllowedContentLength="2147483648" />
+        </requestFiltering>
+      </security>
+      <serverRuntime uploadReadAheadSize="10485760" />
+      <aspNetCore processPath="%LAUNCHER_PATH%"
+                  arguments="%LAUNCHER_ARGS%"
+                  stdoutLogEnabled="false"
+                  stdoutLogFile=".\logs\stdout"
+                  hostingModel="InProcess"
+                  requestTimeout="00:30:00" />
+    </system.webServer>
+  </location>
+</configuration>


### PR DESCRIPTION
## Summary
- add a custom web.config so IIS publishes with large request limits and read-ahead size
- ensure the web.config is copied during build/publish output

## Testing
- not run (dotnet SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d3c6c9d48c83318bdae5a83302a84b