### PR TITLE
Add server-side SRT export for OpenAI transcriptions

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -158,7 +158,7 @@
                   mat-stroked-button
                   color="primary"
                   (click)="downloadSrt()"
-                  [disabled]="!canDownloadSrt()"
+                  [disabled]="!canDownloadSrt() || downloadingSrt"
                 >
                   <mat-icon>subtitles</mat-icon>
                   <span>SRT</span>

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -38,6 +38,7 @@ export interface OpenAiTranscriptionTaskDetailsDto extends OpenAiTranscriptionTa
   recognizedText: string | null;
   processedText: string | null;
   markdownText: string | null;
+  hasSegments: boolean;
   steps: OpenAiTranscriptionStepDto[];
   segments: OpenAiRecognizedSegmentDto[];
 }
@@ -108,6 +109,10 @@ export class OpenAiTranscriptionService {
 
   exportDocx(id: string): Observable<Blob> {
     return this.http.get(`${this.apiUrl}/${id}/export/docx`, { responseType: 'blob' });
+  }
+
+  exportSrt(id: string): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/${id}/export/srt`, { responseType: 'blob' });
   }
 
   exportBbcode(id: string): Observable<string> {

--- a/models/DTO/OpenAiTranscriptionDtos.cs
+++ b/models/DTO/OpenAiTranscriptionDtos.cs
@@ -38,6 +38,8 @@ namespace YandexSpeech.models.DTO
 
         public string? MarkdownText { get; set; }
 
+        public bool HasSegments { get; set; }
+
         public IReadOnlyList<OpenAiTranscriptionStepDto> Steps { get; set; }
             = Array.Empty<OpenAiTranscriptionStepDto>();
 

--- a/services/SrtFormatter.cs
+++ b/services/SrtFormatter.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace YandexSpeech.services
+{
+    internal static class SrtFormatter
+    {
+        internal sealed class SrtEntry
+        {
+            public TimeSpan Start { get; init; }
+            public TimeSpan? End { get; init; }
+            public string Text { get; init; } = string.Empty;
+        }
+
+        public static string Build(IEnumerable<SrtEntry> entries)
+        {
+            if (entries == null)
+            {
+                return string.Empty;
+            }
+
+            var ordered = entries
+                .Where(entry => entry != null)
+                .Select(entry => new SrtEntry
+                {
+                    Start = entry.Start < TimeSpan.Zero ? TimeSpan.Zero : entry.Start,
+                    End = entry.End,
+                    Text = (entry.Text ?? string.Empty).Replace("\r", string.Empty).Trim()
+                })
+                .OrderBy(entry => entry.Start)
+                .ToList();
+
+            if (ordered.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder();
+            var index = 1;
+
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var current = ordered[i];
+                if (string.IsNullOrWhiteSpace(current.Text) || current.Text == "\\n" || current.Text == "\n")
+                {
+                    continue;
+                }
+
+                var start = current.Start;
+                var end = current.End ?? FindNextStart(ordered, i) - TimeSpan.FromMilliseconds(1);
+                if (end <= start)
+                {
+                    end = start + TimeSpan.FromMilliseconds(500);
+                }
+
+                builder.AppendLine(index.ToString());
+                builder.AppendLine($"{FormatTimestamp(start)} --> {FormatTimestamp(end)}");
+                builder.AppendLine(current.Text);
+                builder.AppendLine();
+
+                index++;
+            }
+
+            return builder.ToString();
+        }
+
+        private static TimeSpan FindNextStart(IReadOnlyList<SrtEntry> entries, int index)
+        {
+            for (var i = index + 1; i < entries.Count; i++)
+            {
+                var text = entries[i].Text;
+                if (!string.IsNullOrWhiteSpace(text) && text != "\\n" && text != "\n")
+                {
+                    return entries[i].Start;
+                }
+            }
+
+            return entries[index].Start + TimeSpan.FromSeconds(2);
+        }
+
+        private static string FormatTimestamp(TimeSpan time)
+        {
+            return $"{(int)time.TotalHours:00}:{time.Minutes:00}:{time.Seconds:00},{time.Milliseconds:000}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an API endpoint that builds SRT files from stored Whisper segments and expose the capability in the transcription DTOs
- reuse a shared SRT formatter for both transcription exports and existing YouTube subtitle generation
- update the Angular transcription screen to call the server-side exporter and handle the download state

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9197e1a188331909eca0a0abf5309