### PR TITLE
Enable markdown editing and deletion on transcriptions

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -187,6 +187,8 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 12px;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .tasks-card a.active {
@@ -198,6 +200,44 @@
   justify-content: center;
   min-height: 160px;
   text-align: center;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.section-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.markdown-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.markdown-editor md-editor {
+  min-height: 320px;
+}
+
+.editor-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.markdown-placeholder {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+  font-style: italic;
 }
 
 @media (min-width: 960px) {

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -120,6 +120,7 @@
             <div class="result-actions">
               <button
                 mat-stroked-button
+                type="button"
                 color="primary"
                 [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
               >
@@ -129,9 +130,89 @@
             </div>
           </section>
 
-          <section class="result-block" *ngIf="selectedTask.markdownText">
-            <h3>Форматированный Markdown</h3>
-            <pre>{{ selectedTask.markdownText }}</pre>
+          <section class="result-block">
+            <div class="section-header">
+              <h3>Форматированный Markdown</h3>
+              <div class="section-actions">
+                <button
+                  mat-stroked-button
+                  type="button"
+                  color="primary"
+                  (click)="downloadMarkdown()"
+                  [disabled]="!canDownloadMarkdown"
+                >
+                  <mat-icon>download</mat-icon>
+                  <span>Скачать .md</span>
+                </button>
+                <button
+                  mat-stroked-button
+                  type="button"
+                  color="accent"
+                  *ngIf="!markdownEditing"
+                  (click)="startMarkdownEditing()"
+                  [disabled]="!canEditMarkdown"
+                >
+                  <mat-icon>edit</mat-icon>
+                  <span>Редактировать</span>
+                </button>
+                <button
+                  mat-stroked-button
+                  type="button"
+                  color="warn"
+                  (click)="deleteTask()"
+                  [disabled]="!canDeleteTask"
+                >
+                  <mat-icon>delete</mat-icon>
+                  <span>{{ deleteInProgress ? 'Удаление…' : 'Удалить' }}</span>
+                </button>
+              </div>
+            </div>
+
+            <div class="markdown-editor" *ngIf="markdownEditing; else markdownPreview">
+              <md-editor
+                name="markdownEditor"
+                [(ngModel)]="markdownDraft"
+                preview="vertical"
+                height="'100%'"
+                [options]="markdownEditorOptions"
+              ></md-editor>
+              <div class="editor-actions">
+                <button
+                  mat-raised-button
+                  type="button"
+                  color="accent"
+                  (click)="saveMarkdown()"
+                  [disabled]="!canSaveMarkdown"
+                >
+                  <mat-icon>save</mat-icon>
+                  <span>Сохранить</span>
+                </button>
+                <button
+                  mat-button
+                  type="button"
+                  (click)="cancelMarkdownEditing()"
+                  [disabled]="markdownSaving"
+                >
+                  <mat-icon>close</mat-icon>
+                  <span>Отмена</span>
+                </button>
+                <mat-progress-spinner
+                  *ngIf="markdownSaving"
+                  class="inline-spinner"
+                  mode="indeterminate"
+                  diameter="28"
+                ></mat-progress-spinner>
+              </div>
+            </div>
+
+            <ng-template #markdownPreview>
+              <pre *ngIf="selectedTask.markdownText; else emptyMarkdown">{{ selectedTask.markdownText }}</pre>
+              <ng-template #emptyMarkdown>
+                <p class="markdown-placeholder">Markdown ещё не сформирован.</p>
+              </ng-template>
+            </ng-template>
+
+            <div class="error" *ngIf="markdownError">{{ markdownError }}</div>
           </section>
         </ng-container>
       </ng-template>

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -81,11 +81,19 @@ export class OpenAiTranscriptionService {
     return this.http.get<OpenAiTranscriptionTaskDetailsDto>(`${this.apiUrl}/${id}`);
   }
 
-  updateRecognizedText(id: string, recognizedText: string, markdownText?: string | null): Observable<void> {
+  updateRecognizedText(
+    id: string,
+    recognizedText?: string | null,
+    markdownText?: string | null,
+  ): Observable<void> {
     return this.http.put<void>(`${this.apiUrl}/${id}/recognized-text`, {
-      recognizedText,
-      markdownText,
+      recognizedText: recognizedText ?? null,
+      markdownText: markdownText ?? null,
     });
+  }
+
+  deleteTask(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
   }
 
   getStatusText(status: OpenAiTranscriptionStatus | null | undefined): string {


### PR DESCRIPTION
## Summary
- allow OpenAI transcription tasks to be deleted via a new API endpoint that also cleans up stored files
- extend the transcriptions dashboard with an inline markdown editor, export, and delete controls mirroring the standalone editor page
- update the Angular transcription service and styles to support optional markdown saves and improved layout for the new actions

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68d4b359953c8331af3938a18fcc798f