### PR TITLE
Add transcription editor page and API updates

### DIFF
--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -3,11 +3,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { YoutubeDownloaderComponent } from './youtube-downloader/youtube-downloader.component';
 import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
+import { OpenAiTranscriptionEditorComponent } from './openai-transcription-editor/openai-transcription-editor.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
+  { path: 'transcriptions/:id/edit', component: OpenAiTranscriptionEditorComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
 ];
 

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks
 import { SubtitlesTasksComponent } from './subtitles-task/subtitles-tasks.component';
 import { MarkdownConverterComponent } from './Markdown-converter/markdown-converter.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
+import { OpenAiTranscriptionEditorComponent } from './openai-transcription-editor/openai-transcription-editor.component';
 
 export const appRoutes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: SubtitlesTasksComponent },
+  { path: 'transcriptions/:id/edit', component: OpenAiTranscriptionEditorComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
 

--- a/Angular/youtube-downloader/src/app/openai-transcription-editor/openai-transcription-editor.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription-editor/openai-transcription-editor.component.css
@@ -1,0 +1,73 @@
+:host {
+  display: block;
+  height: calc(100vh - 64px);
+}
+
+.editor-page {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 16px;
+  height: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.page-header button[mat-button] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.title-block {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title-block h1 {
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.3;
+}
+
+.subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.editor-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.editor-card md-editor {
+  flex: 1;
+  min-height: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+}
+
+.state-card {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.state-card.error {
+  color: #c62828;
+}

--- a/Angular/youtube-downloader/src/app/openai-transcription-editor/openai-transcription-editor.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription-editor/openai-transcription-editor.component.html
@@ -1,0 +1,67 @@
+<div class="editor-page">
+  <ng-container *ngIf="!loading && !errorMessage; else loadingOrError">
+    <div class="page-header">
+      <button mat-button type="button" (click)="goBack()">
+        <mat-icon>arrow_back</mat-icon>
+        К списку расшифровок
+      </button>
+
+      <div class="title-block">
+        <h1>{{ task?.displayName || 'Расшифровка' }}</h1>
+        <p class="subtitle" *ngIf="task?.modifiedAt">
+          Обновлено: {{ task?.modifiedAt | date: 'dd.MM.yyyy HH:mm' }}
+        </p>
+      </div>
+
+      <button
+        mat-icon-button
+        type="button"
+        (click)="refresh()"
+        [disabled]="loading || reloading"
+        aria-label="Обновить"
+      >
+        <mat-progress-spinner
+          *ngIf="reloading"
+          diameter="20"
+          mode="indeterminate"
+        ></mat-progress-spinner>
+        <mat-icon *ngIf="!reloading">refresh</mat-icon>
+      </button>
+    </div>
+
+    <mat-card class="editor-card">
+      <md-editor
+        name="transcriptionEditor"
+        [(ngModel)]="recognizedContent"
+        preview="vertical"
+        height="'100%'"
+        [options]="editorOptions"
+      ></md-editor>
+    </mat-card>
+
+    <div class="actions">
+      <button mat-raised-button type="button" color="primary" (click)="download()" [disabled]="!recognizedContent">
+        <mat-icon>download</mat-icon>
+        Скачать .txt
+      </button>
+      <button mat-raised-button type="button" color="accent" (click)="save()" [disabled]="!canSave">
+        <mat-icon>save</mat-icon>
+        Сохранить
+      </button>
+    </div>
+  </ng-container>
+
+  <ng-template #loadingOrError>
+    <div class="state-card" *ngIf="loading">
+      <mat-progress-spinner diameter="48" mode="indeterminate"></mat-progress-spinner>
+      <p>Загружаем расшифровку…</p>
+    </div>
+    <div class="state-card error" *ngIf="!loading && errorMessage">
+      <p>{{ errorMessage }}</p>
+      <button mat-stroked-button type="button" color="primary" (click)="refresh()">
+        <mat-icon>refresh</mat-icon>
+        Повторить
+      </button>
+    </div>
+  </ng-template>
+</div>

--- a/Angular/youtube-downloader/src/app/openai-transcription-editor/openai-transcription-editor.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription-editor/openai-transcription-editor.component.ts
@@ -1,0 +1,201 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { LMarkdownEditorModule } from 'ngx-markdown-editor';
+
+import {
+  OpenAiTranscriptionService,
+  OpenAiTranscriptionTaskDetailsDto,
+} from '../services/openai-transcription.service';
+
+@Component({
+  selector: 'app-openai-transcription-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    LMarkdownEditorModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './openai-transcription-editor.component.html',
+  styleUrls: ['./openai-transcription-editor.component.css'],
+})
+export class OpenAiTranscriptionEditorComponent implements OnInit, OnDestroy {
+  taskId!: string;
+  task: OpenAiTranscriptionTaskDetailsDto | null = null;
+  recognizedContent = '';
+
+  loading = true;
+  saving = false;
+  reloading = false;
+  errorMessage: string | null = null;
+
+  editorOptions = {
+    placeholder: 'Отредактируйте текст расшифровки…',
+    theme: 'github',
+    lineNumbers: true,
+    dragDrop: true,
+    showPreviewPanel: true,
+    hideIcons: [] as string[],
+  };
+
+  private paramSubscription?: Subscription;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly title: Title,
+    private readonly transcriptionService: OpenAiTranscriptionService,
+    private readonly snackBar: MatSnackBar,
+  ) {}
+
+  ngOnInit(): void {
+    this.paramSubscription = this.route.paramMap.subscribe((params) => {
+      const id = params.get('id');
+      if (!id) {
+        this.errorMessage = 'Не указан идентификатор задачи.';
+        this.loading = false;
+        return;
+      }
+
+      if (this.taskId === id) {
+        return;
+      }
+
+      this.taskId = id;
+      this.loadTask();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.paramSubscription?.unsubscribe();
+  }
+
+  get canSave(): boolean {
+    return !this.saving && !!this.taskId && this.recognizedContent.trim().length > 0;
+  }
+
+  loadTask(showSpinner = true): void {
+    if (!this.taskId) {
+      return;
+    }
+
+    if (showSpinner) {
+      this.loading = true;
+    }
+    this.errorMessage = null;
+
+    this.transcriptionService.getTask(this.taskId).subscribe({
+      next: (task) => {
+        this.task = task;
+        this.recognizedContent = task.recognizedText ?? '';
+        this.loading = false;
+        this.reloading = false;
+        this.title.setTitle(`Редактирование расшифровки: ${task.displayName}`);
+      },
+      error: (error) => {
+        this.loading = false;
+        this.reloading = false;
+        this.errorMessage = this.extractError(error) ?? 'Не удалось загрузить данные о задаче.';
+        this.title.setTitle('Ошибка загрузки расшифровки');
+      },
+    });
+  }
+
+  refresh(): void {
+    if (this.loading || !this.taskId) {
+      return;
+    }
+
+    this.reloading = true;
+    this.loadTask(false);
+  }
+
+  goBack(): void {
+    this.router.navigate(['/transcriptions']);
+  }
+
+  download(): void {
+    if (!this.recognizedContent) {
+      return;
+    }
+
+    const blob = new Blob([this.recognizedContent], { type: 'text/plain;charset=utf-8' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const fileName = this.task?.displayName || this.taskId || 'transcription';
+    a.download = `${fileName}.txt`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  save(): void {
+    if (!this.canSave) {
+      return;
+    }
+
+    this.saving = true;
+
+    this.transcriptionService
+      .updateRecognizedText(this.taskId, this.recognizedContent)
+      .subscribe({
+        next: () => {
+          this.saving = false;
+          this.snackBar.open('Расшифровка сохранена', '', { duration: 2000 });
+          if (this.task) {
+            this.task = {
+              ...this.task,
+              recognizedText: this.recognizedContent,
+              modifiedAt: new Date().toISOString(),
+            };
+          }
+        },
+        error: (error) => {
+          this.saving = false;
+          const message = this.extractError(error) ?? 'Не удалось сохранить изменения.';
+          this.snackBar.open(message, 'OK', { duration: 3000 });
+        },
+      });
+  }
+
+  private extractError(error: unknown): string | null {
+    if (!error) {
+      return null;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      const anyError = error as { error?: unknown; message?: string };
+      if (anyError.error) {
+        if (typeof anyError.error === 'string') {
+          return anyError.error;
+        }
+        if (typeof anyError.error === 'object') {
+          const nested = anyError.error as { message?: string; title?: string };
+          return nested.message || nested.title || null;
+        }
+      }
+      return anyError.message ?? null;
+    }
+
+    return null;
+  }
+}

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -183,6 +183,12 @@
   overflow: auto;
 }
 
+.result-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
 .tasks-card a.active {
   background: rgba(63, 81, 181, 0.08);
 }

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -117,6 +117,16 @@
           <section class="result-block" *ngIf="selectedTask.recognizedText">
             <h3>Распознанный текст</h3>
             <pre>{{ selectedTask.recognizedText }}</pre>
+            <div class="result-actions">
+              <button
+                mat-stroked-button
+                color="primary"
+                [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
+              >
+                <mat-icon>edit</mat-icon>
+                <span>Редактировать</span>
+              </button>
+            </div>
           </section>
 
           <section class="result-block" *ngIf="selectedTask.markdownText">

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -8,6 +8,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Subscription, timer } from 'rxjs';
 import { exhaustMap } from 'rxjs/operators';
+import { RouterModule } from '@angular/router';
 import {
   OpenAiTranscriptionService,
   OpenAiTranscriptionStatus,
@@ -30,6 +31,7 @@ import { LocalTimePipe } from '../pipe/local-time.pipe';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     LocalTimePipe,
+    RouterModule,
   ],
   templateUrl: './openai-transcription.component.html',
   styleUrls: ['./openai-transcription.component.css'],

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -81,6 +81,13 @@ export class OpenAiTranscriptionService {
     return this.http.get<OpenAiTranscriptionTaskDetailsDto>(`${this.apiUrl}/${id}`);
   }
 
+  updateRecognizedText(id: string, recognizedText: string, markdownText?: string | null): Observable<void> {
+    return this.http.put<void>(`${this.apiUrl}/${id}/recognized-text`, {
+      recognizedText,
+      markdownText,
+    });
+  }
+
   getStatusText(status: OpenAiTranscriptionStatus | null | undefined): string {
     switch (status) {
       case OpenAiTranscriptionStatus.Created:

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -31,6 +31,7 @@ import { RoleGuard } from './app/services/role.guard';
 import { ProfileComponent } from './app/profile/profile.component';
 import { AuthGuard } from './app/services/auth.guard';
 import { OpenAiTranscriptionComponent } from './app/openai-transcription/openai-transcription.component';
+import { OpenAiTranscriptionEditorComponent } from './app/openai-transcription-editor/openai-transcription-editor.component';
 
 
 
@@ -51,6 +52,12 @@ const routes: Routes = [
   {
     path: 'audio',
     component: AudioFilesComponent, // главная страница
+  },
+
+  {
+    path: 'transcriptions/:id/edit',
+    component: OpenAiTranscriptionEditorComponent,
+    canActivate: [AuthGuard],
   },
 
   {

--- a/models/DTO/UpdateOpenAiTranscriptionTextRequest.cs
+++ b/models/DTO/UpdateOpenAiTranscriptionTextRequest.cs
@@ -1,0 +1,9 @@
+namespace YandexSpeech.models.DTO
+{
+    public class UpdateOpenAiTranscriptionTextRequest
+    {
+        public string? RecognizedText { get; set; }
+
+        public string? MarkdownText { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add backend DTO and API endpoint to update OpenAI transcription texts
- create Angular transcription editor page for editing recognized text with markdown editor
- integrate routing, service updates, and UI links from the transcription list to the new editor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b049c6f4833181b19dab0f2ccfd4