### PR TITLE
Add configurable YooMoney repository service

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,6 +8,7 @@ using System.Text;
 using YandexSpeech;
 using YandexSpeech.models.DB;
 using YandexSpeech.services;
+using YandexSpeech.services.Interface;
 using YandexSpeech.Services;
 using YoutubeDownload.Managers;
 using YoutubeDownload.Services;
@@ -138,6 +139,9 @@ builder.Services.AddSingleton<CaptionService>();
 builder.Services.AddScoped<IYSpeechService, YSpeechService>();
 builder.Services.AddSingleton<IPunctuationService, PunctuationService>();
 builder.Services.AddScoped<ISpeechWorkflowService, SpeechWorkflowService>();
+
+builder.Services.Configure<YooMoneyOptions>(builder.Configuration.GetSection("YooMoney"));
+builder.Services.AddHttpClient<IYooMoneyRepository, YooMoneyRepository>();
 
 builder.Services.AddAudioTaskManager();  // ← вот эта строка
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -60,5 +60,11 @@
     "DefaultBucketName": "ruticker"
   },
 
+  "YooMoney": {
+    "ClientId": "your-client-id",
+    "AccessToken": "your-access-token",
+    "RedirectUri": "https://stockchart.ru/admin/yandexget"
+  },
+
   "AllowedHosts": "*"
 }

--- a/services/Interface/IYooMoneyRepository.cs
+++ b/services/Interface/IYooMoneyRepository.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace YandexSpeech.services.Interface
+{
+    public interface IYooMoneyRepository
+    {
+        Task<OperationDetails?> GetOperationDetailsAsync(string operationId, CancellationToken cancellationToken = default);
+
+        Task<IReadOnlyList<OperationHistory>?> GetOperationHistoryAsync(int from, int count, CancellationToken cancellationToken = default);
+
+        Task<string> AuthorizeAsync(CancellationToken cancellationToken = default);
+
+        Task<string> ExchangeTokenAsync(string code, CancellationToken cancellationToken = default);
+    }
+}

