### PR TITLE
feat: move transcription markdown editing to dedicated page

### DIFF
--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -4,12 +4,14 @@ import { YoutubeDownloaderComponent } from './youtube-downloader/youtube-downloa
 import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
 import { OpenAiTranscriptionEditorComponent } from './openai-transcription-editor/openai-transcription-editor.component';
+import { OpenAiTranscriptionMarkdownEditorComponent } from './openai-transcription-markdown-editor/openai-transcription-markdown-editor.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
   { path: 'transcriptions/:id/edit', component: OpenAiTranscriptionEditorComponent },
+  { path: 'transcriptions/:id/markdown', component: OpenAiTranscriptionMarkdownEditorComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
 ];
 

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -5,12 +5,14 @@ import { SubtitlesTasksComponent } from './subtitles-task/subtitles-tasks.compon
 import { MarkdownConverterComponent } from './Markdown-converter/markdown-converter.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
 import { OpenAiTranscriptionEditorComponent } from './openai-transcription-editor/openai-transcription-editor.component';
+import { OpenAiTranscriptionMarkdownEditorComponent } from './openai-transcription-markdown-editor/openai-transcription-markdown-editor.component';
 
 export const appRoutes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: SubtitlesTasksComponent },
   { path: 'transcriptions/:id/edit', component: OpenAiTranscriptionEditorComponent },
