### PR TITLE
Set Russian as default Whisper transcription language

### DIFF
--- a/services/Whisper/FasterWhisperTranscriptionService.cs
+++ b/services/Whisper/FasterWhisperTranscriptionService.cs
@@ -17,6 +17,7 @@ namespace YandexSpeech.services.Whisper
         private readonly string _model;
         private readonly string _device;
         private readonly string _computeType;
+        private readonly string _language;
 
         public FasterWhisperTranscriptionService(
             IConfiguration configuration,
@@ -29,6 +30,9 @@ namespace YandexSpeech.services.Whisper
             _model = section.GetValue<string>("Model") ?? configuration.GetValue<string>("Whisper:Model") ?? "medium";
             _device = section.GetValue<string>("Device") ?? configuration.GetValue<string>("Whisper:Device") ?? "cpu";
             _computeType = section.GetValue<string>("ComputeType") ?? "int8";
+            _language = section.GetValue<string>("Language")
+                ?? configuration.GetValue<string>("Whisper:Language")
+                ?? "ru";
         }
 
         public async Task<WhisperTranscriptionResult> TranscribeAsync(
@@ -131,6 +135,8 @@ namespace YandexSpeech.services.Whisper
             startInfo.ArgumentList.Add("json");
             startInfo.ArgumentList.Add("--word_timestamps");
             startInfo.ArgumentList.Add("True");
+            startInfo.ArgumentList.Add("--language");
+            startInfo.ArgumentList.Add(_language);
 
             return startInfo;
         }

--- a/services/Whisper/WhisperCliTranscriptionService.cs
+++ b/services/Whisper/WhisperCliTranscriptionService.cs
@@ -16,6 +16,7 @@ namespace YandexSpeech.services.Whisper
         private readonly string _whisperExecutableSetting;
         private readonly string _whisperModel;
         private readonly string _whisperDevice;
+        private readonly string _whisperLanguage;
 
         public WhisperCliTranscriptionService(
             IConfiguration configuration,
@@ -26,6 +27,7 @@ namespace YandexSpeech.services.Whisper
             var whisperSection = configuration.GetSection("Whisper");
             _whisperExecutableSetting = whisperSection.GetValue<string>("ExecutablePath") ?? "whisper";
             _whisperModel = whisperSection.GetValue<string>("Model") ?? "medium";
+            _whisperLanguage = whisperSection.GetValue<string>("Language") ?? "ru";
 
             var configuredDevice = whisperSection.GetValue<string>("Device");
             if (!string.IsNullOrWhiteSpace(configuredDevice))
@@ -135,6 +137,8 @@ namespace YandexSpeech.services.Whisper
             startInfo.ArgumentList.Add("json");
             startInfo.ArgumentList.Add("--word_timestamps");
             startInfo.ArgumentList.Add("True");
+            startInfo.ArgumentList.Add("--language");
+            startInfo.ArgumentList.Add(_whisperLanguage);
             startInfo.ArgumentList.Add("--output_dir");
             startInfo.ArgumentList.Add(outputDirectory);
 


### PR DESCRIPTION
## Summary
- add a configurable language option to both Whisper CLI and FasterWhisper services
- default the language setting to Russian and pass it to the respective executables

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d61a8d35248331883b256aa3954178