### PR TITLE
Add YooMoney subscription and wallet payment integration

### DIFF
--- a/Angular/youtube-downloader/src/app/billing/billing.component.css
+++ b/Angular/youtube-downloader/src/app/billing/billing.component.css
@@ -1,0 +1,68 @@
+.billing-container {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 24px;
+}
+
+.wallet__balance {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.wallet__amount {
+  font-size: 32px;
+  font-weight: 600;
+}
+
+.wallet__hint {
+  font-size: 14px;
+  color: #1976d2;
+}
+
+.wallet__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.plans h2 {
+  margin: 0 0 16px;
+}
+
+.plans__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.plan-card__price {
+  font-size: 28px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.plan-card__description {
+  min-height: 48px;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+@media (max-width: 768px) {
+  .billing-container {
+    padding: 16px;
+  }
+
+  .wallet__form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/Angular/youtube-downloader/src/app/billing/billing.component.html
+++ b/Angular/youtube-downloader/src/app/billing/billing.component.html
@@ -1,0 +1,70 @@
+<div class="billing-container" *ngIf="!loadingPlans && !loadingWallet; else loadingTemplate">
+  <section class="wallet" *ngIf="wallet">
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Баланс для распознавания митингов</mat-card-title>
+        <mat-card-subtitle>Средства списываются при обработке митингов</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="wallet__balance">
+          <span class="wallet__amount">{{ wallet.balance | number:'1.0-2' }} {{ wallet.currency }}</span>
+          <span class="wallet__hint" *ngIf="infoMessage">{{ infoMessage }}</span>
+        </div>
+        <form class="wallet__form" (ngSubmit)="deposit()">
+          <mat-form-field appearance="outline">
+            <mat-label>Сумма пополнения</mat-label>
+            <input matInput type="number" [formControl]="depositControl" min="100" max="100000" step="100" />
+            <mat-hint>Минимум 100 ₽</mat-hint>
+            <mat-error *ngIf="depositControl.hasError('required')">Укажите сумму</mat-error>
+            <mat-error *ngIf="depositControl.hasError('min')">Минимальная сумма — 100 ₽</mat-error>
+            <mat-error *ngIf="depositControl.hasError('max')">Максимальная сумма — 100000 ₽</mat-error>
+          </mat-form-field>
+          <button mat-flat-button color="primary" type="submit" [disabled]="depositControl.invalid || submitting">
+            Пополнить кошелёк
+          </button>
+        </form>
+      </mat-card-content>
+    </mat-card>
+  </section>
+
+  <section class="plans">
+    <h2>Подписки</h2>
+    <div class="plans__grid">
+      <mat-card *ngFor="let plan of plans" class="plan-card">
+        <mat-card-header>
+          <mat-card-title>{{ plan.name }}</mat-card-title>
+          <mat-card-subtitle>{{ getPlanDuration(plan) }}</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <p class="plan-card__price">{{ formatPrice(plan) }}</p>
+          <p class="plan-card__description" *ngIf="plan.description">{{ plan.description }}</p>
+          <mat-list>
+            <mat-list-item *ngIf="plan.canHideCaptions">
+              <mat-icon matListItemIcon color="primary">visibility_off</mat-icon>
+              <span matListItemTitle>Скрытие собственных видео из общего доступа</span>
+            </mat-list-item>
+            <mat-list-item *ngIf="plan.isUnlimitedRecognitions">
+              <mat-icon matListItemIcon color="primary">speed</mat-icon>
+              <span matListItemTitle>Без ограничений на количество распознаваний</span>
+            </mat-list-item>
+            <mat-list-item *ngIf="!plan.canHideCaptions && !plan.isUnlimitedRecognitions">
+              <mat-icon matListItemIcon color="primary">star</mat-icon>
+              <span matListItemTitle>Специальные возможности аккаунта</span>
+            </mat-list-item>
+          </mat-list>
+        </mat-card-content>
+        <mat-card-actions>
+          <button mat-stroked-button color="primary" (click)="buyPlan(plan)" [disabled]="submitting">
+            Оформить подписку
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+  </section>
+</div>
+
+<ng-template #loadingTemplate>
+  <div class="loading">
+    <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
+  </div>
+</ng-template>

--- a/Angular/youtube-downloader/src/app/billing/billing.component.ts
+++ b/Angular/youtube-downloader/src/app/billing/billing.component.ts
@@ -1,0 +1,177 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subject, takeUntil } from 'rxjs';
+import { PaymentsService, SubscriptionPlan, WalletBalance } from '../services/payments.service';
+
+@Component({
+  selector: 'app-billing',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatListModule,
+    MatSnackBarModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './billing.component.html',
+  styleUrls: ['./billing.component.css']
+})
+export class BillingComponent implements OnInit, OnDestroy {
+  private readonly destroy$ = new Subject<void>();
+
+  readonly depositControl = new FormControl<number | null>(500, {
+    nonNullable: false,
+    validators: [Validators.required, Validators.min(100), Validators.max(100000)]
+  });
+
+  plans: SubscriptionPlan[] = [];
+  wallet?: WalletBalance;
+  loadingPlans = false;
+  loadingWallet = false;
+  submitting = false;
+  infoMessage = '';
+
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly snackBar: MatSnackBar,
+    private readonly route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    this.loadPlans();
+    this.loadWallet();
+
+    this.route.queryParamMap
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(params => {
+        const status = params.get('status');
+        const operation = params.get('operation');
+        if (status === 'success' || status === null && operation) {
+          this.infoMessage = 'Платёж обработан. Обновите страницу через несколько секунд, если изменения ещё не применились.';
+        } else if (status === 'failed') {
+          this.infoMessage = 'Платёж не был завершён. Попробуйте снова.';
+        } else {
+          this.infoMessage = '';
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  loadPlans(): void {
+    this.loadingPlans = true;
+    this.paymentsService.getPlans().subscribe({
+      next: plans => {
+        this.plans = plans;
+        this.loadingPlans = false;
+      },
+      error: () => {
+        this.loadingPlans = false;
+        this.snackBar.open('Не удалось загрузить тарифы. Попробуйте позже.', 'Закрыть', { duration: 4000 });
+      }
+    });
+  }
+
+  loadWallet(): void {
+    this.loadingWallet = true;
+    this.paymentsService.getWallet().subscribe({
+      next: wallet => {
+        this.wallet = wallet;
+        this.loadingWallet = false;
+      },
+      error: () => {
+        this.loadingWallet = false;
+        this.snackBar.open('Не удалось получить баланс кошелька.', 'Закрыть', { duration: 4000 });
+      }
+    });
+  }
+
+  openPayment(url: string): void {
+    window.open(url, '_blank');
+    this.snackBar.open('Окно оплаты открыто. После успешного платежа вернитесь на эту страницу.', 'Понятно', { duration: 5000 });
+  }
+
+  buyPlan(plan: SubscriptionPlan): void {
+    if (this.submitting) {
+      return;
+    }
+
+    this.submitting = true;
+    this.paymentsService.createSubscription(plan.code).subscribe({
+      next: response => {
+        this.submitting = false;
+        this.openPayment(response.paymentUrl);
+      },
+      error: () => {
+        this.submitting = false;
+        this.snackBar.open('Не удалось создать платёж. Попробуйте позже.', 'Закрыть', { duration: 4000 });
+      }
+    });
+  }
+
+  deposit(): void {
+    if (this.submitting) {
+      return;
+    }
+
+    if (this.depositControl.invalid) {
+      this.depositControl.markAsTouched();
+      return;
+    }
+
+    const amount = this.depositControl.value;
+    if (amount == null) {
+      return;
+    }
+
+    this.submitting = true;
+    this.paymentsService.createWalletDeposit(amount).subscribe({
+      next: response => {
+        this.submitting = false;
+        this.openPayment(response.paymentUrl);
+      },
+      error: () => {
+        this.submitting = false;
+        this.snackBar.open('Не удалось создать пополнение. Попробуйте позже.', 'Закрыть', { duration: 4000 });
+      }
+    });
+  }
+
+  formatPrice(plan: SubscriptionPlan): string {
+    return new Intl.NumberFormat('ru-RU', { style: 'currency', currency: plan.currency }).format(plan.price);
+  }
+
+  getPlanDuration(plan: SubscriptionPlan): string {
+    if (plan.isLifetime) {
+      return 'Бессрочно';
+    }
+
+    switch (plan.billingPeriod) {
+      case 'Monthly':
+        return '1 месяц';
+      case 'Yearly':
+        return '1 год';
+      default:
+        return 'Разово';
+    }
+  }
+}

--- a/Angular/youtube-downloader/src/app/services/payments.service.ts
+++ b/Angular/youtube-downloader/src/app/services/payments.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface SubscriptionPlan {
+  id: string;
+  code: string;
+  name: string;
+  description?: string;
+  billingPeriod: string;
+  price: number;
+  currency: string;
+  maxRecognitionsPerDay?: number | null;
+  canHideCaptions: boolean;
+  isUnlimitedRecognitions: boolean;
+  isLifetime: boolean;
+}
+
+export interface PaymentInitResponse {
+  operationId: string;
+  paymentUrl: string;
+}
+
+export interface WalletBalance {
+  balance: number;
+  currency: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PaymentsService {
+  private readonly baseUrl = '/api/payments';
+
+  constructor(private readonly http: HttpClient) {}
+
+  getPlans(): Observable<SubscriptionPlan[]> {
+    return this.http.get<SubscriptionPlan[]>(`${this.baseUrl}/plans`);
+  }
+
+  getWallet(): Observable<WalletBalance> {
+    return this.http.get<WalletBalance>(`${this.baseUrl}/wallet`);
+  }
+
+  createSubscription(planCode: string): Observable<PaymentInitResponse> {
+    return this.http.post<PaymentInitResponse>(`${this.baseUrl}/subscriptions`, { planCode });
+  }
+
+  createWalletDeposit(amount: number, comment?: string): Observable<PaymentInitResponse> {
+    return this.http.post<PaymentInitResponse>(`${this.baseUrl}/wallet/deposit`, { amount, comment });
+  }
+}

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -29,6 +29,10 @@
       <mat-icon matListItemIcon>account_circle</mat-icon>
       <span matListItemTitle>Профиль</span>
     </a>
+    <a mat-list-item (click)="navigate('/billing')">
+      <mat-icon matListItemIcon>credit_card</mat-icon>
+      <span matListItemTitle>Подписки и баланс</span>
+    </a>
     <a mat-list-item *ngIf="hasRole(user, 'Moderator')" (click)="navigate('/blog/new')">
       <mat-icon matListItemIcon>post_add</mat-icon>
       <span matListItemTitle>Новая тема</span>

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -32,6 +32,7 @@ import { ProfileComponent } from './app/profile/profile.component';
 import { AuthGuard } from './app/services/auth.guard';
 import { OpenAiTranscriptionComponent } from './app/openai-transcription/openai-transcription.component';
 import { TranscriptionEditorComponent } from './app/transcription-editor/transcription-editor.component';
+import { BillingComponent } from './app/billing/billing.component';
 
 
 
@@ -121,6 +122,11 @@ const routes: Routes = [
   {
     path: 'blog',
     component: BlogFeedComponent,
+  },
+  {
+    path: 'billing',
+    component: BillingComponent,
+    canActivate: [AuthGuard]
   },
   {
     path: 'profile',

--- a/Controllers/PaymentsController.cs
+++ b/Controllers/PaymentsController.cs
@@ -1,0 +1,447 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http;
+using YandexSpeech.models.DB;
+using YandexSpeech.models.DTO;
+using YandexSpeech.services;
+using YandexSpeech.services.Interface;
+
+namespace YandexSpeech.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class PaymentsController : ControllerBase
+    {
+        private const string SubscriptionPayloadType = "subscription";
+        private const string WalletPayloadType = "wallet";
+
+        private readonly MyDbContext _dbContext;
+        private readonly IPaymentGatewayService _paymentGatewayService;
+        private readonly ISubscriptionService _subscriptionService;
+        private readonly IWalletService _walletService;
+        private readonly IOptions<YooMoneyOptions> _yooMoneyOptions;
+        private readonly ILogger<PaymentsController> _logger;
+
+        public PaymentsController(
+            MyDbContext dbContext,
+            IPaymentGatewayService paymentGatewayService,
+            ISubscriptionService subscriptionService,
+            IWalletService walletService,
+            IOptions<YooMoneyOptions> yooMoneyOptions,
+            ILogger<PaymentsController> logger)
+        {
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _paymentGatewayService = paymentGatewayService ?? throw new ArgumentNullException(nameof(paymentGatewayService));
+            _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+            _walletService = walletService ?? throw new ArgumentNullException(nameof(walletService));
+            _yooMoneyOptions = yooMoneyOptions ?? throw new ArgumentNullException(nameof(yooMoneyOptions));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        [HttpGet("plans")]
+        public async Task<ActionResult<IReadOnlyList<SubscriptionPlanDto>>> GetPlans(CancellationToken cancellationToken)
+        {
+            var plans = await _subscriptionService.GetPlansAsync(includeInactive: false, cancellationToken)
+                .ConfigureAwait(false);
+
+            var response = new List<SubscriptionPlanDto>(plans.Count);
+            foreach (var plan in plans)
+            {
+                response.Add(new SubscriptionPlanDto
+                {
+                    Id = plan.Id,
+                    Code = plan.Code,
+                    Name = plan.Name,
+                    Description = plan.Description,
+                    BillingPeriod = plan.BillingPeriod,
+                    Price = plan.Price,
+                    Currency = plan.Currency,
+                    MaxRecognitionsPerDay = plan.MaxRecognitionsPerDay,
+                    CanHideCaptions = plan.CanHideCaptions,
+                    IsUnlimitedRecognitions = plan.IsUnlimitedRecognitions,
+                    IsLifetime = plan.BillingPeriod == SubscriptionBillingPeriod.Lifetime
+                });
+            }
+
+            return Ok(response);
+        }
+
+        [HttpGet("wallet")]
+        public async Task<ActionResult<WalletBalanceDto>> GetWallet(CancellationToken cancellationToken)
+        {
+            var userId = GetUserId();
+            var wallet = await _walletService.GetOrCreateWalletAsync(userId, cancellationToken).ConfigureAwait(false);
+
+            return Ok(new WalletBalanceDto
+            {
+                Balance = wallet.Balance,
+                Currency = wallet.Currency
+            });
+        }
+
+        [HttpPost("subscriptions")]
+        public async Task<ActionResult<PaymentInitResponse>> CreateSubscriptionPayment(
+            [FromBody] CreateSubscriptionPaymentRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+            {
+                return ValidationProblem(ModelState);
+            }
+
+            var plan = await _dbContext.SubscriptionPlans
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Code == request.PlanCode && p.IsActive, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (plan == null)
+            {
+                return NotFound($"Subscription plan '{request.PlanCode}' was not found.");
+            }
+
+            if (plan.Price <= 0)
+            {
+                return BadRequest("Подписка с нулевой стоимостью не требует оплаты.");
+            }
+
+            var userId = GetUserId();
+
+            var payload = SerializePayload(new PaymentPayload
+            {
+                Type = SubscriptionPayloadType,
+                PlanId = plan.Id
+            });
+
+            var operation = await _paymentGatewayService
+                .RegisterOperationAsync(userId, plan.Price, plan.Currency, PaymentProvider.YooMoney, payload, cancellationToken)
+                .ConfigureAwait(false);
+
+            var paymentUrl = BuildQuickpayUrl(operation.Id, plan.Price, plan.Currency, plan.Name);
+
+            return Ok(new PaymentInitResponse
+            {
+                OperationId = operation.Id,
+                PaymentUrl = paymentUrl
+            });
+        }
+
+        [HttpPost("wallet/deposit")]
+        public async Task<ActionResult<PaymentInitResponse>> CreateWalletDeposit(
+            [FromBody] CreateWalletDepositRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+            {
+                return ValidationProblem(ModelState);
+            }
+
+            if (request.Amount <= 0)
+            {
+                return BadRequest("Сумма пополнения должна быть больше нуля.");
+            }
+
+            var userId = GetUserId();
+
+            var payload = SerializePayload(new PaymentPayload
+            {
+                Type = WalletPayloadType,
+                Comment = string.IsNullOrWhiteSpace(request.Comment)
+                    ? "Пополнение счёта для распознавания митингов"
+                    : request.Comment
+            });
+
+            var operation = await _paymentGatewayService
+                .RegisterOperationAsync(userId, request.Amount, "RUB", PaymentProvider.YooMoney, payload, cancellationToken)
+                .ConfigureAwait(false);
+
+            var paymentUrl = BuildQuickpayUrl(operation.Id, request.Amount, "RUB", "Пополнение счёта");
+
+            return Ok(new PaymentInitResponse
+            {
+                OperationId = operation.Id,
+                PaymentUrl = paymentUrl
+            });
+        }
+
+        [AllowAnonymous]
+        [HttpPost("notifications/yoomoney")]
+        [Consumes("application/x-www-form-urlencoded")]
+        public async Task<IActionResult> HandleYooMoneyNotification([FromForm] YooMoneyNotification notification, CancellationToken cancellationToken)
+        {
+            if (notification == null)
+            {
+                return BadRequest("Пустое уведомление");
+            }
+
+            if (!Guid.TryParse(notification.Label, out var operationId))
+            {
+                _logger.LogWarning("Получено уведомление YooMoney без корректного идентификатора операции: {Label}", notification.Label);
+                return BadRequest("Некорректный идентификатор операции");
+            }
+
+            if (!ValidateSignature(notification))
+            {
+                _logger.LogWarning("Получено уведомление YooMoney с некорректной подписью: {OperationId}", operationId);
+                return BadRequest("Некорректная подпись уведомления");
+            }
+
+            var operation = await _paymentGatewayService.GetOperationAsync(operationId, cancellationToken).ConfigureAwait(false);
+            if (operation == null)
+            {
+                _logger.LogWarning("Операция {OperationId} не найдена при обработке уведомления YooMoney", operationId);
+                return NotFound();
+            }
+
+            if (operation.Status == PaymentOperationStatus.Succeeded)
+            {
+                return Ok();
+            }
+
+            var payload = DeserializePayload(operation.Payload);
+            if (payload == null)
+            {
+                _logger.LogError("Не удалось определить тип операции {OperationId}", operationId);
+                return BadRequest("Не удалось определить тип операции");
+            }
+
+            var amount = notification.Amount ?? 0m;
+            if (amount <= 0m)
+            {
+                _logger.LogWarning("Уведомление YooMoney {OperationId} содержит некорректную сумму {Amount}", operationId, amount);
+                return BadRequest("Некорректная сумма");
+            }
+
+            if (operation.Amount > 0 && Math.Abs(operation.Amount - amount) > 0.01m)
+            {
+                _logger.LogWarning("Сумма уведомления YooMoney {Amount} не совпадает с ожидаемой {Expected} для операции {OperationId}", amount, operation.Amount, operationId);
+                return BadRequest("Некорректная сумма операции");
+            }
+
+            try
+            {
+                switch (payload.Type)
+                {
+                    case SubscriptionPayloadType:
+                        await HandleSubscriptionPaymentAsync(operation, payload, notification, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case WalletPayloadType:
+                        await HandleWalletDepositAsync(operation, payload, notification, cancellationToken).ConfigureAwait(false);
+                        break;
+                    default:
+                        _logger.LogError("Неизвестный тип операции {Type} для {OperationId}", payload.Type, operationId);
+                        return BadRequest("Неизвестный тип операции");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ошибка при обработке уведомления YooMoney для операции {OperationId}", operationId);
+                return StatusCode(StatusCodes.Status500InternalServerError, "Ошибка обработки уведомления");
+            }
+
+            return Ok();
+        }
+
+        private async Task HandleSubscriptionPaymentAsync(
+            PaymentOperation operation,
+            PaymentPayload payload,
+            YooMoneyNotification notification,
+            CancellationToken cancellationToken)
+        {
+            if (payload.PlanId == null)
+            {
+                throw new InvalidOperationException("Отсутствует идентификатор плана подписки.");
+            }
+
+            await _subscriptionService
+                .ActivateSubscriptionAsync(operation.UserId, payload.PlanId.Value, externalPaymentId: notification.OperationId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            await _paymentGatewayService
+                .MarkSucceededAsync(operation.Id, notification.OperationId ?? string.Empty, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation("Активирована подписка {PlanId} для пользователя {UserId} по операции {OperationId}", payload.PlanId, operation.UserId, operation.Id);
+        }
+
+        private async Task HandleWalletDepositAsync(
+            PaymentOperation operation,
+            PaymentPayload payload,
+            YooMoneyNotification notification,
+            CancellationToken cancellationToken)
+        {
+            var comment = payload.Comment ?? "Пополнение счёта";
+            var transaction = await _walletService
+                .DepositAsync(operation.UserId, notification.Amount ?? operation.Amount, notification.Currency ?? "RUB", relatedEntityId: operation.Id, reference: notification.OperationId, comment: comment, cancellationToken)
+                .ConfigureAwait(false);
+
+            await _paymentGatewayService
+                .MarkSucceededAsync(operation.Id, notification.OperationId ?? string.Empty, transaction.Id, cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation("Пополнен кошелёк пользователя {UserId} на сумму {Amount} по операции {OperationId}", operation.UserId, notification.Amount, operation.Id);
+        }
+
+        private string BuildQuickpayUrl(Guid operationId, decimal amount, string currency, string title)
+        {
+            var options = _yooMoneyOptions.Value;
+            if (string.IsNullOrWhiteSpace(options.Receiver))
+            {
+                throw new InvalidOperationException("В конфигурации не указан кошелёк YooMoney для приема платежей.");
+            }
+
+            var baseUrl = "https://yoomoney.ru/quickpay/confirm";
+            var amountText = amount.ToString("F2", CultureInfo.InvariantCulture);
+
+            var successUrl = AppendOperation(options.SuccessUrl, operationId.ToString());
+            var failUrl = AppendOperation(options.FailUrl, operationId.ToString());
+
+            var query = new Dictionary<string, string?>
+            {
+                ["receiver"] = options.Receiver,
+                ["quickpay-form"] = options.QuickpayForm,
+                ["paymentType"] = options.PaymentType,
+                ["sum"] = amountText,
+                ["label"] = operationId.ToString(),
+                ["targets"] = title,
+                ["comment"] = title,
+                ["successURL"] = successUrl,
+                ["failURL"] = failUrl
+            };
+
+            var filteredQuery = new Dictionary<string, string?>();
+            foreach (var (key, value) in query)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    filteredQuery[key] = value;
+                }
+            }
+
+            return QueryHelpers.AddQueryString(baseUrl, filteredQuery);
+        }
+
+        private static string? AppendOperation(string? url, string operationId)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return null;
+            }
+
+            return QueryHelpers.AddQueryString(url, "operation", operationId);
+        }
+
+        private string GetUserId()
+        {
+            var userId = User.FindFirstValue(System.Security.Claims.ClaimTypes.NameIdentifier);
+            return userId ?? throw new InvalidOperationException("Не удалось определить пользователя.");
+        }
+
+        private bool ValidateSignature(YooMoneyNotification notification)
+        {
+            var secret = _yooMoneyOptions.Value.NotificationSecret;
+            if (string.IsNullOrWhiteSpace(secret))
+            {
+                return true; // подпись не настроена
+            }
+
+            var builder = new StringBuilder();
+            builder.Append(notification.NotificationType ?? string.Empty).Append('&');
+            builder.Append(notification.OperationId ?? string.Empty).Append('&');
+            builder.Append(notification.Amount?.ToString("F2", CultureInfo.InvariantCulture) ?? string.Empty).Append('&');
+            builder.Append(notification.Currency ?? string.Empty).Append('&');
+            builder.Append(notification.DateTime ?? string.Empty).Append('&');
+            builder.Append(notification.Sender ?? string.Empty).Append('&');
+            builder.Append(notification.CodePro ? "true" : "false").Append('&');
+            builder.Append(secret).Append('&');
+            builder.Append(notification.Label ?? string.Empty);
+
+            using var sha1 = SHA1.Create();
+            var data = Encoding.UTF8.GetBytes(builder.ToString());
+            var hash = sha1.ComputeHash(data);
+            var computed = BitConverter.ToString(hash).Replace("-", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+
+            return string.Equals(computed, notification.Sha1Hash, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string SerializePayload(PaymentPayload payload)
+        {
+            return JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+            });
+        }
+
+        private static PaymentPayload? DeserializePayload(string? payload)
+        {
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return null;
+            }
+
+            try
+            {
+                return JsonSerializer.Deserialize<PaymentPayload>(payload, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private sealed class PaymentPayload
+        {
+            public string Type { get; set; } = string.Empty;
+
+            public Guid? PlanId { get; set; }
+
+            public string? Comment { get; set; }
+        }
+
+        public sealed class YooMoneyNotification
+        {
+            [FromForm(Name = "notification_type")]
+            public string? NotificationType { get; set; }
+
+            [FromForm(Name = "operation_id")]
+            public string? OperationId { get; set; }
+
+            [FromForm(Name = "amount")]
+            public decimal? Amount { get; set; }
+
+            [FromForm(Name = "currency")]
+            public string? Currency { get; set; }
+
+            [FromForm(Name = "datetime")]
+            public string? DateTime { get; set; }
+
+            [FromForm(Name = "sender")]
+            public string? Sender { get; set; }
+
+            [FromForm(Name = "codepro")]
+            public bool CodePro { get; set; }
+
+            [FromForm(Name = "label")]
+            public string? Label { get; set; }
+
+            [FromForm(Name = "sha1_hash")]
+            public string? Sha1Hash { get; set; }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -182,6 +182,7 @@ builder.Services.AddSpaStaticFiles(opts => opts.RootPath = "wwwroot");
 var app = builder.Build();
 
 await EnsureRolesAsync(app.Services);
+await SubscriptionPlanSeeder.EnsureDefaultPlansAsync(app.Services);
 
 // (пропущена инициализация ролей и IndexNow для краткости)
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -71,7 +71,13 @@
   "YooMoney": {
     "ClientId": "your-client-id",
     "AccessToken": "your-access-token",
-    "RedirectUri": "https://stockchart.ru/admin/yandexget"
+    "RedirectUri": "https://stockchart.ru/admin/yandexget",
+    "Receiver": "41001111222333",
+    "QuickpayForm": "shop",
+    "PaymentType": "AC",
+    "SuccessUrl": "https://stockchart.ru/billing",
+    "FailUrl": "https://stockchart.ru/billing?status=failed",
+    "NotificationSecret": "your-notification-secret"
   },
 
   "AllowedHosts": "*"

--- a/models/DTO/PaymentDtos.cs
+++ b/models/DTO/PaymentDtos.cs
@@ -1,0 +1,61 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using YandexSpeech.models.DB;
+
+namespace YandexSpeech.models.DTO
+{
+    public class SubscriptionPlanDto
+    {
+        public Guid Id { get; set; }
+
+        public string Code { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        public SubscriptionBillingPeriod BillingPeriod { get; set; }
+
+        public decimal Price { get; set; }
+
+        public string Currency { get; set; } = "RUB";
+
+        public int? MaxRecognitionsPerDay { get; set; }
+
+        public bool CanHideCaptions { get; set; }
+
+        public bool IsUnlimitedRecognitions { get; set; }
+
+        public bool IsLifetime { get; set; }
+    }
+
+    public class PaymentInitResponse
+    {
+        public Guid OperationId { get; set; }
+
+        public string PaymentUrl { get; set; } = string.Empty;
+    }
+
+    public class CreateSubscriptionPaymentRequest
+    {
+        [Required]
+        [MaxLength(64)]
+        public string PlanCode { get; set; } = string.Empty;
+    }
+
+    public class CreateWalletDepositRequest
+    {
+        [Range(1, 1_000_000)]
+        public decimal Amount { get; set; }
+
+        [MaxLength(256)]
+        public string? Comment { get; set; }
+    }
+
+    public class WalletBalanceDto
+    {
+        public decimal Balance { get; set; }
+
+        public string Currency { get; set; } = "RUB";
+    }
+}

--- a/services/SubscriptionPlanSeeder.cs
+++ b/services/SubscriptionPlanSeeder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using YandexSpeech.models.DB;
+
+namespace YandexSpeech.services
+{
+    public static class SubscriptionPlanSeeder
+    {
+        private sealed record PlanSeed(
+            string Code,
+            string Name,
+            string Description,
+            SubscriptionBillingPeriod Period,
+            decimal Price,
+            bool CanHideCaptions,
+            bool IsUnlimitedRecognitions,
+            int Priority);
+
+        private static readonly IReadOnlyList<PlanSeed> DefaultPlans = new List<PlanSeed>
+        {
+            new(
+                Code: "hide_videos",
+                Name: "Скрыть мои видео",
+                Description: "Пожизненная подписка, позволяющая скрывать собственные ролики в общем списке.",
+                Period: SubscriptionBillingPeriod.Lifetime,
+                Price: 1490m,
+                CanHideCaptions: true,
+                IsUnlimitedRecognitions: false,
+                Priority: 10),
+            new(
+                Code: "recognition_unlimited_month",
+                Name: "Без ограничений на распознавание (1 месяц)",
+                Description: "Снимает дневные ограничения на распознавание на один месяц.",
+                Period: SubscriptionBillingPeriod.Monthly,
+                Price: 890m,
+                CanHideCaptions: false,
+                IsUnlimitedRecognitions: true,
+                Priority: 20),
+            new(
+                Code: "recognition_unlimited_year",
+                Name: "Без ограничений на распознавание (1 год)",
+                Description: "Снимает дневные ограничения на распознавание на один год.",
+                Period: SubscriptionBillingPeriod.Yearly,
+                Price: 8990m,
+                CanHideCaptions: false,
+                IsUnlimitedRecognitions: true,
+                Priority: 30)
+        };
+
+        public static async Task EnsureDefaultPlansAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        {
+            await using var scope = services.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<MyDbContext>();
+            var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("SubscriptionPlanSeeder");
+
+            foreach (var seed in DefaultPlans)
+            {
+                var plan = await dbContext.SubscriptionPlans
+                    .FirstOrDefaultAsync(p => p.Code == seed.Code, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (plan == null)
+                {
+                    plan = new SubscriptionPlan
+                    {
+                        Id = Guid.NewGuid(),
+                        Code = seed.Code,
+                        CreatedAt = DateTime.UtcNow
+                    };
+                    dbContext.SubscriptionPlans.Add(plan);
+                    logger.LogInformation("Created subscription plan {Code}", seed.Code);
+                }
+
+                plan.Name = seed.Name;
+                plan.Description = seed.Description;
+                plan.BillingPeriod = seed.Period;
+                plan.Price = seed.Price;
+                plan.Currency = "RUB";
+                plan.CanHideCaptions = seed.CanHideCaptions;
+                plan.IsUnlimitedRecognitions = seed.IsUnlimitedRecognitions;
+                plan.Priority = seed.Priority;
+                plan.IsActive = true;
+                plan.UpdatedAt = DateTime.UtcNow;
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/services/YooMoneyRepository.cs
+++ b/services/YooMoneyRepository.cs
@@ -17,6 +17,18 @@ namespace YandexSpeech.services
         public string? AccessToken { get; set; }
 
         public string? RedirectUri { get; set; }
+
+        public string? Receiver { get; set; }
+
+        public string QuickpayForm { get; set; } = "shop";
+
+        public string PaymentType { get; set; } = "AC";
+
+        public string? SuccessUrl { get; set; }
+
+        public string? FailUrl { get; set; }
+
+        public string? NotificationSecret { get; set; }
     }
 
     public class YooMoneyRepository : IYooMoneyRepository


### PR DESCRIPTION
## Summary
- add a payments API controller that exposes YooMoney checkout links, validates notifications, and credits subscriptions or wallet balances
- seed default subscription plans and extend the YooMoney options/configuration to support quickpay parameters
- build a billing screen in the Angular client with a payments service, wallet top-up form, and navigation entry

## Testing
- dotnet build *(fails: dotnet not installed in container)*
- npm run lint *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d6319b283c8331ad69296b349eb719