### PR TITLE
Add billing route and guard

### DIFF
--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -3,12 +3,15 @@ import { RouterModule, Routes } from '@angular/router';
 import { YoutubeDownloaderComponent } from './youtube-downloader/youtube-downloader.component';
 import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
+import { BillingComponent } from './billing/billing.component';
+import { AuthGuard } from './services/auth.guard';
 
 const routes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
+  { path: 'billing', component: BillingComponent, canActivate: [AuthGuard] },
 ];
 
 @NgModule({

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -4,6 +4,8 @@ import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks
 import { SubtitlesTasksComponent } from './subtitles-task/subtitles-tasks.component';
 import { MarkdownConverterComponent } from './Markdown-converter/markdown-converter.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
+import { BillingComponent } from './billing/billing.component';
+import { AuthGuard } from './services/auth.guard';
 
 export const appRoutes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
@@ -11,5 +13,6 @@ export const appRoutes: Routes = [
   { path: 'recognition-tasks', component: SubtitlesTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
+  { path: 'billing', component: BillingComponent, canActivate: [AuthGuard] },
 
 ];


### PR DESCRIPTION
## Summary
- expose the billing component via the Angular router
- protect the billing route with the existing authentication guard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63718fdd08331a5ebd7152595e5a5