### PR TITLE
Make FasterWhisper decoding parameters configurable

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -22,7 +22,12 @@
     "ExecutablePath": "faster-whisper",
     "Model": "medium",
     "Device": "cuda",
-    "ComputeType": "float16"
+    "ComputeType": "float16",
+    "Temperatures": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+    "CompressionRatioThreshold": 2.4,
+    "LogProbThreshold": -1.0,
+    "NoSpeechThreshold": 0.6,
+    "ConditionOnPreviousText": true
   },
 
   "FfmpegExePath": "C:\\Documents and Settings\\user\\AppData\\Local\\Programs\\FFmpeg\\bin\\",


### PR DESCRIPTION
## Summary
- add configuration-backed decoding settings for the FasterWhisper transcription service
- propagate the configured temperatures and thresholds into the generated Python runner script
- document default decoding parameters in `appsettings.json` for easier tuning

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6ceff9d308331b5fbb53e7146044b