### PR TITLE
Refactor Whisper transcription into pluggable services

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -9,6 +9,7 @@ using YandexSpeech;
 using YandexSpeech.models.DB;
 using YandexSpeech.services;
 using YandexSpeech.services.Interface;
+using YandexSpeech.services.Whisper;
 using YandexSpeech.Services;
 using YoutubeDownload.Managers;
 using YoutubeDownload.Services;
@@ -130,6 +131,18 @@ builder.Services.AddAuthentication(o =>
 
 builder.Services.AddScoped<IAudioFileService, AudioFileService>();
 builder.Services.AddScoped<ISpeechWorkflowService, SpeechWorkflowService>();
+
+var whisperProvider = builder.Configuration.GetValue<string>("Whisper:Provider");
+if (string.Equals(whisperProvider, "faster", StringComparison.OrdinalIgnoreCase)
+    || string.Equals(whisperProvider, "faster-whisper", StringComparison.OrdinalIgnoreCase))
+{
+    builder.Services.AddScoped<IWhisperTranscriptionService, FasterWhisperTranscriptionService>();
+}
+else
+{
+    builder.Services.AddScoped<IWhisperTranscriptionService, WhisperCliTranscriptionService>();
+}
+
 builder.Services.AddScoped<IOpenAiTranscriptionService, OpenAiTranscriptionService>();
 
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -14,7 +14,15 @@
   "Whisper": {
     "ExecutablePath": "whisper",
     "Model": "medium",
-    "UseGpu": true
+    "UseGpu": true,
+    "Provider": "whisper"
+  },
+
+  "FasterWhisper": {
+    "ExecutablePath": "faster-whisper",
+    "Model": "medium",
+    "Device": "cuda",
+    "ComputeType": "float16"
   },
 
   "FfmpegExePath": "C:\\Documents and Settings\\user\\AppData\\Local\\Programs\\FFmpeg\\bin\\",

--- a/services/Interface/IWhisperTranscriptionService.cs
+++ b/services/Interface/IWhisperTranscriptionService.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+using YandexSpeech.services.Whisper;
+
+namespace YandexSpeech.services
+{
+    public interface IWhisperTranscriptionService
+    {
+        Task<WhisperTranscriptionResult> TranscribeAsync(
+            string audioFilePath,
+            string workingDirectory,
+            string? ffmpegExecutable,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/services/Models/WhisperTranscriptionModels.cs
+++ b/services/Models/WhisperTranscriptionModels.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace YandexSpeech.services.Whisper
+{
+    public sealed class WhisperTranscriptionResult
+    {
+        public string TimecodedText { get; init; } = string.Empty;
+        public string RawJson { get; init; } = string.Empty;
+    }
+
+    internal sealed class WhisperTranscriptionResponse
+    {
+        [JsonPropertyName("segments")]
+        public List<WhisperSegment> Segments { get; set; } = new();
+    }
+
+    internal sealed class WhisperSegment
+    {
+        [JsonPropertyName("start")]
+        public double Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public double End { get; set; }
+
+        [JsonPropertyName("text")]
+        public string? Text { get; set; }
+
+        [JsonPropertyName("words")]
+        public List<WhisperWord>? Words { get; set; }
+    }
+
+    internal sealed class WhisperWord
+    {
+        [JsonPropertyName("word")]
+        public string? Word { get; set; }
+
+        [JsonPropertyName("start")]
+        public double? Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public double? End { get; set; }
+    }
+}

--- a/services/Whisper/FasterWhisperTranscriptionService.cs
+++ b/services/Whisper/FasterWhisperTranscriptionService.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace YandexSpeech.services.Whisper
+{
+    public sealed class FasterWhisperTranscriptionService : IWhisperTranscriptionService
+    {
+        private readonly ILogger<FasterWhisperTranscriptionService> _logger;
+        private readonly string _executableSetting;
+        private readonly string _model;
+        private readonly string _device;
+        private readonly string _computeType;
+
+        public FasterWhisperTranscriptionService(
+            IConfiguration configuration,
+            ILogger<FasterWhisperTranscriptionService> logger)
+        {
+            _logger = logger;
+
+            var section = configuration.GetSection("FasterWhisper");
+            _executableSetting = section.GetValue<string>("ExecutablePath") ?? "faster-whisper";
+            _model = section.GetValue<string>("Model") ?? configuration.GetValue<string>("Whisper:Model") ?? "medium";
+            _device = section.GetValue<string>("Device") ?? configuration.GetValue<string>("Whisper:Device") ?? "cpu";
+            _computeType = section.GetValue<string>("ComputeType") ?? "int8";
+        }
+
+        public async Task<WhisperTranscriptionResult> TranscribeAsync(
+            string audioFilePath,
+            string workingDirectory,
+            string? ffmpegExecutable,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(audioFilePath))
+                throw new ArgumentException("Audio file path must be provided.", nameof(audioFilePath));
+
+            var audioPath = Path.GetFullPath(audioFilePath);
+            if (!File.Exists(audioPath))
+                throw new FileNotFoundException("Audio file not found for Whisper transcription.", audioPath);
+
+            if (string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                workingDirectory = Path.Combine(Path.GetTempPath(), "openai-transcriptions");
+            }
+
+            Directory.CreateDirectory(workingDirectory);
+
+            var outputDirectory = Path.Combine(workingDirectory, $"faster-whisper-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(outputDirectory);
+
+            var startInfo = BuildProcessStartInfo(audioPath, outputDirectory, ffmpegExecutable);
+
+            using var process = new Process { StartInfo = startInfo };
+
+            try
+            {
+                process.Start();
+
+                var standardErrorTask = process.StandardError.ReadToEndAsync();
+                var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+
+                await process.WaitForExitAsync(cancellationToken);
+                await Task.WhenAll(standardErrorTask, standardOutputTask);
+
+                var standardError = await standardErrorTask;
+                var standardOutput = await standardOutputTask;
+
+                if (process.ExitCode != 0)
+                {
+                    throw new InvalidOperationException($"FasterWhisper transcription failed (exit code {process.ExitCode}): {standardError}\n{standardOutput}");
+                }
+
+                var transcriptFile = WhisperTranscriptionHelper.FindFirstJsonFile(outputDirectory);
+                if (transcriptFile == null)
+                {
+                    throw new InvalidOperationException($"FasterWhisper transcription did not produce a JSON file. Output: {standardOutput} Error: {standardError}");
+                }
+
+                var transcription = await File.ReadAllTextAsync(transcriptFile, cancellationToken);
+                if (string.IsNullOrWhiteSpace(transcription))
+                    throw new InvalidOperationException("FasterWhisper transcription result is empty.");
+
+                var parsed = WhisperTranscriptionHelper.Parse(transcription);
+                if (parsed?.Segments == null || parsed.Segments.Count == 0)
+                    throw new InvalidOperationException("FasterWhisper transcription does not contain segments.");
+
+                var timecodedText = WhisperTranscriptionHelper.BuildTimecodedText(parsed);
+
+                return new WhisperTranscriptionResult
+                {
+                    TimecodedText = timecodedText,
+                    RawJson = transcription
+                };
+            }
+            finally
+            {
+                CleanupDirectory(outputDirectory);
+            }
+        }
+
+        private ProcessStartInfo BuildProcessStartInfo(string audioPath, string outputDirectory, string? ffmpegExecutable)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = ResolveExecutable(),
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true,
+            };
+
+            EnsureEnvironmentEncoding(startInfo);
+            ConfigureFfmpegEnvironment(startInfo, ffmpegExecutable);
+
+            startInfo.ArgumentList.Add(audioPath);
+            startInfo.ArgumentList.Add("--model");
+            startInfo.ArgumentList.Add(_model);
+            startInfo.ArgumentList.Add("--device");
+            startInfo.ArgumentList.Add(_device);
+            startInfo.ArgumentList.Add("--compute_type");
+            startInfo.ArgumentList.Add(_computeType);
+            startInfo.ArgumentList.Add("--output_dir");
+            startInfo.ArgumentList.Add(outputDirectory);
+            startInfo.ArgumentList.Add("--output_format");
+            startInfo.ArgumentList.Add("json");
+            startInfo.ArgumentList.Add("--word_timestamps");
+            startInfo.ArgumentList.Add("True");
+
+            return startInfo;
+        }
+
+        private string ResolveExecutable()
+        {
+            if (File.Exists(_executableSetting))
+                return _executableSetting;
+
+            if (Directory.Exists(_executableSetting))
+            {
+                var executableName = OperatingSystem.IsWindows() ? "faster-whisper.exe" : "faster-whisper";
+                var candidate = Path.Combine(_executableSetting, executableName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            return _executableSetting;
+        }
+
+        private static void EnsureEnvironmentEncoding(ProcessStartInfo startInfo)
+        {
+            if (!startInfo.Environment.ContainsKey("PYTHONIOENCODING"))
+            {
+                startInfo.Environment["PYTHONIOENCODING"] = "utf-8";
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                startInfo.Environment["PYTHONUTF8"] = "1";
+            }
+
+            startInfo.StandardErrorEncoding = Encoding.UTF8;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
+        }
+
+        private static void ConfigureFfmpegEnvironment(ProcessStartInfo startInfo, string? ffmpegExecutable)
+        {
+            if (string.IsNullOrWhiteSpace(ffmpegExecutable))
+            {
+                return;
+            }
+
+            startInfo.Environment["FFMPEG_BINARY"] = ffmpegExecutable;
+
+            var ffmpegDirectory = Path.GetDirectoryName(ffmpegExecutable);
+            if (string.IsNullOrWhiteSpace(ffmpegDirectory) || !Directory.Exists(ffmpegDirectory))
+            {
+                return;
+            }
+
+            var pathVariableName = OperatingSystem.IsWindows() ? "Path" : "PATH";
+            if (!startInfo.Environment.TryGetValue(pathVariableName, out var currentPath) || string.IsNullOrWhiteSpace(currentPath))
+            {
+                currentPath = Environment.GetEnvironmentVariable(pathVariableName);
+            }
+
+            if (string.IsNullOrWhiteSpace(currentPath))
+            {
+                startInfo.Environment[pathVariableName] = ffmpegDirectory;
+                return;
+            }
+
+            var segments = currentPath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (!segments.Any(p => string.Equals(p, ffmpegDirectory, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)))
+            {
+                startInfo.Environment[pathVariableName] = string.Concat(ffmpegDirectory, Path.PathSeparator, currentPath);
+            }
+        }
+
+        private void CleanupDirectory(string directory)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to remove FasterWhisper output directory {OutputDirectory}", directory);
+            }
+        }
+    }
+}

--- a/services/Whisper/WhisperCliTranscriptionService.cs
+++ b/services/Whisper/WhisperCliTranscriptionService.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace YandexSpeech.services.Whisper
+{
+    public sealed class WhisperCliTranscriptionService : IWhisperTranscriptionService
+    {
+        private readonly ILogger<WhisperCliTranscriptionService> _logger;
+        private readonly string _whisperExecutableSetting;
+        private readonly string _whisperModel;
+        private readonly string _whisperDevice;
+
+        public WhisperCliTranscriptionService(
+            IConfiguration configuration,
+            ILogger<WhisperCliTranscriptionService> logger)
+        {
+            _logger = logger;
+
+            var whisperSection = configuration.GetSection("Whisper");
+            _whisperExecutableSetting = whisperSection.GetValue<string>("ExecutablePath") ?? "whisper";
+            _whisperModel = whisperSection.GetValue<string>("Model") ?? "medium";
+
+            var configuredDevice = whisperSection.GetValue<string>("Device");
+            if (!string.IsNullOrWhiteSpace(configuredDevice))
+            {
+                _whisperDevice = configuredDevice;
+            }
+            else
+            {
+                var useGpu = whisperSection.GetValue<bool?>("UseGpu") ?? false;
+                _whisperDevice = useGpu ? "cuda" : "cpu";
+            }
+        }
+
+        public async Task<WhisperTranscriptionResult> TranscribeAsync(
+            string audioFilePath,
+            string workingDirectory,
+            string? ffmpegExecutable,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(audioFilePath))
+                throw new ArgumentException("Audio file path must be provided.", nameof(audioFilePath));
+
+            var audioPath = Path.GetFullPath(audioFilePath);
+            if (!File.Exists(audioPath))
+                throw new FileNotFoundException("Audio file not found for Whisper transcription.", audioPath);
+
+            if (string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                workingDirectory = Path.Combine(Path.GetTempPath(), "openai-transcriptions");
+            }
+
+            Directory.CreateDirectory(workingDirectory);
+
+            var outputDirectory = Path.Combine(workingDirectory, $"whisper-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(outputDirectory);
+
+            var startInfo = BuildProcessStartInfo(audioPath, outputDirectory, ffmpegExecutable);
+
+            using var process = new Process { StartInfo = startInfo };
+
+            try
+            {
+                process.Start();
+
+                var standardErrorTask = process.StandardError.ReadToEndAsync();
+                var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+
+                await process.WaitForExitAsync(cancellationToken);
+                await Task.WhenAll(standardErrorTask, standardOutputTask);
+
+                var standardError = await standardErrorTask;
+                var standardOutput = await standardOutputTask;
+
+                if (process.ExitCode != 0)
+                {
+                    throw new InvalidOperationException($"Whisper transcription failed (exit code {process.ExitCode}): {standardError}\n{standardOutput}");
+                }
+
+                var transcriptFile = WhisperTranscriptionHelper.FindFirstJsonFile(outputDirectory);
+                if (transcriptFile == null)
+                {
+                    throw new InvalidOperationException($"Whisper transcription did not produce a JSON file. Output: {standardOutput} Error: {standardError}");
+                }
+
+                var transcription = await File.ReadAllTextAsync(transcriptFile, cancellationToken);
+                if (string.IsNullOrWhiteSpace(transcription))
+                    throw new InvalidOperationException("Whisper transcription result is empty.");
+
+                var parsed = WhisperTranscriptionHelper.Parse(transcription);
+                if (parsed?.Segments == null || parsed.Segments.Count == 0)
+                    throw new InvalidOperationException("Whisper transcription does not contain segments.");
+
+                var timecodedText = WhisperTranscriptionHelper.BuildTimecodedText(parsed);
+
+                return new WhisperTranscriptionResult
+                {
+                    TimecodedText = timecodedText,
+                    RawJson = transcription
+                };
+            }
+            finally
+            {
+                CleanupDirectory(outputDirectory);
+            }
+        }
+
+        private ProcessStartInfo BuildProcessStartInfo(string audioPath, string outputDirectory, string? ffmpegExecutable)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = ResolveWhisperExecutable(),
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true,
+            };
+
+            EnsureEnvironmentEncoding(startInfo);
+            ConfigureFfmpegEnvironment(startInfo, ffmpegExecutable);
+
+            startInfo.ArgumentList.Add(audioPath);
+            startInfo.ArgumentList.Add("--model");
+            startInfo.ArgumentList.Add(_whisperModel);
+            startInfo.ArgumentList.Add("--task");
+            startInfo.ArgumentList.Add("transcribe");
+            startInfo.ArgumentList.Add("--output_format");
+            startInfo.ArgumentList.Add("json");
+            startInfo.ArgumentList.Add("--word_timestamps");
+            startInfo.ArgumentList.Add("True");
+            startInfo.ArgumentList.Add("--output_dir");
+            startInfo.ArgumentList.Add(outputDirectory);
+
+            if (!string.IsNullOrWhiteSpace(_whisperDevice))
+            {
+                startInfo.ArgumentList.Add("--device");
+                startInfo.ArgumentList.Add(_whisperDevice);
+
+                if (string.Equals(_whisperDevice, "cpu", StringComparison.OrdinalIgnoreCase))
+                {
+                    startInfo.ArgumentList.Add("--fp16");
+                    startInfo.ArgumentList.Add("False");
+                }
+            }
+
+            return startInfo;
+        }
+
+        private string ResolveWhisperExecutable()
+        {
+            if (File.Exists(_whisperExecutableSetting))
+                return _whisperExecutableSetting;
+
+            if (Directory.Exists(_whisperExecutableSetting))
+            {
+                var executableName = OperatingSystem.IsWindows() ? "whisper.exe" : "whisper";
+                var candidate = Path.Combine(_whisperExecutableSetting, executableName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            return _whisperExecutableSetting;
+        }
+
+        private static void EnsureEnvironmentEncoding(ProcessStartInfo startInfo)
+        {
+            if (!startInfo.Environment.ContainsKey("PYTHONIOENCODING"))
+            {
+                startInfo.Environment["PYTHONIOENCODING"] = "utf-8";
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                startInfo.Environment["PYTHONUTF8"] = "1";
+            }
+
+            startInfo.StandardErrorEncoding = Encoding.UTF8;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
+        }
+
+        private static void ConfigureFfmpegEnvironment(ProcessStartInfo startInfo, string? ffmpegExecutable)
+        {
+            if (string.IsNullOrWhiteSpace(ffmpegExecutable))
+            {
+                return;
+            }
+
+            startInfo.Environment["FFMPEG_BINARY"] = ffmpegExecutable;
+
+            var ffmpegDirectory = Path.GetDirectoryName(ffmpegExecutable);
+            if (string.IsNullOrWhiteSpace(ffmpegDirectory) || !Directory.Exists(ffmpegDirectory))
+            {
+                return;
+            }
+
+            var pathVariableName = OperatingSystem.IsWindows() ? "Path" : "PATH";
+            if (!startInfo.Environment.TryGetValue(pathVariableName, out var currentPath) || string.IsNullOrWhiteSpace(currentPath))
+            {
+                currentPath = Environment.GetEnvironmentVariable(pathVariableName);
+            }
+
+            if (string.IsNullOrWhiteSpace(currentPath))
+            {
+                startInfo.Environment[pathVariableName] = ffmpegDirectory;
+                return;
+            }
+
+            var segments = currentPath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+            if (!segments.Any(p => string.Equals(p, ffmpegDirectory, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)))
+            {
+                startInfo.Environment[pathVariableName] = string.Concat(ffmpegDirectory, Path.PathSeparator, currentPath);
+            }
+        }
+
+        private void CleanupDirectory(string directory)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to remove Whisper output directory {OutputDirectory}", directory);
+            }
+        }
+    }
+}

