### PR TITLE
Fix navigation mapping for payment and recognition usage

### DIFF
--- a/dbcontext.cs
+++ b/dbcontext.cs
@@ -136,7 +136,7 @@ namespace YandexSpeech
                 .HasPrecision(18, 2);
 
             builder.Entity<PaymentOperation>()
-                .HasOne<ApplicationUser>()
+                .HasOne(p => p.User)
                 .WithMany()
                 .HasForeignKey(p => p.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
@@ -150,7 +150,7 @@ namespace YandexSpeech
                 .IsUnique();
 
             builder.Entity<RecognitionUsage>()
-                .HasOne<ApplicationUser>()
+                .HasOne(r => r.User)
                 .WithMany()
                 .HasForeignKey(r => r.UserId)
                 .OnDelete(DeleteBehavior.Cascade);


### PR DESCRIPTION
## Summary
- map PaymentOperation.User navigation explicitly to prevent shadow FK creation
- map RecognitionUsage.User navigation explicitly to avoid duplicate foreign key columns

## Testing
- not run (dotnet CLI unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d664a2ca5483318899a1cf41c8e721