### PR TITLE
Fix Whisper process encoding to handle Unicode output

### DIFF
--- a/services/OpenAiTranscriptionService.cs
+++ b/services/OpenAiTranscriptionService.cs
@@ -530,6 +530,19 @@ namespace YandexSpeech.services
                 CreateNoWindow = true
             };
 
+            if (!startInfo.Environment.ContainsKey("PYTHONIOENCODING"))
+            {
+                startInfo.Environment["PYTHONIOENCODING"] = "utf-8";
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                startInfo.Environment["PYTHONUTF8"] = "1";
+            }
+
+            startInfo.StandardErrorEncoding = Encoding.UTF8;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
+
             if (!string.IsNullOrWhiteSpace(ffmpegExecutable))
             {
                 startInfo.Environment["FFMPEG_BINARY"] = ffmpegExecutable;


### PR DESCRIPTION
## Summary
- ensure the Whisper CLI runs with UTF-8 Python output by setting PYTHONIOENCODING/PYTHONUTF8
- force UTF-8 decoding of the Whisper process output streams to prevent UnicodeEncodeError failures on Windows

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d41feaf5b483318002eb3032e0eb17