### PR TITLE
Remove redundant web.config content item

### DIFF
--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -36,13 +36,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\YoutubeExplode-master\YoutubeExplode\YoutubeExplode.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="web.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
   <PropertyGroup>
     <AngularProjectDir>$(MSBuildProjectDirectory)/Angular/youtube-downloader/</AngularProjectDir>
     <AngularDistDir>$(AngularProjectDir)dist/youtube-downloader/</AngularDistDir>


### PR DESCRIPTION
## Summary
- remove the explicit web.config content inclusion to avoid duplicate implicit content items

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d3c95946608331914bbded32317587