### PR TITLE
Add transcription editor with export and backend endpoints

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -183,6 +183,12 @@
   overflow: auto;
 }
 
+.result-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
 .tasks-card a.active {
   background: rgba(63, 81, 181, 0.08);
 }

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -121,6 +121,16 @@
 
           <section class="result-block" *ngIf="selectedTask.markdownText">
             <h3>Форматированный Markdown</h3>
+            <div class="result-actions">
+              <button
+                mat-stroked-button
+                color="primary"
+                [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
+              >
+                <mat-icon>edit</mat-icon>
+                <span>Редактировать</span>
+              </button>
+            </div>
             <pre>{{ selectedTask.markdownText }}</pre>
           </section>
         </ng-container>

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -6,6 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { RouterModule } from '@angular/router';
 import { Subscription, timer } from 'rxjs';
 import { exhaustMap } from 'rxjs/operators';
 import {
@@ -30,6 +31,7 @@ import { LocalTimePipe } from '../pipe/local-time.pipe';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     LocalTimePipe,
+    RouterModule,
   ],
   templateUrl: './openai-transcription.component.html',
   styleUrls: ['./openai-transcription.component.css'],

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -81,6 +81,26 @@ export class OpenAiTranscriptionService {
     return this.http.get<OpenAiTranscriptionTaskDetailsDto>(`${this.apiUrl}/${id}`);
   }
 
+  updateMarkdown(id: string, markdown: string): Observable<void> {
+    return this.http.put<void>(`${this.apiUrl}/${id}/markdown`, { markdown });
+  }
+
+  deleteTask(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+
+  exportPdf(id: string): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/${id}/export/pdf`, { responseType: 'blob' });
+  }
+
+  exportDocx(id: string): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/${id}/export/docx`, { responseType: 'blob' });
+  }
+
+  exportBbcode(id: string): Observable<string> {
+    return this.http.get(`${this.apiUrl}/${id}/export/bbcode`, { responseType: 'text' });
+  }
+
   getStatusText(status: OpenAiTranscriptionStatus | null | undefined): string {
     switch (status) {
       case OpenAiTranscriptionStatus.Created:

--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.css
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.css
@@ -1,0 +1,54 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 64px);
+  overflow: hidden;
+}
+
+.page-container {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  overflow: hidden;
+}
+
+.editor-card {
+  grid-row: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.editor-card md-editor {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.actions {
+  grid-row: 2;
+  padding: 16px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  background: #fff;
+  border-top: 1px solid #ececec;
+}
+
+.actions .spacer {
+  flex: 1 1 auto;
+}
+
+.status-block {
+  height: 100%;
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.status-block.error {
+  color: #c62828;
+}

--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
@@ -1,0 +1,87 @@
+<div class="page-container" *ngIf="!loading && !errorMessage; else loadingOrError">
+  <mat-card class="editor-card">
+    <md-editor
+      name="transcriptionEditor"
+      [(ngModel)]="markdownContent"
+      preview="vertical"
+      height="'100%'"
+      [options]="editorOptions"
+      [preRender]="renderWithMath"
+    >
+    </md-editor>
+  </mat-card>
+
+  <div class="actions">
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="onDownloadMd()"
+      [disabled]="!hasContent() || exporting"
+    >
+      <mat-icon>download</mat-icon>
+      Скачать .md
+    </button>
+
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="onDownloadPdf()"
+      [disabled]="!hasContent() || exporting"
+    >
+      <mat-icon>picture_as_pdf</mat-icon>
+      PDF
+    </button>
+
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="onDownloadDocx()"
+      [disabled]="!hasContent() || exporting"
+    >
+      <mat-icon>description</mat-icon>
+      DOCX
+    </button>
+
+    <button
+      mat-stroked-button
+      color="primary"
+      (click)="onCopyBbcode()"
+      [disabled]="!hasContent() || exporting"
+    >
+      <mat-icon>content_copy</mat-icon>
+      BBCode
+    </button>
+
+    <span class="spacer"></span>
+
+    <button
+      mat-raised-button
+      color="accent"
+      (click)="onSave()"
+      [disabled]="!hasContent() || saving"
+    >
+      <mat-icon>save</mat-icon>
+      Сохранить
+    </button>
+
+    <button
+      mat-raised-button
+      color="warn"
+      (click)="onDelete()"
+      [disabled]="deleting"
+    >
+      <mat-icon>delete</mat-icon>
+      Удалить
+    </button>
+  </div>
+</div>
+
+<ng-template #loadingOrError>
+  <div class="status-block" *ngIf="loading">
+    <mat-progress-spinner mode="indeterminate" diameter="40"></mat-progress-spinner>
+    <p>Загружаем данные…</p>
+  </div>
+  <div class="status-block error" *ngIf="!loading && errorMessage">
+    <p>{{ errorMessage }}</p>
+  </div>
+</ng-template>

--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.ts
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.ts
@@ -1,0 +1,264 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { LMarkdownEditorModule } from 'ngx-markdown-editor';
+import {
+  OpenAiTranscriptionService,
+  OpenAiTranscriptionTaskDetailsDto
+} from '../services/openai-transcription.service';
+import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
+
+@Component({
+  selector: 'app-transcription-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    LMarkdownEditorModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './transcription-editor.component.html',
+  styleUrls: ['./transcription-editor.component.css']
+})
+export class TranscriptionEditorComponent implements OnInit {
+  taskId!: string;
+  task: OpenAiTranscriptionTaskDetailsDto | null = null;
+  markdownContent = '';
+  loading = true;
+  errorMessage: string | null = null;
+  saving = false;
+  deleting = false;
+  exporting = false;
+
+  editorOptions = {
+    placeholder: 'Пишите Markdown и LaTeX: $…$ или $$…$$',
+    katex: true,
+    theme: 'github',
+    lineNumbers: true,
+    dragDrop: true,
+    showPreviewPanel: true,
+    hideIcons: []
+  };
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly titleService: Title,
+    private readonly transcriptionService: OpenAiTranscriptionService,
+    private readonly snackBar: MatSnackBar,
+    private readonly markdownRenderer: MarkdownRendererService1
+  ) {
+    this.renderWithMath = this.renderWithMath.bind(this);
+  }
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe(params => {
+      const id = params.get('id');
+      if (id) {
+        this.taskId = id;
+        this.loadTask();
+      }
+    });
+  }
+
+  renderWithMath(content: string): string {
+    return this.markdownRenderer.renderMath(content);
+  }
+
+  private loadTask(): void {
+    this.loading = true;
+    this.errorMessage = null;
+
+    this.transcriptionService.getTask(this.taskId).subscribe({
+      next: task => {
+        this.task = task;
+        this.markdownContent = task.markdownText || task.processedText || task.recognizedText || '';
+        this.loading = false;
+        this.titleService.setTitle(`Расшифровка: ${task.displayName || this.taskId}`);
+      },
+      error: error => {
+        this.loading = false;
+        this.errorMessage = this.extractError(error) ?? 'Не удалось загрузить задачу.';
+        this.titleService.setTitle('Ошибка загрузки');
+      }
+    });
+  }
+
+  onDownloadMd(): void {
+    if (!this.hasContent() || this.exporting) {
+      return;
+    }
+
+    const blob = new Blob([this.markdownContent], { type: 'text/markdown' });
+    this.triggerDownload(blob, `${this.getFileBaseName()}.md`);
+  }
+
+  onDownloadPdf(): void {
+    if (!this.hasContent() || this.exporting) {
+      return;
+    }
+
+    this.exporting = true;
+    this.transcriptionService.exportPdf(this.taskId).subscribe({
+      next: blob => {
+        this.triggerDownload(blob, `${this.getFileBaseName()}.pdf`);
+        this.exporting = false;
+      },
+      error: error => {
+        this.exporting = false;
+        this.handleActionError(error, 'Не удалось сформировать PDF файл.');
+      }
+    });
+  }
+
+  onDownloadDocx(): void {
+    if (!this.hasContent() || this.exporting) {
+      return;
+    }
+
+    this.exporting = true;
+    this.transcriptionService.exportDocx(this.taskId).subscribe({
+      next: blob => {
+        this.triggerDownload(blob, `${this.getFileBaseName()}.docx`);
+        this.exporting = false;
+      },
+      error: error => {
+        this.exporting = false;
+        this.handleActionError(error, 'Не удалось сформировать DOCX файл.');
+      }
+    });
+  }
+
+  onCopyBbcode(): void {
+    if (!this.hasContent() || this.exporting) {
+      return;
+    }
+
+    this.exporting = true;
+    this.transcriptionService.exportBbcode(this.taskId).subscribe({
+      next: text => {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          console.error('Clipboard API is not available');
+          this.snackBar.open('Буфер обмена недоступен в этом браузере', 'OK', { duration: 3000 });
+          this.exporting = false;
+          return;
+        }
+
+        navigator.clipboard.writeText(text).then(() => {
+          this.snackBar.open('BBCode скопирован в буфер обмена', '', { duration: 2000 });
+          this.exporting = false;
+        }).catch(err => {
+          console.error('Clipboard error', err);
+          this.snackBar.open('Не удалось скопировать в буфер обмена', 'OK', { duration: 3000 });
+          this.exporting = false;
+        });
+      },
+      error: error => {
+        this.exporting = false;
+        this.handleActionError(error, 'Не удалось подготовить BBCode.');
+      }
+    });
+  }
+
+  onSave(): void {
+    if (!this.hasContent() || this.saving) {
+      return;
+    }
+
+    this.saving = true;
+    this.transcriptionService.updateMarkdown(this.taskId, this.markdownContent).subscribe({
+      next: () => {
+        this.saving = false;
+        this.snackBar.open('Расшифровка сохранена', '', { duration: 2000 });
+      },
+      error: error => {
+        this.saving = false;
+        this.handleActionError(error, 'Ошибка при сохранении расшифровки.');
+      }
+    });
+  }
+
+  onDelete(): void {
+    if (this.deleting) {
+      return;
+    }
+
+    const confirmed = confirm('Удалить эту расшифровку?');
+    if (!confirmed) {
+      return;
+    }
+
+    this.deleting = true;
+    this.transcriptionService.deleteTask(this.taskId).subscribe({
+      next: () => {
+        this.deleting = false;
+        this.snackBar.open('Расшифровка удалена', '', { duration: 2000 });
+        this.router.navigate(['/transcriptions']);
+      },
+      error: error => {
+        this.deleting = false;
+        this.handleActionError(error, 'Не удалось удалить расшифровку.');
+      }
+    });
+  }
+
+  hasContent(): boolean {
+    return !!this.markdownContent && this.markdownContent.trim().length > 0;
+  }
+
+  private triggerDownload(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  private getFileBaseName(): string {
+    const candidate = this.task?.displayName?.trim() || this.task?.fileName?.trim() || this.taskId;
+    return candidate.replace(/[\\/:*?"<>|]+/g, '_');
+  }
+
+  private handleActionError(error: unknown, fallback: string): void {
+    const message = this.extractError(error) ?? fallback;
+    this.snackBar.open(message, 'OK', { duration: 3000 });
+  }
+
+  private extractError(error: unknown): string | null {
+    if (!error) {
+      return null;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (typeof error === 'object') {
+      const anyError = error as { error?: unknown; message?: string };
+      if (anyError.error) {
+        if (typeof anyError.error === 'string') {
+          return anyError.error;
+        }
+        if (typeof anyError.error === 'object') {
+          const nested = anyError.error as { message?: string; title?: string };
+          return nested.message || nested.title || null;
+        }
+      }
+      return anyError.message ?? null;
+    }
+
+    return null;
+  }
+}

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -31,6 +31,7 @@ import { RoleGuard } from './app/services/role.guard';
 import { ProfileComponent } from './app/profile/profile.component';
 import { AuthGuard } from './app/services/auth.guard';
 import { OpenAiTranscriptionComponent } from './app/openai-transcription/openai-transcription.component';
+import { TranscriptionEditorComponent } from './app/transcription-editor/transcription-editor.component';
 
 
 
@@ -56,6 +57,11 @@ const routes: Routes = [
   {
     path: 'transcriptions',
     component: OpenAiTranscriptionComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'transcriptions/:id/edit',
+    component: TranscriptionEditorComponent,
     canActivate: [AuthGuard],
   },
 

--- a/Controllers/OpenAiTranscriptionController.cs
+++ b/Controllers/OpenAiTranscriptionController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
@@ -28,19 +29,22 @@ namespace YandexSpeech.Controllers
         private readonly IWebHostEnvironment _environment;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<OpenAiTranscriptionController> _logger;
+        private readonly IDocumentGeneratorService _documentGeneratorService;
 
         public OpenAiTranscriptionController(
             IOpenAiTranscriptionService transcriptionService,
             MyDbContext dbContext,
             IWebHostEnvironment environment,
             IServiceScopeFactory scopeFactory,
-            ILogger<OpenAiTranscriptionController> logger)
+            ILogger<OpenAiTranscriptionController> logger,
+            IDocumentGeneratorService documentGeneratorService)
         {
             _transcriptionService = transcriptionService;
             _dbContext = dbContext;
             _environment = environment;
             _scopeFactory = scopeFactory;
             _logger = logger;
+            _documentGeneratorService = documentGeneratorService;
         }
 
         [HttpPost]
@@ -169,6 +173,142 @@ namespace YandexSpeech.Controllers
             });
 
             return Ok(MapToDetailsDto(preparedTask));
+        }
+
+        [HttpPut("{id}/markdown")]
+        public async Task<IActionResult> UpdateMarkdown(string id, [FromBody] UpdateMarkdownRequest request)
+        {
+            if (request == null || string.IsNullOrWhiteSpace(request.Markdown))
+            {
+                return BadRequest("Markdown must be provided.");
+            }
+
+            var userId = User.GetUserId();
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var task = await _dbContext.OpenAiTranscriptionTasks
+                .FirstOrDefaultAsync(t => t.Id == id && t.CreatedBy == userId);
+
+            if (task == null)
+            {
+                return NotFound();
+            }
+
+            task.MarkdownText = request.Markdown;
+            task.ModifiedAt = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(string id)
+        {
+            var userId = User.GetUserId();
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var task = await _dbContext.OpenAiTranscriptionTasks
+                .Include(t => t.Segments)
+                .Include(t => t.Steps)
+                .FirstOrDefaultAsync(t => t.Id == id && t.CreatedBy == userId);
+
+            if (task == null)
+            {
+                return NotFound();
+            }
+
+            if (!string.IsNullOrEmpty(task.SourceFilePath))
+            {
+                TryDeleteFile(task.SourceFilePath);
+            }
+
+            if (!string.IsNullOrEmpty(task.ConvertedFilePath))
+            {
+                TryDeleteFile(task.ConvertedFilePath);
+            }
+
+            if (task.Segments?.Any() == true)
+            {
+                _dbContext.OpenAiRecognizedSegments.RemoveRange(task.Segments);
+            }
+
+            if (task.Steps?.Any() == true)
+            {
+                _dbContext.OpenAiTranscriptionSteps.RemoveRange(task.Steps);
+            }
+
+            _dbContext.OpenAiTranscriptionTasks.Remove(task);
+            await _dbContext.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        [HttpGet("{id}/export/pdf")]
+        public async Task<IActionResult> ExportPdf(string id)
+        {
+            var taskResult = await LoadTaskForExportAsync(id);
+            if (taskResult.Result != null)
+            {
+                return taskResult.Result;
+            }
+
+            var entity = taskResult.Value!;
+            var filePath = await _documentGeneratorService.GeneratePdfFromMarkdownAsync(entity.Id, entity.MarkdownText!);
+            try
+            {
+                var bytes = await System.IO.File.ReadAllBytesAsync(filePath);
+                var fileName = CreateExportFileName(entity, "pdf");
+                return File(bytes, "application/pdf", fileName);
+            }
+            finally
+            {
+                TryDeleteFile(filePath);
+            }
+        }
+
+        [HttpGet("{id}/export/docx")]
+        public async Task<IActionResult> ExportDocx(string id)
+        {
+            var taskResult = await LoadTaskForExportAsync(id);
+            if (taskResult.Result != null)
+            {
+                return taskResult.Result;
+            }
+
+            var entity = taskResult.Value!;
+            var filePath = await _documentGeneratorService.GenerateWordFromMarkdownAsync(entity.Id, entity.MarkdownText!);
+            try
+            {
+                var bytes = await System.IO.File.ReadAllBytesAsync(filePath);
+                var fileName = CreateExportFileName(entity, "docx");
+                return File(bytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", fileName);
+            }
+            finally
+            {
+                TryDeleteFile(filePath);
+            }
+        }
+
+        [HttpGet("{id}/export/bbcode")]
+        public async Task<IActionResult> ExportBbcode(string id)
+        {
+            var taskResult = await LoadTaskForExportAsync(id);
+            if (taskResult.Result != null)
+            {
+                return taskResult.Result;
+            }
+
+            var entity = taskResult.Value!;
+            var bbcode = await _documentGeneratorService.GenerateBbcodeFromMarkdownAsync(entity.Id, entity.MarkdownText!);
+            var fileName = CreateExportFileName(entity, "bbcode");
+            var bytes = Encoding.UTF8.GetBytes(bbcode);
+            return File(bytes, "text/plain", fileName);
         }
 
         private async Task<OpenAiTranscriptionTask?> LoadTaskWithDetailsAsync(string taskId, string createdBy)
@@ -304,6 +444,70 @@ namespace YandexSpeech.Controllers
                 .ToList() ?? new List<OpenAiRecognizedSegmentDto>();
 
             return dto;
+        }
+
+        private void TryDeleteFile(string path)
+        {
+            try
+            {
+                if (System.IO.File.Exists(path))
+                {
+                    System.IO.File.Delete(path);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to delete file {FilePath} for transcription task", path);
+            }
+        }
+
+        private string CreateExportFileName(OpenAiTranscriptionTask task, string extension)
+        {
+            var displayName = ResolveDisplayName(task.SourceFilePath);
+            var baseName = Path.GetFileNameWithoutExtension(displayName);
+            if (string.IsNullOrWhiteSpace(baseName))
+            {
+                baseName = "transcription";
+            }
+
+            var fileName = $"{baseName}.{extension}";
+            var sanitized = SanitizeFileName(fileName);
+            if (!sanitized.EndsWith($".{extension}", StringComparison.OrdinalIgnoreCase))
+            {
+                sanitized = $"{sanitized}.{extension}";
+            }
+
+            return sanitized;
+        }
+
+        private async Task<ActionResult<OpenAiTranscriptionTask>> LoadTaskForExportAsync(string id)
+        {
+            var userId = User.GetUserId();
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Unauthorized();
+            }
+
+            var task = await _dbContext.OpenAiTranscriptionTasks
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.Id == id && t.CreatedBy == userId);
+
+            if (task == null)
+            {
+                return NotFound();
+            }
+
+            if (string.IsNullOrWhiteSpace(task.MarkdownText))
+            {
+                return BadRequest("Task does not contain formatted Markdown.");
+            }
+
+            return task;
+        }
+
+        public class UpdateMarkdownRequest
+        {
+            public string Markdown { get; set; } = string.Empty;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add REST endpoints for updating, deleting, and exporting transcription markdown
- create a dedicated Angular transcription editor page with markdown editing and export actions
- hook the transcription list UI to the editor, extend routing, and expose new service helpers

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68d4c114a4808331b67971493cf57048