+  { path: 'transcriptions/:id/markdown', component: OpenAiTranscriptionMarkdownEditorComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
 

--- a/Angular/youtube-downloader/src/app/openai-transcription-markdown-editor/openai-transcription-markdown-editor.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription-markdown-editor/openai-transcription-markdown-editor.component.css
@@ -1,0 +1,74 @@
+:host {
+  display: block;
+  height: calc(100vh - 64px);
+}
+
+.editor-page {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 16px;
+  height: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.page-header button[mat-button] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.title-block {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title-block h1 {
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.3;
+}
+
+.subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.editor-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.editor-card md-editor {
+  flex: 1;
+  min-height: 0;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.state-card {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.state-card.error {
+  color: #c62828;
+}

--- a/Angular/youtube-downloader/src/app/openai-transcription-markdown-editor/openai-transcription-markdown-editor.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription-markdown-editor/openai-transcription-markdown-editor.component.html
@@ -1,0 +1,98 @@
+<div class="editor-page">
+  <ng-container *ngIf="!loading && !errorMessage; else loadingOrError">
+    <div class="page-header">
+      <button mat-button type="button" (click)="goBack()">
+        <mat-icon>arrow_back</mat-icon>
+        К списку расшифровок
+      </button>
+
+      <div class="title-block">
+        <h1>{{ task?.displayName || 'Расшифровка' }}</h1>
+        <p class="subtitle" *ngIf="task?.modifiedAt">
+          Обновлено: {{ task?.modifiedAt | date: 'dd.MM.yyyy HH:mm' }}
+        </p>
+      </div>
+
+      <button
+        mat-icon-button
+        type="button"
+        (click)="refresh()"
+        [disabled]="loading || reloading"
+        aria-label="Обновить"
+      >
+        <mat-progress-spinner
+          *ngIf="reloading"
+          diameter="20"
+          mode="indeterminate"
+        ></mat-progress-spinner>
+        <mat-icon *ngIf="!reloading">refresh</mat-icon>
+      </button>
+    </div>
+
+    <mat-card class="editor-card">
+      <md-editor
+        name="markdownEditor"
+        [(ngModel)]="markdownContent"
+        preview="vertical"
+        height="'100%'"
+        [options]="editorOptions"
+      ></md-editor>
+    </mat-card>
+
+    <div class="actions">
+      <button
+        mat-raised-button
+        type="button"
+        color="primary"
+        (click)="downloadMarkdown()"
+        [disabled]="!canDownloadMarkdown"
+      >
+        <mat-icon>download</mat-icon>
+        Скачать .md
+      </button>
+      <button
+        mat-raised-button
+        type="button"
+        (click)="downloadRecognized()"
+        [disabled]="!task?.recognizedText"
+      >
+        <mat-icon>description</mat-icon>
+        Скачать .txt
+      </button>
+      <button
+        mat-raised-button
+        type="button"
+        color="accent"
+        (click)="save()"
+        [disabled]="!canSave"
+      >
+        <mat-icon>save</mat-icon>
+        Сохранить
+      </button>
+      <button
+        mat-stroked-button
+        color="warn"
+        type="button"
+        (click)="deleteTask()"
+        [disabled]="deleting"
+      >
+        <mat-icon>delete</mat-icon>
+        {{ deleting ? 'Удаление…' : 'Удалить' }}
+      </button>
+    </div>
+  </ng-container>
+
+  <ng-template #loadingOrError>
+    <div class="state-card" *ngIf="loading">
+      <mat-progress-spinner diameter="48" mode="indeterminate"></mat-progress-spinner>
+      <p>Загружаем расшифровку…</p>
+    </div>
+    <div class="state-card error" *ngIf="!loading && errorMessage">
+      <p>{{ errorMessage }}</p>
+      <button mat-stroked-button type="button" color="primary" (click)="refresh()">
+        <mat-icon>refresh</mat-icon>
+        Повторить
+      </button>
+    </div>
+  </ng-template>
+</div>

--- a/Angular/youtube-downloader/src/app/openai-transcription-markdown-editor/openai-transcription-markdown-editor.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription-markdown-editor/openai-transcription-markdown-editor.component.ts
@@ -1,0 +1,252 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { LMarkdownEditorModule } from 'ngx-markdown-editor';
+
+import {
+  OpenAiTranscriptionService,
+  OpenAiTranscriptionTaskDetailsDto,
+} from '../services/openai-transcription.service';
+
+@Component({
+  selector: 'app-openai-transcription-markdown-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    LMarkdownEditorModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './openai-transcription-markdown-editor.component.html',
+  styleUrls: ['./openai-transcription-markdown-editor.component.css'],
+})
+export class OpenAiTranscriptionMarkdownEditorComponent implements OnInit, OnDestroy {
+  taskId!: string;
+  task: OpenAiTranscriptionTaskDetailsDto | null = null;
+  markdownContent = '';
+
+  loading = true;
+  saving = false;
+  reloading = false;
+  deleting = false;
+  errorMessage: string | null = null;
+
+  editorOptions = {
+    placeholder: 'Отредактируйте итоговый Markdown…',
+    theme: 'github',
+    lineNumbers: true,
+    dragDrop: true,
+    showPreviewPanel: true,
+    hideIcons: [] as string[],
+  };
+
+  private paramSubscription?: Subscription;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly title: Title,
+    private readonly transcriptionService: OpenAiTranscriptionService,
+    private readonly snackBar: MatSnackBar,
+  ) {}
+
+  ngOnInit(): void {
+    this.paramSubscription = this.route.paramMap.subscribe((params) => {
+      const id = params.get('id');
+      if (!id) {
+        this.errorMessage = 'Не указан идентификатор задачи.';
+        this.loading = false;
+        return;
+      }
+
+      if (this.taskId === id) {
+        return;
+      }
+
+      this.taskId = id;
+      this.loadTask();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.paramSubscription?.unsubscribe();
+  }
+
+  get canSave(): boolean {
+    return !this.saving && !!this.taskId && this.markdownContent.trim().length > 0;
+  }
+
+  get canDownloadMarkdown(): boolean {
+    return this.markdownContent.trim().length > 0;
+  }
+
+  loadTask(showSpinner = true): void {
+    if (!this.taskId) {
+      return;
+    }
+
+    if (showSpinner) {
+      this.loading = true;
+    }
+    this.errorMessage = null;
+
+    this.transcriptionService.getTask(this.taskId).subscribe({
+      next: (task) => {
+        this.task = task;
+        this.markdownContent = task.markdownText ?? '';
+        this.loading = false;
+        this.reloading = false;
+        this.title.setTitle(`Редактирование Markdown: ${task.displayName}`);
+      },
+      error: (error) => {
+        this.loading = false;
+        this.reloading = false;
+        this.errorMessage = this.extractError(error) ?? 'Не удалось загрузить данные о задаче.';
+        this.title.setTitle('Ошибка загрузки Markdown');
+      },
+    });
+  }
+
+  refresh(): void {
+    if (this.loading || !this.taskId) {
+      return;
+    }
+
+    this.reloading = true;
+    this.loadTask(false);
+  }
+
+  goBack(): void {
+    this.router.navigate(['/transcriptions']);
+  }
+
+  downloadMarkdown(): void {
+    if (!this.canDownloadMarkdown) {
+      return;
+    }
+
+    const blob = new Blob([this.markdownContent], { type: 'text/markdown;charset=utf-8' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const fileName = this.task?.displayName || this.taskId || 'transcription-markdown';
+    a.download = `${fileName}.md`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  downloadRecognized(): void {
+    if (!this.task?.recognizedText) {
+      return;
+    }
+
+    const blob = new Blob([this.task.recognizedText], { type: 'text/plain;charset=utf-8' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const fileName = this.task.displayName || this.taskId || 'transcription';
+    a.download = `${fileName}.txt`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  save(): void {
+    if (!this.canSave) {
+      return;
+    }
+
+    this.saving = true;
+
+    const recognizedText = this.task?.recognizedText ?? null;
+
+    this.transcriptionService
+      .updateRecognizedText(this.taskId, recognizedText, this.markdownContent)
+      .subscribe({
+        next: () => {
+          this.saving = false;
+          this.snackBar.open('Markdown сохранён', '', { duration: 2000 });
+          if (this.task) {
+            this.task = {
+              ...this.task,
+              markdownText: this.markdownContent,
+              modifiedAt: new Date().toISOString(),
+            };
+          }
+        },
+        error: (error) => {
+          this.saving = false;
+          const message = this.extractError(error) ?? 'Не удалось сохранить Markdown.';
+          this.snackBar.open(message, 'OK', { duration: 3000 });
+        },
+      });
+  }
+
+  deleteTask(): void {
+    if (!this.taskId || this.deleting) {
+      return;
+    }
+
+    const displayName = this.task?.displayName;
+    const confirmed = confirm(
+      displayName ? `Удалить расшифровку «${displayName}»?` : 'Удалить расшифровку?'
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    this.deleting = true;
+
+    this.transcriptionService.deleteTask(this.taskId).subscribe({
+      next: () => {
+        this.deleting = false;
+        this.snackBar.open('Расшифровка удалена', '', { duration: 2000 });
+        this.router.navigate(['/transcriptions']);
+      },
+      error: (error) => {
+        this.deleting = false;
+        const message = this.extractError(error) ?? 'Не удалось удалить расшифровку.';
+        this.snackBar.open(message, 'OK', { duration: 3000 });
+      },
+    });
+  }
+
+  private extractError(error: unknown): string | null {
+    if (!error) {
+      return null;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      const anyError = error as { error?: unknown; message?: string };
+      if (anyError.error) {
+        if (typeof anyError.error === 'string') {
+          return anyError.error;
+        }
+        if (typeof anyError.error === 'object') {
+          const nested = anyError.error as { message?: string; title?: string };
+          return nested.message || nested.title || null;
+        }
+      }
+      return anyError.message ?? null;
+    }
+
+    return null;
+  }
+}

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -216,24 +216,6 @@
   flex-wrap: wrap;
 }
 
-.markdown-editor {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.markdown-editor md-editor {
-  min-height: 320px;
-}
-
-.editor-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
 .markdown-placeholder {
   margin: 0;
   color: rgba(0, 0, 0, 0.6);

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -144,17 +144,15 @@
                   <mat-icon>download</mat-icon>
                   <span>Скачать .md</span>
                 </button>
-                <button
+                <a
                   mat-stroked-button
-                  type="button"
                   color="accent"
-                  *ngIf="!markdownEditing"
-                  (click)="startMarkdownEditing()"
-                  [disabled]="!canEditMarkdown"
+                  *ngIf="selectedTask?.done"
+                  [routerLink]="['/transcriptions', selectedTask.id, 'markdown']"
                 >
                   <mat-icon>edit</mat-icon>
                   <span>Редактировать</span>
-                </button>
+                </a>
                 <button
                   mat-stroked-button
                   type="button"
@@ -168,51 +166,12 @@
               </div>
             </div>
 
-            <div class="markdown-editor" *ngIf="markdownEditing; else markdownPreview">
-              <md-editor
-                name="markdownEditor"
-                [(ngModel)]="markdownDraft"
-                preview="vertical"
-                height="'100%'"
-                [options]="markdownEditorOptions"
-              ></md-editor>
-              <div class="editor-actions">
-                <button
-                  mat-raised-button
-                  type="button"
-                  color="accent"
-                  (click)="saveMarkdown()"
-                  [disabled]="!canSaveMarkdown"
-                >
-                  <mat-icon>save</mat-icon>
-                  <span>Сохранить</span>
-                </button>
-                <button
-                  mat-button
-                  type="button"
-                  (click)="cancelMarkdownEditing()"
-                  [disabled]="markdownSaving"
-                >
-                  <mat-icon>close</mat-icon>
-                  <span>Отмена</span>
-                </button>
-                <mat-progress-spinner
-                  *ngIf="markdownSaving"
-                  class="inline-spinner"
-                  mode="indeterminate"
-                  diameter="28"
-                ></mat-progress-spinner>
-              </div>
-            </div>
-
-            <ng-template #markdownPreview>
-              <pre *ngIf="selectedTask.markdownText; else emptyMarkdown">{{ selectedTask.markdownText }}</pre>
-              <ng-template #emptyMarkdown>
-                <p class="markdown-placeholder">Markdown ещё не сформирован.</p>
-              </ng-template>
+            <pre *ngIf="selectedTask.markdownText; else emptyMarkdown">{{ selectedTask.markdownText }}</pre>
+            <ng-template #emptyMarkdown>
+              <p class="markdown-placeholder">Markdown ещё не сформирован.</p>
             </ng-template>
 
-            <div class="error" *ngIf="markdownError">{{ markdownError }}</div>
+            <div class="error" *ngIf="taskActionError">{{ taskActionError }}</div>
           </section>
         </ng-container>
       </ng-template>


### PR DESCRIPTION
## Summary
- remove inline markdown editing from the /transcriptions overview and link to a dedicated editor route
- add a new OpenAI transcription markdown editor page with download, save, and delete actions
- register the new page in the router and keep markdown export available from the task list

## Testing
- npm run build -- --configuration development --progress false

------
https://chatgpt.com/codex/tasks/task_e_68d4b72c17c08331947181bf575d06ce