### PR TITLE
Ensure OpenAI transcription workflow completes

### DIFF
--- a/tests/YandexSpeech.Tests/YandexSpeech.Tests.csproj
+++ b/tests/YandexSpeech.Tests/YandexSpeech.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- replace the guarded loop in `ContinueTranscriptionAsync` with a status-driven workflow that keeps executing steps until the transcription task completes or errors
- add an infinite loop safety check and make the formatting helper overridable for tests
- add EF Core InMemory to the test project and cover a multi-segment transcription progressing through formatting to Done

## Testing
- dotnet test *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e03690788331ac695315da07a59c