### PR TITLE
Fix cascading delete cycle between users and subscriptions

### DIFF
--- a/Migrations/20250925153439_new1.cs
+++ b/Migrations/20250925153439_new1.cs
@@ -278,7 +278,7 @@ namespace YandexSpeech.Migrations
                         column: x => x.UserId,
                         principalTable: "AspNetUsers",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_UserSubscriptions_SubscriptionPlans_PlanId",
                         column: x => x.PlanId,

--- a/Migrations/20260201000000_subscriptions_wallet.cs
+++ b/Migrations/20260201000000_subscriptions_wallet.cs
@@ -246,7 +246,7 @@ namespace YandexSpeech.Migrations
                         column: x => x.UserId,
                         principalTable: "AspNetUsers",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_UserSubscriptions_SubscriptionPlans_PlanId",
                         column: x => x.PlanId,

--- a/Migrations/MyDbContextModelSnapshot.cs
+++ b/Migrations/MyDbContextModelSnapshot.cs
@@ -1566,7 +1566,7 @@ namespace YandexSpeech.Migrations
                     b.HasOne("YandexSpeech.models.DB.ApplicationUser", "User")
                         .WithMany("Subscriptions")
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Plan");

--- a/dbcontext.cs
+++ b/dbcontext.cs
@@ -87,7 +87,7 @@ namespace YandexSpeech
                 .HasOne(us => us.User)
                 .WithMany(u => u.Subscriptions)
                 .HasForeignKey(us => us.UserId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
 
             builder.Entity<UserSubscription>()
                 .HasOne(us => us.Plan)


### PR DESCRIPTION
## Summary
- prevent cascading deletes between users and their subscriptions to avoid cycles
- update the user-subscription foreign keys in migrations to use Restrict delete behavior
- keep the model snapshot consistent with the new delete behavior

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5619066ac83319854c70b0c7d2e6f