### PR TITLE
Fix billing plan card sizing

### DIFF
--- a/Angular/youtube-downloader/src/app/billing/billing.component.css
+++ b/Angular/youtube-downloader/src/app/billing/billing.component.css
@@ -35,8 +35,27 @@
 
 .plans__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 24px;
+}
+
+.plan-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 420px;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.plan-card mat-card-header {
+  margin-bottom: 16px;
+}
+
+.plan-card mat-card-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .plan-card__price {
@@ -48,6 +67,10 @@
 .plan-card__description {
   min-height: 48px;
   color: rgba(0, 0, 0, 0.7);
+}
+
+.plan-card mat-card-actions {
+  margin-top: auto;
 }
 
 .loading {


### PR DESCRIPTION
## Summary
- make billing subscription cards wider with a fixed minimum height so descriptions no longer affect layout
- use flexbox inside the cards to keep content evenly spaced and align the action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d654ae21c48331ad0ced700d24b8d1