### PR TITLE
Add support for external transcription uploads

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -18,6 +18,28 @@
   align-items: center;
 }
 
+.link-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.link-input-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.link-input-row input {
+  flex: 1 1 260px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  font-family: inherit;
+}
+
 .clarification-field {
   display: flex;
   flex-direction: column;

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -2,7 +2,8 @@
   <mat-card class="upload-card">
     <h2>Новая расшифровка</h2>
     <p class="upload-hint">
-      Загрузите аудио или видео файл, чтобы отправить его в обработку через OpenAI.
+      Загрузите аудио или видео файл с компьютера или укажите прямую ссылку (Яндекс.Диск и т.д.),
+      чтобы отправить его в обработку через OpenAI.
     </p>
     <div class="upload-controls">
       <input
@@ -19,6 +20,27 @@
         <mat-icon>cloud_upload</mat-icon>
         <span>Отправить</span>
       </button>
+    </div>
+    <div class="link-upload">
+      <label class="clarification-label" for="file-url-input">Или вставьте ссылку на файл</label>
+      <div class="link-input-row">
+        <input
+          id="file-url-input"
+          type="url"
+          [(ngModel)]="fileUrl"
+          [ngModelOptions]="{ standalone: true }"
+          placeholder="https://disk.yandex.ru/i/..."
+        />
+        <button
+          mat-stroked-button
+          color="primary"
+          (click)="uploadFromUrl()"
+          [disabled]="!fileUrl || !fileUrl.trim() || uploading"
+        >
+          <mat-icon>link</mat-icon>
+          <span>Загрузить по ссылке</span>
+        </button>
+      </div>
     </div>
     <div class="clarification-field">
       <label class="clarification-label" for="clarification-input"

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -77,6 +77,15 @@ export class OpenAiTranscriptionService {
     return this.http.post<OpenAiTranscriptionTaskDto>(this.apiUrl, formData);
   }
 
+  uploadFromUrl(fileUrl: string, clarification?: string | null): Observable<OpenAiTranscriptionTaskDto> {
+    const formData = new FormData();
+    formData.append('fileUrl', fileUrl);
+    if (clarification && clarification.trim().length > 0) {
+      formData.append('clarification', clarification.trim());
+    }
+    return this.http.post<OpenAiTranscriptionTaskDto>(this.apiUrl, formData);
+  }
+
   list(): Observable<OpenAiTranscriptionTaskDto[]> {
     return this.http.get<OpenAiTranscriptionTaskDto[]>(this.apiUrl);
   }

--- a/Program.cs
+++ b/Program.cs
@@ -51,6 +51,9 @@ builder.Services.AddCors(opts =>
 // 2. Контроллеры
 builder.Services.AddControllers();
 
+// Общий HttpClient для внешних запросов
+builder.Services.AddHttpClient();
+
 // 3. DbContext
 var conn = builder.Configuration.GetConnectionString("DefaultConnection")
            ?? throw new InvalidOperationException("DefaultConnection not found");


### PR DESCRIPTION
## Summary
- allow the OpenAI transcription API to accept either uploaded files or external URLs and download remote sources
- register a shared HTTP client for remote downloads and add helper utilities for file name resolution
- update the Angular transcription UI and service to submit URL-based uploads alongside local file uploads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90acdf004833185e80f853dc0ca03