### PR TITLE
Arrange transcription panels side by side

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -226,3 +226,17 @@ pre {
     align-items: stretch;
   }
 }
+
+@media (min-width: 960px) {
+  .layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .tasks-card,
+  .details-card,
+  .empty-details {
+    height: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a wide-screen layout that places the transcription list and details cards side by side
- ensure the cards stretch to match the split layout while retaining the stacked mobile experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d922ca2bb883319f99326256bb582b