--- a/services/YooMoneyModels.cs
+++ b/services/YooMoneyModels.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace YandexSpeech.services
+{
+    public class OperationDetails
+    {
+        [JsonProperty("operation_id")]
+        public string? OperationId { get; set; }
+
+        [JsonProperty("title")]
+        public string? Title { get; set; }
+
+        [JsonProperty("amount"), JsonConverter(typeof(NullableDecimalConverter))]
+        public decimal? Amount { get; set; }
+
+        [JsonProperty("datetime")]
+        public DateTime? DateTime { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken>? AdditionalData { get; set; }
+    }
+
+    public class OperationHistory
+    {
+        [JsonProperty("operation_id")]
+        public string? OperationId { get; set; }
+
+        [JsonProperty("title")]
+        public string? Title { get; set; }
+
+        [JsonProperty("amount"), JsonConverter(typeof(NullableDecimalConverter))]
+        public decimal? Amount { get; set; }
+
+        [JsonProperty("datetime")]
+        public DateTime? DateTime { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken>? AdditionalData { get; set; }
+    }
+
+    public class OperationHistoryResponse
+    {
+        [JsonProperty("operations")]
+        public List<OperationHistory>? Operations { get; set; }
+    }
+
+    /// <summary>
+    /// Converter that handles decimal values represented as strings or numbers.
+    /// </summary>
+    internal sealed class NullableDecimalConverter : JsonConverter<decimal?>
+    {
+        public override decimal? ReadJson(JsonReader reader, Type objectType, decimal? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Integer)
+            {
+                return Convert.ToDecimal(reader.Value);
+            }
+
+            if (reader.TokenType == JsonToken.String)
+            {
+                var text = reader.Value?.ToString();
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    return null;
+                }
+
+                if (decimal.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+                {
+                    return result;
+                }
+            }
+
+            throw new JsonSerializationException($"Unable to convert value '{reader.Value}' to decimal.");
+        }
+
+        public override void WriteJson(JsonWriter writer, decimal? value, JsonSerializer serializer)
+        {
+            if (value.HasValue)
+            {
+                writer.WriteValue(value.Value);
+            }
+            else
+            {
+                writer.WriteNull();
+            }
+        }
+    }
+}

--- a/services/YooMoneyRepository.cs
+++ b/services/YooMoneyRepository.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using YandexSpeech.services.Interface;
+
+namespace YandexSpeech.services
+{
+    public class YooMoneyOptions
+    {
+        public string? ClientId { get; set; }
+
+        public string? AccessToken { get; set; }
+
+        public string? RedirectUri { get; set; }
+    }
+
+    public class YooMoneyRepository : IYooMoneyRepository
+    {
+        private static readonly Uri BaseUri = new("https://yoomoney.ru/");
+
+        private readonly HttpClient httpClient;
+        private readonly YooMoneyOptions options;
+
+        public YooMoneyRepository(HttpClient httpClient, IOptions<YooMoneyOptions> optionsAccessor)
+        {
+            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            ArgumentNullException.ThrowIfNull(optionsAccessor);
+
+            options = optionsAccessor.Value ?? throw new InvalidOperationException("YooMoney options are not configured.");
+            var clientId = EnsureConfigured(options.ClientId, nameof(options.ClientId));
+            var accessToken = EnsureConfigured(options.AccessToken, nameof(options.AccessToken));
+            var redirectUri = EnsureConfigured(options.RedirectUri, nameof(options.RedirectUri));
+
+            // ensure http client configured once
+            if (httpClient.BaseAddress == null)
+            {
+                httpClient.BaseAddress = BaseUri;
+            }
+
+            // store validated values
+            options.ClientId = clientId;
+            options.AccessToken = accessToken;
+            options.RedirectUri = redirectUri;
+        }
+
+        public async Task<OperationDetails?> GetOperationDetailsAsync(string operationId, CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(operationId);
+
+            var responseJson = await PostAsync("api/operation-details",
+                new[] { new KeyValuePair<string, string>("operation_id", operationId) },
+                includeToken: true,
+                cancellationToken).ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<OperationDetails>(responseJson);
+        }
+
+        public async Task<IReadOnlyList<OperationHistory>?> GetOperationHistoryAsync(int from, int count, CancellationToken cancellationToken = default)
+        {
+            if (from < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(from));
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            var responseJson = await PostAsync("api/operation-history",
+                new[]
+                {
+                    new KeyValuePair<string, string>("records", count.ToString()),
+                    new KeyValuePair<string, string>("start_record", from.ToString())
+                },
+                includeToken: true,
+                cancellationToken).ConfigureAwait(false);
+
+            var response = JsonConvert.DeserializeObject<OperationHistoryResponse>(responseJson);
+            return response?.Operations;
+        }
+
+        public Task<string> AuthorizeAsync(CancellationToken cancellationToken = default)
+        {
+            var payload = new[]
+            {
+                new KeyValuePair<string, string>("client_id", options.ClientId!),
+                new KeyValuePair<string, string>("response_type", "code"),
+                new KeyValuePair<string, string>("redirect_uri", options.RedirectUri!),
+                new KeyValuePair<string, string>("scope", "account-info operation-history operation-details"),
+            };
+
+            return PostAsync("oauth/authorize", payload, includeToken: false, cancellationToken);
+        }
+
+        public Task<string> ExchangeTokenAsync(string code, CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(code);
+
+            var payload = new[]
+            {
+                new KeyValuePair<string, string>("code", code),
+                new KeyValuePair<string, string>("client_id", options.ClientId!),
+                new KeyValuePair<string, string>("grant_type", "authorization_code"),
+                new KeyValuePair<string, string>("redirect_uri", options.RedirectUri!),
+            };
+
+            return PostAsync("oauth/authorize", payload, includeToken: false, cancellationToken);
+        }
+
+        private async Task<string> PostAsync(string endpoint, IEnumerable<KeyValuePair<string, string>> payload, bool includeToken, CancellationToken cancellationToken)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+            {
+                Content = new FormUrlEncodedContent(payload)
+            };
+
+            if (includeToken)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", options.AccessToken);
+            }
+
+            using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private static string EnsureConfigured(string? value, string name)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"Configuration value 'YooMoney:{name}' is missing or empty.");
+            }
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a YooMoney repository implementation that reads credentials from configuration and uses HttpClient
- introduce supporting interface and models and register the repository through dependency injection
- extend appsettings with a YooMoney section for client, token, and redirect values

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e494e9348331b10267d97d69299e