### PR TITLE
Fix FasterWhisper queue client accessibility

### DIFF
--- a/services/Whisper/FasterWhisperQueueClient.cs
+++ b/services/Whisper/FasterWhisperQueueClient.cs
@@ -12,7 +12,7 @@ using YandexSpeech.services.Options;
 
 namespace YandexSpeech.services.Whisper
 {
-    internal sealed class FasterWhisperQueueClient : IAsyncDisposable
+    public sealed class FasterWhisperQueueClient : IAsyncDisposable
     {
         private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 


### PR DESCRIPTION
## Summary
- change `FasterWhisperQueueClient` to be public so it can be injected into the public transcription service constructor

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80551996c83318d52f67ad0acf696