### PR TITLE
Remove redundant shadow user navigation columns

### DIFF
--- a/Migrations/20260205000000_RemoveShadowUserColumns.cs
+++ b/Migrations/20260205000000_RemoveShadowUserColumns.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace YandexSpeech.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveShadowUserColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PaymentOperations_AspNetUsers_UserId1",
+                table: "PaymentOperations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RecognitionUsage_AspNetUsers_UserId1",
+                table: "RecognitionUsage");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PaymentOperations_UserId1",
+                table: "PaymentOperations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RecognitionUsage_UserId1",
+                table: "RecognitionUsage");
+
+            migrationBuilder.DropColumn(
+                name: "UserId1",
+                table: "PaymentOperations");
+
+            migrationBuilder.DropColumn(
+                name: "UserId1",
+                table: "RecognitionUsage");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UserId1",
+                table: "RecognitionUsage",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UserId1",
+                table: "PaymentOperations",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentOperations_UserId1",
+                table: "PaymentOperations",
+                column: "UserId1");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecognitionUsage_UserId1",
+                table: "RecognitionUsage",
+                column: "UserId1");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PaymentOperations_AspNetUsers_UserId1",
+                table: "PaymentOperations",
+                column: "UserId1",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RecognitionUsage_AspNetUsers_UserId1",
+                table: "RecognitionUsage",
+                column: "UserId1",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Migrations/MyDbContextModelSnapshot.cs
+++ b/Migrations/MyDbContextModelSnapshot.cs
@@ -613,17 +613,12 @@ namespace YandexSpeech.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("UserId1")
-                        .HasColumnType("nvarchar(450)");
-
                     b.Property<Guid?>("WalletTransactionId")
                         .HasColumnType("uniqueidentifier");
 
                     b.HasKey("Id");
 
                     b.HasIndex("UserId");
-
-                    b.HasIndex("UserId1");
 
                     b.ToTable("PaymentOperations");
                 });
@@ -656,15 +651,10 @@ namespace YandexSpeech.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("UserId1")
-                        .HasColumnType("nvarchar(450)");
-
                     b.Property<Guid?>("WalletTransactionId")
                         .HasColumnType("uniqueidentifier");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("UserId1");
 
                     b.HasIndex("UserId", "Date")
                         .IsUnique();
@@ -1486,30 +1476,22 @@ namespace YandexSpeech.Migrations
 
             modelBuilder.Entity("YandexSpeech.models.DB.PaymentOperation", b =>
                 {
-                    b.HasOne("YandexSpeech.models.DB.ApplicationUser", null)
+                    b.HasOne("YandexSpeech.models.DB.ApplicationUser", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.HasOne("YandexSpeech.models.DB.ApplicationUser", "User")
-                        .WithMany()
-                        .HasForeignKey("UserId1");
 
                     b.Navigation("User");
                 });
 
             modelBuilder.Entity("YandexSpeech.models.DB.RecognitionUsage", b =>
                 {
-                    b.HasOne("YandexSpeech.models.DB.ApplicationUser", null)
+                    b.HasOne("YandexSpeech.models.DB.ApplicationUser", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.HasOne("YandexSpeech.models.DB.ApplicationUser", "User")
-                        .WithMany()
-                        .HasForeignKey("UserId1");
 
                     b.Navigation("User");
                 });


### PR DESCRIPTION
## Summary
- drop the legacy `UserId1` columns, indexes, and foreign keys from `PaymentOperations` and `RecognitionUsage`
- update the model snapshot so the EF model only uses the primary `UserId` relationship

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d665653d9c8331a39d227847c1facd