### PR TITLE
Handle missing name identifier claims for API requests

### DIFF
--- a/Controllers/AudioFilesController.cs
+++ b/Controllers/AudioFilesController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using YandexSpeech.models.DB;
 using YandexSpeech.services;
+using YandexSpeech.Extensions;
 
 namespace YandexSpeech.Controllers
 {
@@ -39,7 +40,7 @@ namespace YandexSpeech.Controllers
             if (file == null || file.Length == 0)
                 return BadRequest("File not provided.");
 
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
@@ -51,7 +52,7 @@ namespace YandexSpeech.Controllers
         [HttpGet]
         public async Task<ActionResult> List()
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId)) return Unauthorized();
 
             var files = await _db.AudioFiles
@@ -73,7 +74,7 @@ namespace YandexSpeech.Controllers
         [HttpGet("{id}")]
         public async Task<ActionResult<AudioFile>> GetById(string id)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             var file = await _db.AudioFiles.FirstOrDefaultAsync(f => f.Id == id && f.CreatedBy == userId);
             if (file == null)
                 return NotFound();
@@ -85,7 +86,7 @@ namespace YandexSpeech.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(string id)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             var file = await _db.AudioFiles.FirstOrDefaultAsync(f => f.Id == id && f.CreatedBy == userId);
             if (file == null)
                 return NotFound();

--- a/Controllers/AudioWorkflowController.cs
+++ b/Controllers/AudioWorkflowController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using YandexSpeech.services;
+using YandexSpeech.Extensions;
 
 namespace YandexSpeech.Controllers
 {
@@ -23,7 +24,7 @@ namespace YandexSpeech.Controllers
         [HttpPost("{fileId}/recognize")]
         public async Task<ActionResult<string>> StartRecognition(string fileId)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 

--- a/Controllers/OpenAiTranscriptionController.cs
+++ b/Controllers/OpenAiTranscriptionController.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using YandexSpeech.models.DB;
 using YandexSpeech.models.DTO;
 using YandexSpeech.services;
+using YandexSpeech.Extensions;
 
 namespace YandexSpeech.Controllers
 {
@@ -55,7 +56,7 @@ namespace YandexSpeech.Controllers
                 return BadRequest("File not provided.");
             }
 
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId))
             {
                 return Unauthorized();
@@ -95,7 +96,7 @@ namespace YandexSpeech.Controllers
         [HttpGet]
         public async Task<ActionResult> List()
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId))
             {
                 return Unauthorized();
@@ -113,7 +114,7 @@ namespace YandexSpeech.Controllers
         [HttpGet("{id}")]
         public async Task<ActionResult<OpenAiTranscriptionTaskDetailsDto>> GetById(string id)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId))
             {
                 return Unauthorized();
@@ -135,7 +136,7 @@ namespace YandexSpeech.Controllers
         [HttpPost("{id}/continue")]
         public async Task<ActionResult<OpenAiTranscriptionTaskDetailsDto>> Continue(string id)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (string.IsNullOrEmpty(userId))
             {
                 return Unauthorized();

--- a/Controllers/YSubtitilesController.cs
+++ b/Controllers/YSubtitilesController.cs
@@ -6,6 +6,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using YandexSpeech.models.DB;
 using YandexSpeech.services;
+using YandexSpeech.Extensions;
 using YoutubeExplode.Videos;
 using YoutubeDownload.Services; // <-- добавили
 using System.Text;
@@ -240,7 +241,7 @@ namespace YandexSpeech.Controllers
             if (!User.Identity?.IsAuthenticated ?? true)
                 return Unauthorized("not authenticated");
 
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (userId == null)
                 return Unauthorized("User is not authenticated");
 

--- a/Controllers/YoutubeController.cs
+++ b/Controllers/YoutubeController.cs
@@ -10,6 +10,7 @@ using YoutubeDownload.Managers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using System.Security.Claims;             // StreamDto, MergedVideoDto
+using YandexSpeech.Extensions;
 
 namespace YourNamespace.Controllers
 {
@@ -120,7 +121,7 @@ namespace YourNamespace.Controllers
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]       
         public async Task<IActionResult> MergeVideoAndAudios([FromBody] MergeRequestDto dto)
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (userId == null)
                 return Unauthorized("User is not authenticated");
 
@@ -208,7 +209,7 @@ namespace YourNamespace.Controllers
         [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         public async Task<ActionResult<List<MergedVideoDto>>> GetMergedVideos()
         {
-            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var userId = User.GetUserId();
             if (userId == null)
                 return Unauthorized("User is not authenticated");
 

--- a/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,19 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace YandexSpeech.Extensions
+{
+    public static class ClaimsPrincipalExtensions
+    {
+        public static string? GetUserId(this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+            {
+                return null;
+            }
+
+            return principal.FindFirstValue(ClaimTypes.NameIdentifier)
+                   ?? principal.FindFirstValue(JwtRegisteredClaimNames.Sub);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared ClaimsPrincipal extension to resolve the authenticated user id from either the name identifier or sub claims
- update audio, youtube, subtitle, and OpenAI transcription controllers to use the helper, ensuring valid JWTs are accepted even when the name identifier claim is absent

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d454facb0c83318c6a4724f32a236b