### PR TITLE
Use bundled YoutubeExplode binary

### DIFF
--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -35,7 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\YoutubeExplode-master\YoutubeExplode\YoutubeExplode.csproj" />
+    <Reference Include="YoutubeExplode">
+      <HintPath>YTExpl/YoutubeExplode.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <PropertyGroup>
     <AngularProjectDir>$(MSBuildProjectDirectory)/Angular/youtube-downloader/</AngularProjectDir>

--- a/YandexSpeech.sln
+++ b/YandexSpeech.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YandexSpeech", "YandexSpeec
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1F90DCE8-E867-4179-8428-75921A237B2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeExplode", "..\..\YoutubeExplode-master\YoutubeExplode\YoutubeExplode.csproj", "{42830168-32DE-4B24-A577-97EB3892AD80}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YandexSpeech.Tests", "tests\YandexSpeech.Tests\YandexSpeech.Tests.csproj", "{CD64ABB5-142E-4B4A-9AD9-FEE44398BD59}"
 EndProject
 Global
@@ -21,10 +19,6 @@ Global
 		{ECBB67C5-E865-4746-A686-44E1131DF69D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ECBB67C5-E865-4746-A686-44E1131DF69D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ECBB67C5-E865-4746-A686-44E1131DF69D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{42830168-32DE-4B24-A577-97EB3892AD80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{42830168-32DE-4B24-A577-97EB3892AD80}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{42830168-32DE-4B24-A577-97EB3892AD80}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{42830168-32DE-4B24-A577-97EB3892AD80}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CD64ABB5-142E-4B4A-9AD9-FEE44398BD59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CD64ABB5-142E-4B4A-9AD9-FEE44398BD59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CD64ABB5-142E-4B4A-9AD9-FEE44398BD59}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
## Summary
- replace the external YoutubeExplode project reference with the in-repo DLL
- remove the YoutubeExplode project entry from the solution so MSBuild only expects tracked projects

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e24c85c883318e845b411f5c23fe