### PR TITLE
Improve completed transcription result view

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -152,6 +152,7 @@
   color: rgba(0, 0, 0, 0.6);
 }
 
+
 .details-actions {
   display: flex;
   align-items: center;
@@ -198,6 +199,35 @@
   background-color: rgba(244, 67, 54, 0.08);
 }
 
+.result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: 12px;
+}
+
+.markdown-content {
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+  overflow-x: auto;
+  max-height: 60vh;
+}
+
+.markdown-content :is(p, ul, ol, pre, blockquote, h1, h2, h3, h4, h5, h6) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.markdown-content pre {
+  background: rgba(0, 0, 0, 0.04);
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
 .step-icon {
   font-size: 24px;
 }
@@ -233,11 +263,6 @@
   overflow: auto;
 }
 
-.result-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 12px;
-}
 
 .tasks-card a.active {
   background: rgba(63, 81, 181, 0.08);

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -111,67 +111,128 @@
             <span>{{ selectedTask.clarification }}</span>
           </div>
 
-          <div class="error" *ngIf="selectedTask.error">{{ selectedTask.error }}</div>
-
-          <div
-            class="details-actions"
-            *ngIf="selectedTask.status === OpenAiTranscriptionStatus.Error"
-          >
-            <button
-              mat-stroked-button
-              color="primary"
-              (click)="continueTask()"
-              [disabled]="continueInProgress"
-            >
-              <mat-icon>play_arrow</mat-icon>
-              <span>Продолжить задачу</span>
-            </button>
-            <mat-progress-spinner
-              *ngIf="continueInProgress"
-              class="inline-spinner"
-              mode="indeterminate"
-              diameter="28"
-            ></mat-progress-spinner>
+          <div class="error" *ngIf="selectedTask.error && !isTaskCompleted(selectedTask)">
+            {{ selectedTask.error }}
           </div>
 
-          <div class="error" *ngIf="continueError">{{ continueError }}</div>
+          <ng-container *ngIf="isTaskCompleted(selectedTask); else processingView">
+            <section class="result-block">
+              <h3>Результат</h3>
+              <div class="result-actions">
+                <button
+                  mat-stroked-button
+                  color="primary"
+                  [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
+                >
+                  <mat-icon>edit</mat-icon>
+                  <span>Редактировать</span>
+                </button>
+                <button
+                  mat-stroked-button
+                  color="primary"
+                  (click)="exportDocx()"
+                  [disabled]="exportingDocx"
+                >
+                  <mat-icon>description</mat-icon>
+                  <span>Word</span>
+                </button>
+                <button
+                  mat-stroked-button
+                  color="primary"
+                  (click)="exportPdf()"
+                  [disabled]="exportingPdf"
+                >
+                  <mat-icon>picture_as_pdf</mat-icon>
+                  <span>PDF</span>
+                </button>
+                <button
+                  mat-stroked-button
+                  color="primary"
+                  (click)="downloadMarkdown()"
+                  [disabled]="!hasMarkdown()"
+                >
+                  <mat-icon>code</mat-icon>
+                  <span>Markdown</span>
+                </button>
+                <button
+                  mat-stroked-button
+                  color="primary"
+                  (click)="downloadSrt()"
+                  [disabled]="!canDownloadSrt()"
+                >
+                  <mat-icon>subtitles</mat-icon>
+                  <span>SRT</span>
+                </button>
+              </div>
+              <div class="error" *ngIf="exportError">{{ exportError }}</div>
+              <div
+                class="markdown-content"
+                *ngIf="renderedMarkdown; else plainResult"
+                [innerHTML]="renderedMarkdown"
+              ></div>
+              <ng-template #plainResult>
+                <pre *ngIf="hasMarkdown(); else recognizedFallback">{{ markdownContent }}</pre>
+              </ng-template>
+              <ng-template #recognizedFallback>
+                <pre *ngIf="selectedTask.recognizedText; else emptyResult">{{ selectedTask.recognizedText }}</pre>
+              </ng-template>
+              <ng-template #emptyResult>
+                <div class="empty-state">Результат пока недоступен.</div>
+              </ng-template>
+            </section>
+          </ng-container>
 
-          <section class="steps-section" *ngIf="selectedTask.steps.length">
-            <h3>Прогресс</h3>
-            <ul class="steps-list">
-              <li *ngFor="let step of selectedTask.steps; trackBy: trackStep" [class]="getStepClass(step.status)">
-                <mat-icon class="step-icon">{{ getStepIcon(step.status) }}</mat-icon>
-                <div class="step-info">
-                  <div class="step-title">{{ getStatusText(step.step) }}</div>
-                  <div class="step-meta">
-                    <span>{{ getStepStatusText(step.status) }}</span>
-                    <span *ngIf="step.startedAt">· {{ step.startedAt | localTime }}</span>
-                  </div>
-                  <div class="step-error" *ngIf="step.error">{{ step.error }}</div>
-                </div>
-              </li>
-            </ul>
-          </section>
-
-          <section class="result-block" *ngIf="selectedTask.recognizedText">
-            <h3>Распознанный текст</h3>
-            <pre>{{ selectedTask.recognizedText }}</pre>
-          </section>
-
-          <section class="result-block" *ngIf="selectedTask.markdownText">
-            <h3>Форматированный Markdown</h3>
-            <div class="result-actions">
+          <ng-template #processingView>
+            <div
+              class="details-actions"
+              *ngIf="selectedTask.status === OpenAiTranscriptionStatus.Error"
+            >
               <button
                 mat-stroked-button
                 color="primary"
-                [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
+                (click)="continueTask()"
+                [disabled]="continueInProgress"
               >
-                <mat-icon>edit</mat-icon>
-                <span>Редактировать</span>
+                <mat-icon>play_arrow</mat-icon>
+                <span>Продолжить задачу</span>
               </button>
+              <mat-progress-spinner
+                *ngIf="continueInProgress"
+                class="inline-spinner"
+                mode="indeterminate"
+                diameter="28"
+              ></mat-progress-spinner>
             </div>
-            <pre>{{ selectedTask.markdownText }}</pre>
-          </section>
+
+            <div class="error" *ngIf="continueError">{{ continueError }}</div>
+
+            <section class="steps-section" *ngIf="selectedTask.steps.length">
+              <h3>Прогресс</h3>
+              <ul class="steps-list">
+                <li *ngFor="let step of selectedTask.steps; trackBy: trackStep" [class]="getStepClass(step.status)">
+                  <mat-icon class="step-icon">{{ getStepIcon(step.status) }}</mat-icon>
+                  <div class="step-info">
+                    <div class="step-title">{{ getStatusText(step.step) }}</div>
+                    <div class="step-meta">
+                      <span>{{ getStepStatusText(step.status) }}</span>
+                      <span *ngIf="step.startedAt">· {{ step.startedAt | localTime }}</span>
+                    </div>
+                    <div class="step-error" *ngIf="step.error">{{ step.error }}</div>
+                  </div>
+                </li>
+              </ul>
+            </section>
+
+            <section class="result-block" *ngIf="selectedTask.recognizedText">
+              <h3>Распознанный текст</h3>
+              <pre>{{ selectedTask.recognizedText }}</pre>
+            </section>
+
+            <section class="result-block" *ngIf="selectedTask.markdownText">
+              <h3>Форматированный Markdown</h3>
+              <pre>{{ selectedTask.markdownText }}</pre>
+            </section>
+          </ng-template>
         </ng-container>
       </ng-template>
 


### PR DESCRIPTION
## Summary
- hide processing details for completed OpenAI transcription tasks and render the final markdown using the shared renderer
- add export actions for DOCX, PDF, Markdown, and SRT alongside the edit shortcut
- enhance styling for the rendered result block and ensure graceful fallbacks when no formatted text exists

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d914bbb22c8331a9d97aab7f1750fd