### PR TITLE
Fix log prob threshold argument name in FasterWhisper runner

### DIFF
--- a/services/Whisper/FasterWhisperTranscriptionService.cs
+++ b/services/Whisper/FasterWhisperTranscriptionService.cs
@@ -463,7 +463,7 @@ def main():
             beam_size=5,
             temperature=__TEMPERATURE__,
             compression_ratio_threshold=__COMPRESSION_RATIO_THRESHOLD__,
-            logprob_threshold=__LOGPROB_THRESHOLD__,
+            log_prob_threshold=__LOGPROB_THRESHOLD__,
             no_speech_threshold=__NO_SPEECH_THRESHOLD__,
             condition_on_previous_text=__CONDITION_ON_PREVIOUS_TEXT__,
             without_timestamps=False  # нужны таймкоды сегментов


### PR DESCRIPTION
## Summary
- update the embedded fw_runner.py template to pass the correct log_prob_threshold keyword

## Testing
- dotnet build *(fails: command not found dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d1d0b34083318f0d91395f1a2fb6