### PR TITLE
Fix FasterWhisper accessibility and migration naming

### DIFF
--- a/Migrations/20250923131200_recogn.Designer.cs
+++ b/Migrations/20250923131200_recogn.Designer.cs
@@ -13,7 +13,7 @@ namespace YandexSpeech.Migrations
 {
     [DbContext(typeof(MyDbContext))]
     [Migration("20250923131200_recogn")]
-    partial class recogn
+    partial class Recogn
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/Migrations/20250923131200_recogn.cs
+++ b/Migrations/20250923131200_recogn.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace YandexSpeech.Migrations
 {
     /// <inheritdoc />
-    public partial class recogn : Migration
+    public partial class Recogn : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/services/Whisper/FasterWhisperQueueClient.cs
+++ b/services/Whisper/FasterWhisperQueueClient.cs
@@ -139,7 +139,7 @@ namespace YandexSpeech.services.Whisper
         }
     }
 
-    internal sealed record FasterWhisperQueueRequest
+    public sealed record FasterWhisperQueueRequest
     {
         public string Audio { get; init; } = string.Empty;
         public string Model { get; init; } = string.Empty;
@@ -154,7 +154,7 @@ namespace YandexSpeech.services.Whisper
         public string? FfmpegExecutable { get; init; }
     }
 
-    internal sealed class FasterWhisperQueueResponse
+    public sealed class FasterWhisperQueueResponse
     {
         public bool Success { get; set; }
         public string? Error { get; set; }


### PR DESCRIPTION
## Summary
- expose the FasterWhisper queue request and response types so the public client method compiles
- rename the Recogn migration class to use PascalCase and silence the lowercase identifier warning

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d8084481a8833189df118d0e075155