### PR TITLE
Handle OpenAI connectivity retries and allow resuming transcription tasks

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -102,6 +102,17 @@
   color: rgba(0, 0, 0, 0.6);
 }
 
+.details-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.inline-spinner {
+  width: 28px !important;
+  height: 28px !important;
+}
+
 .steps-section h3,
 .result-block h3 {
   margin-top: 0;

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -74,6 +74,29 @@
 
           <div class="error" *ngIf="selectedTask.error">{{ selectedTask.error }}</div>
 
+          <div
+            class="details-actions"
+            *ngIf="selectedTask.status === OpenAiTranscriptionStatus.Error"
+          >
+            <button
+              mat-stroked-button
+              color="primary"
+              (click)="continueTask()"
+              [disabled]="continueInProgress"
+            >
+              <mat-icon>play_arrow</mat-icon>
+              <span>Продолжить задачу</span>
+            </button>
+            <mat-progress-spinner
+              *ngIf="continueInProgress"
+              class="inline-spinner"
+              mode="indeterminate"
+              diameter="28"
+            ></mat-progress-spinner>
+          </div>
+
+          <div class="error" *ngIf="continueError">{{ continueError }}</div>
+
           <section class="steps-section" *ngIf="selectedTask.steps.length">
             <h3>Прогресс</h3>
             <ul class="steps-list">

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -6,6 +6,8 @@ export enum OpenAiTranscriptionStatus {
   Created = 0,
   Converting = 10,
   Transcribing = 20,
+  Segmenting = 25,
+  ProcessingSegments = 27,
   Formatting = 30,
   Done = 900,
   Error = 999,
@@ -27,12 +29,16 @@ export interface OpenAiTranscriptionTaskDto {
   error: string | null;
   createdAt: string;
   modifiedAt: string;
+  segmentsTotal: number;
+  segmentsProcessed: number;
 }
 
 export interface OpenAiTranscriptionTaskDetailsDto extends OpenAiTranscriptionTaskDto {
   recognizedText: string | null;
+  processedText: string | null;
   markdownText: string | null;
   steps: OpenAiTranscriptionStepDto[];
+  segments: OpenAiRecognizedSegmentDto[];
 }
 
 export interface OpenAiTranscriptionStepDto {
@@ -42,6 +48,17 @@ export interface OpenAiTranscriptionStepDto {
   startedAt: string;
   finishedAt: string | null;
   error: string | null;
+}
+
+export interface OpenAiRecognizedSegmentDto {
+  segmentId: number;
+  order: number;
+  text: string;
+  processedText: string | null;
+  isProcessed: boolean;
+  isProcessing: boolean;
+  startSeconds: number | null;
+  endSeconds: number | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -72,6 +89,10 @@ export class OpenAiTranscriptionService {
         return 'Преобразование аудио';
       case OpenAiTranscriptionStatus.Transcribing:
         return 'Распознавание текста';
+      case OpenAiTranscriptionStatus.Segmenting:
+        return 'Разбиение на сегменты';
+      case OpenAiTranscriptionStatus.ProcessingSegments:
+        return 'Обработка сегментов';
       case OpenAiTranscriptionStatus.Formatting:
         return 'Форматирование результата';
       case OpenAiTranscriptionStatus.Done:
@@ -96,5 +117,9 @@ export class OpenAiTranscriptionService {
       default:
         return 'Неизвестно';
     }
+  }
+
+  continueTask(id: string): Observable<OpenAiTranscriptionTaskDetailsDto> {
+    return this.http.post<OpenAiTranscriptionTaskDetailsDto>(`${this.apiUrl}/${id}/continue`, {});
   }
 }

--- a/services/Interface/IOpenAiTranscriptionService.cs
+++ b/services/Interface/IOpenAiTranscriptionService.cs
@@ -6,6 +6,7 @@ namespace YandexSpeech.services
     public interface IOpenAiTranscriptionService
     {
         Task<OpenAiTranscriptionTask> StartTranscriptionAsync(string sourceFilePath, string createdBy);
+        Task<OpenAiTranscriptionTask?> PrepareForContinuationAsync(string taskId);
         Task<OpenAiTranscriptionTask?> ContinueTranscriptionAsync(string taskId);
     }
 }


### PR DESCRIPTION
## Summary
- add retry handling for OpenAI formatting calls and reset logic so failed transcription tasks can resume from the last step
- expose a backend endpoint and Angular service call to continue failed OpenAI transcription tasks
- update the transcription UI to show a "continue" action, improved status coverage, and keep the details view active while polling resumes

## Testing
- CI=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44afba5508331bfb5b3a150437ca0