### PR TITLE
Align logout menu item styling

### DIFF
--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -35,7 +35,8 @@
     </a>
     <mat-divider></mat-divider>
     <a mat-list-item (click)="onLogout()">
-      <mat-icon>logout</mat-icon><span>Выйти ({{ user.displayName || user.email }})</span>
+      <mat-icon matListItemIcon>logout</mat-icon>
+      <span matListItemTitle>Выйти ({{ user.displayName || user.email }})</span>
     </a>
   </ng-container>
   <ng-template #guestMenu>


### PR DESCRIPTION
## Summary
- add the Angular Material list item directives to the logout entry so it matches other menu items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58e0562608331b9048429489d6962