### PR TITLE
Adjust transcription upload button placement and text styling

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -8,13 +8,6 @@
 .upload-card {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-}
-
-.upload-card-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
   gap: 16px;
 }
 
@@ -22,6 +15,11 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.upload-actions {
+  display: flex;
+  justify-content: flex-start;
 }
 
 .upload-card-text h2 {
@@ -202,25 +200,21 @@
 }
 
 .markdown-content {
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   padding: 16px;
-  background-color: rgba(0, 0, 0, 0.02);
+  background-color: transparent;
 }
 
 pre {
-  background: rgba(0, 0, 0, 0.02);
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.12);
   padding: 16px;
   border-radius: 8px;
   overflow-x: auto;
 }
 
 @media (max-width: 768px) {
-  .upload-card-header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .result-actions {
     flex-direction: column;
     align-items: stretch;

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -1,13 +1,13 @@
 <div class="transcription-page">
   <mat-card class="upload-card">
-    <div class="upload-card-header">
-      <div class="upload-card-text">
-        <h2>Новая расшифровка</h2>
-        <p class="upload-hint">
-          Загрузите аудио или видео файл с компьютера или укажите прямую ссылку (Яндекс.Диск и т.д.),
-          чтобы отправить его в обработку через OpenAI.
-        </p>
-      </div>
+    <div class="upload-card-text">
+      <h2>Новая расшифровка</h2>
+      <p class="upload-hint">
+        Загрузите аудио или видео файл с компьютера или укажите прямую ссылку (Яндекс.Диск и т.д.),
+        чтобы отправить его в обработку через OpenAI.
+      </p>
+    </div>
+    <div class="upload-actions">
       <button mat-raised-button color="primary" (click)="openUploadDialog()" [disabled]="uploading">
         <mat-icon>cloud_upload</mat-icon>
         <span>Загрузить</span>


### PR DESCRIPTION
## Summary
- move the transcription upload action into its own row beneath the description for better layout balance
- restyle the transcription result container with a transparent background and subtle border to match the panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d924af28048331b8ae1203ae4de945