--- a/services/Whisper/WhisperTranscriptionHelper.cs
+++ b/services/Whisper/WhisperTranscriptionHelper.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace YandexSpeech.services.Whisper
+{
+    internal static class WhisperTranscriptionHelper
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        public static WhisperTranscriptionResponse? Parse(string json)
+        {
+            return JsonSerializer.Deserialize<WhisperTranscriptionResponse>(json, JsonOptions);
+        }
+
+        public static string BuildTimecodedText(WhisperTranscriptionResponse parsed)
+        {
+            if (parsed.Segments.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder();
+            foreach (var segment in parsed.Segments)
+            {
+                var start = TimeSpan.FromSeconds(segment.Start);
+                var end = TimeSpan.FromSeconds(segment.End);
+                var text = (segment.Text ?? string.Empty).Trim();
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                builder.Append('[')
+                    .Append(FormatTimestamp(start))
+                    .Append(" --> ")
+                    .Append(FormatTimestamp(end))
+                    .Append("] ")
+                    .AppendLine(text);
+            }
+
+            return builder.ToString().Trim();
+        }
+
+        public static string? FindFirstJsonFile(string directory)
+        {
+            return Directory.Exists(directory)
+                ? Directory.EnumerateFiles(directory, "*.json").FirstOrDefault()
+                : null;
+        }
+
+        private static string FormatTimestamp(TimeSpan time) => time.ToString(@"hh\:mm\:ss\.fff");
+    }
+}


### PR DESCRIPTION
## Summary
- extract Whisper recognition into the new IWhisperTranscriptionService abstraction
- add CLI and Faster-Whisper implementations that share reusable transcription helpers
- wire the OpenAI transcription workflow to consume the new service and choose implementation via configuration
- document provider options in appsettings

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d549721744833198c05ebd577f8403