### PR TITLE
Refactor About3Component into Angular template

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -1,7 +1,652 @@
 :host {
   display: block;
+  color: #0b1f33;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  background: linear-gradient(180deg, #0a1f44 0%, #0e325d 35%, #ffffff 100%);
 }
 
-app-about3 {
-  display: block;
+.about3-page {
+  min-height: 100vh;
+}
+
+.page-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(6, 20, 48, 0.92);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px 32px;
+  gap: 24px;
+  color: #f4f9ff;
+}
+
+.logo-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.logo-group img {
+  width: 44px;
+  height: 44px;
+}
+
+.brand-name {
+  font-size: 1.1rem;
+}
+
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-size: 0.95rem;
+}
+
+.header-nav a {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+}
+
+.header-nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 2px;
+  background: transparent;
+  transition: background 0.2s ease;
+}
+
+.header-nav a:hover::after {
+  background: #66d4ff;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(46, 130, 255, 0.35);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(46, 130, 255, 0.45);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: #f4f9ff;
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateY(-2px);
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 120px;
+  padding: 80px 32px 160px;
+}
+
+section {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: center;
+  color: #f4f9ff;
+}
+
+.hero-text h1 {
+  font-size: 3rem;
+  line-height: 1.15;
+  margin-bottom: 24px;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 24px;
+  max-width: 560px;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 32px;
+  display: grid;
+  gap: 12px;
+}
+
+.hero-highlights li {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 12px 18px;
+  font-weight: 500;
+}
+
+.hero-card {
+  background: rgba(9, 26, 58, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 32px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+}
+
+.card-header {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.card-dropzone {
+  background: rgba(18, 55, 110, 0.85);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px dashed rgba(255, 255, 255, 0.32);
+  text-align: center;
+  display: grid;
+  gap: 12px;
+}
+
+.card-dropzone span {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.card-preview {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+}
+
+.card-preview img {
+  width: min(100%, 320px);
+  border-radius: 16px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+}
+
+.card-preview-caption {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+  text-align: center;
+}
+
+.trusted h2,
+.workflow h2,
+.features h2,
+.teamlogs-advantages h2,
+.business h2,
+.pricing h2,
+.cta h2 {
+  font-size: 2.2rem;
+  margin-bottom: 32px;
+  color: #0b1f33;
+}
+
+.trusted h2,
+.workflow h2,
+.features h2,
+.teamlogs-advantages h2,
+.business h2,
+.pricing h2 {
+  color: #0a1f44;
+}
+
+.trusted {
+  color: #0a1f44;
+}
+
+.logo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 20px;
+}
+
+.logo-card {
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 20px;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 12px 24px rgba(10, 31, 68, 0.12);
+}
+
+.logo-card img {
+  max-width: 120px;
+  max-height: 48px;
+  object-fit: contain;
+}
+
+.workflow {
+  color: #0a1f44;
+}
+
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 28px;
+}
+
+.workflow-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 28px;
+  padding: 28px;
+  display: grid;
+  gap: 16px;
+  box-shadow: 0 20px 40px rgba(10, 31, 68, 0.18);
+}
+
+.workflow-image img {
+  width: 100%;
+  border-radius: 20px;
+}
+
+.workflow-step {
+  font-weight: 600;
+  color: #2a6bff;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.workflow-card h3 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.workflow-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(11, 31, 51, 0.78);
+}
+
+.features {
+  color: #0a1f44;
+}
+
+.features-layout {
+  display: grid;
+  gap: 32px;
+}
+
+.feature-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 40px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 32px;
+  align-items: center;
+  box-shadow: 0 22px 44px rgba(10, 31, 68, 0.18);
+}
+
+.feature-card h3 {
+  font-size: 1.8rem;
+  margin-bottom: 16px;
+}
+
+.feature-card p {
+  line-height: 1.7;
+  color: rgba(11, 31, 51, 0.8);
+}
+
+.feature-card ul {
+  margin: 24px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.feature-card li {
+  position: relative;
+  padding-left: 26px;
+}
+
+.feature-card li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+}
+
+.feature-illustration img {
+  width: 100%;
+  border-radius: 24px;
+  box-shadow: 0 18px 38px rgba(10, 31, 68, 0.2);
+}
+
+.editor-card {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.editor-grid {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.editor-block {
+  background: rgba(10, 31, 68, 0.05);
+  border-radius: 20px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  text-align: center;
+  color: #0a1f44;
+}
+
+.editor-block figcaption {
+  font-weight: 600;
+}
+
+.editor-block img {
+  width: 100%;
+  border-radius: 16px;
+}
+
+.ai-card {
+  background: linear-gradient(135deg, rgba(62, 199, 255, 0.12), rgba(42, 107, 255, 0.12));
+}
+
+.section-header {
+  max-width: 640px;
+  margin-bottom: 32px;
+}
+
+.section-header p {
+  margin: 12px 0 0;
+  line-height: 1.6;
+  color: rgba(11, 31, 51, 0.75);
+}
+
+.advantage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.advantage-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  padding: 28px;
+  display: grid;
+  gap: 16px;
+  text-align: left;
+  box-shadow: 0 18px 36px rgba(10, 31, 68, 0.16);
+}
+
+.advantage-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.advantage-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.business-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 28px;
+}
+
+.business-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(10, 31, 68, 0.18);
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.business-card img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.business-body {
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.business-body h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.business-body p {
+  margin: 0;
+  color: rgba(11, 31, 51, 0.75);
+  line-height: 1.6;
+}
+
+.pricing {
+  background: rgba(255, 255, 255, 0.92);
+  padding: 64px;
+  border-radius: 40px;
+  box-shadow: 0 24px 48px rgba(10, 31, 68, 0.2);
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.pricing-card {
+  background: rgba(10, 31, 68, 0.04);
+  border-radius: 24px;
+  padding: 32px;
+  display: grid;
+  gap: 16px;
+}
+
+.pricing-card h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0a1f44;
+}
+
+.pricing-description {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(11, 31, 51, 0.75);
+}
+
+.pricing-card ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.pricing-card li {
+  position: relative;
+  padding-left: 24px;
+}
+
+.pricing-card li::before {
+  content: '•';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  color: #2a6bff;
+  font-size: 1.2rem;
+}
+
+.pricing-card .btn {
+  justify-self: start;
+  margin-top: 12px;
+}
+
+.cta {
+  color: #0a1f44;
+}
+
+.cta-card {
+  background: linear-gradient(135deg, rgba(62, 199, 255, 0.16), rgba(42, 107, 255, 0.2));
+  border-radius: 40px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 40px;
+  padding: 48px;
+  align-items: center;
+  box-shadow: 0 28px 48px rgba(10, 31, 68, 0.18);
+}
+
+.cta-text h2 {
+  margin-top: 0;
+  color: #0a1f44;
+}
+
+.cta-text p {
+  margin: 16px 0 28px;
+  line-height: 1.7;
+  color: rgba(11, 31, 51, 0.75);
+}
+
+.cta-preview {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 28px;
+  padding: 32px;
+  display: grid;
+  gap: 18px;
+  justify-items: center;
+  text-align: center;
+}
+
+.cta-preview img {
+  width: min(100%, 360px);
+  border-radius: 20px;
+  box-shadow: 0 18px 36px rgba(10, 31, 68, 0.2);
+}
+
+@media (max-width: 1024px) {
+  .page-content {
+    gap: 80px;
+    padding: 64px 24px 120px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .cta-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-content {
+    flex-wrap: wrap;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .header-nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero-text h1 {
+    font-size: 2.4rem;
+  }
+
+  .feature-card {
+    grid-template-columns: 1fr;
+  }
+
+  .pricing {
+    padding: 48px 32px;
+  }
+}
+
+@media (max-width: 520px) {
+  .page-content {
+    padding: 48px 16px 96px;
+  }
+
+  .header-content {
+    padding: 16px;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .header-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .hero-highlights li {
+    font-size: 0.95rem;
+  }
+
+  .logo-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
 }

--- a/Angular/youtube-downloader/src/app/about3/about3.component.html
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.html
@@ -1,237 +1,194 @@
-<link rel="stylesheet" href="assets/about3/teamlogs/css2" />
-<link rel="stylesheet" href="assets/about3/teamlogs/chunk-vendors.4f0ceb74.css" />
-<link rel="stylesheet" href="assets/about3/teamlogs/app.b22c9560.css" />
-<link rel="stylesheet" href="assets/about3/teamlogs/chunk-9824.46a68717.css" />
-<noscript><strong>We're sorry but Сервис транскрибации аудио и видео в текст | Teamlogs doesn't work properly without JavaScript enabled. Please enable it to continue.</strong></noscript><noscript><div><img src=https://mc.yandex.ru/watch/86969682 style="position:absolute; left:-9999px;" alt=""></div></noscript><div id="__chakra-app" data-chakra-component="CThemeProvider"><!----><div data-v-b0d307b2="" class="layout layout--blue"><div data-v-8e8b2596="" data-chakra-component="CBox" class="css-0"></div> <div class="header header--sticky header--blue header--shrink"><header aria-label="Teamlogs" class="header__container"><a href="https://teamlogs.ru/" aria-current="page" class="router-link-active header__name router-link-exact-active router-link-active"><div class="header__logo"><img src="assets/about3/teamlogs/logo.png" alt="Логотип сервиса расшифровки аудио и видео в текст" class="header__logo-image"> <span class="header__logo-text">Teamlogs</span></div></a> <div data-chakra-component="CFlex" spacing="5" class="navbar-actions css-70qvj9"><div data-v-090fa670="" class="landing-links"><a data-v-090fa670="" data-chakra-component="CLink" href="https://teamlogs.ru/#features" class="router-link css-y38yuf">
-    Возможности
-  </a> <a data-v-090fa670="" data-chakra-component="CLink" href="https://teamlogs.ru/#instruction" class="router-link css-y38yuf">
-    Как работает
-  </a> <a data-v-090fa670="" data-chakra-component="CLink" href="https://teamlogs.ru/#business" class="router-link css-y38yuf">
-    Для бизнеса
-  </a> <a data-v-090fa670="" data-chakra-component="CLink" href="https://teamlogs.ru/#pricing" class="router-link css-y38yuf">
-    Сколько стоит
-  </a> <!----></div> <div class="navbar-item"><a href="https://teamlogs.ru/upload" class="css-cxzatq" type="button" tabindex="0" data-chakra-component="CButton">
-      Загрузить файлы
-    </a></div><div class="navbar-item"><a href="https://teamlogs.ru/login" class="css-n30skp" type="button" tabindex="0" data-chakra-component="CButton">
-      Войти
-    </a></div></div></header></div> <div class="layout-content"><!----> <!----> <!----> <div data-v-24ea3700="" data-chakra-component="CBox" class="css-1kzo3b9"><!----> <div data-v-24ea3700="" class="landing"><div data-v-24ea3700="" class="landing__blue-screen"><section data-v-67744231="" data-v-24ea3700="" class="landing__section"><a data-v-67744231="" id="upload" class="landing__anchor-link"></a> <div data-v-67744231="" data-chakra-component="CBox" class="landing__grid css-0"><div data-v-67744231="" class="file-upload"><div data-v-67744231="" class="file-upload__blur file-upload__blur--blue"></div> <div data-v-67744231="" class="file-upload__blur file-upload__blur--cyan"></div> <div data-v-67744231="" class="file-upload__content"><div data-v-67744231="" class="file-upload__header"><h1 data-v-67744231="" class="file-upload__title">
-            Преобразовать аудио и видео в текст
-          </h1></div> <div data-v-67744231="" class="file-upload__dropzone file-upload__dropzone--video"></div> <div data-v-67744231="" class="file-upload__dropzone file-upload__dropzone--audio"></div> <div data-v-67744231="" class="file-upload__form-container"><form data-v-0d633c52="" data-v-67744231="" data-chakra-component="CFlex" class="css-j7qwjs" style="gap: 24px;"><!----> <div data-v-0d633c52="" role="group" data-chakra-component="CFormControl" class="form--item file-uploader css-0"><div data-chakra-component="CFlex" class="css-1mi3tt8"><div class="cv-file-uploader cv-form-item bx--form-item"><strong class="bx--file--label"></strong> <p class="bx--label-description"></p> <div data-file="" class="bx--file"><label for="uid-abfbcdb1-a5e9-49b1-8f9f-243f6fa3d160" role="button" tabindex="0" class="bx--file-browse-btn"><div data-file-drop-container="" class="bx--file__drop-container"><div><div data-chakra-component="CFlex" class="css-gdx2i7"><div class="upload-icon-container"><svg data-chakra-component="CIcon" viewBox="0 0 28 28" role="presentation" aria-label="upload" class="css-5ffdf css-pc3ga2 css-1m7pvug"><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M14.002 13.1a.9.9 0 0 1 .9.9v10.5a.9.9 0 0 1-1.8 0V14a.9.9 0 0 1 .9-.9" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M10.118 2.61A10.23 10.23 0 0 1 20.203 9.6H21a6.735 6.735 0 0 1 6.168 9.425 6.73 6.73 0 0 1-2.949 3.22.9.9 0 0 1-.861-1.58A4.934 4.934 0 0 0 21 11.4h-1.469a.9.9 0 0 1-.871-.675A8.435 8.435 0 0 0 3.685 7.862a8.43 8.43 0 0 0 .49 10.559.9.9 0 1 1-1.348 1.192 10.234 10.234 0 0 1 7.29-17.003z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path></svg></div> <p data-chakra-component="CText" class="css-4z0ghr">
-              Перетащите или загрузите файлы
-            </p> <span data-chakra-component="CText" class="css-1fg8l6w">
-              до 1.5Гб, не более 300 минут
-            </span> <button type="button" tabindex="0" data-chakra-component="CButton" class="css-m8x04w">
-              Выбрать файлы
-            </button></div></div> <input type="file" id="uid-abfbcdb1-a5e9-49b1-8f9f-243f6fa3d160" data-file-uploader="" data-target="[data-file-container]" accept=".wma, .aac, .flac, .mp3, .m4a, .ogg, .wav, .webm, .mkv, .wmv, .ogg, .flv, .mp4, .avi, .webm, .mov" multiple="multiple" class="bx--file-input"></div></label> <!----> <div data-file-container="" class="bx--file-container"></div></div></div></div> <!----> <!----> <div class="file-content" style="display: none;"><div data-v-0d633c52="" data-chakra-component="CFlex" class="css-1ofqig9" style="gap: 24px;"><div data-v-0d633c52="" role="group" data-chakra-component="CFormControl" class="form--item css-0"><div class="label--wrapper"><label data-chakra-component="CFormLabel" class="css-17xzvuo">Разделение на спикеров<span data-chakra-component="CRequiredIndicator" aria-hidden="true" class="css-7jiixm">*</span></label> </div> <div data-chakra-component="CRadioButtonGroup" role="radiogroup" class="radio-group css-0"><button type="button" tabindex="0" data-chakra-component="CButton" aria-checked="true" role="radio" ischecked="true" value="-1" class="css-1vbzfzx">
-      Авто
-      <!----></button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="1" class="css-53ty9">
-      Не разделять
-      <!----></button></div> <!----> <!----></div> <div data-v-0d633c52="" role="group" data-chakra-component="CFormControl" class="form--item css-0" style="display: none;"><div class="label--wrapper"><label data-chakra-component="CFormLabel" class="css-17xzvuo">Уровень шумоподавления<span data-chakra-component="CRequiredIndicator" aria-hidden="true" class="css-7jiixm">*</span></label> </div> <div data-chakra-component="CRadioButtonGroup" role="radiogroup" class="radio-group css-0"><button type="button" tabindex="0" data-chakra-component="CButton" aria-checked="true" role="radio" ischecked="true" value="1" class="css-1vbzfzx">
-      Не использовать
-      <!----></button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="2" class="css-53ty9">
-      Настроить
-      <!----></button></div> <!----> <!----></div> <div data-v-0d633c52="" role="group" data-chakra-component="CFormControl" class="form--item css-1qwj5yi" maxwidth="470px" style="display: none;"><div class="label--wrapper"><label data-chakra-component="CFormLabel" class="css-17xzvuo">Уровень шумоподавления</label> </div> <div data-chakra-component="CRadioButtonGroup" role="radiogroup" class="number-selector css-0"><button type="button" tabindex="0" data-chakra-component="CButton" aria-checked="true" role="radio" ischecked="true" value="0" class="css-1vbzfzx">0</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="1" class="css-53ty9">1</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="2" class="css-53ty9">2</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="3" class="css-53ty9">3</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="4" class="css-53ty9">4</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="5" class="css-53ty9">5</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="6" class="css-53ty9">6</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="7" class="css-53ty9">7</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="8" class="css-53ty9">8</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="9" class="css-53ty9">9</button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="10" class="css-53ty9">10</button></div> <!----> <!----></div> <div data-v-0d633c52="" role="group" data-chakra-component="CFormControl" class="form--item css-0"><div class="label--wrapper"><label data-chakra-component="CFormLabel" class="css-17xzvuo">Язык текста<span data-chakra-component="CRequiredIndicator" aria-hidden="true" class="css-7jiixm">*</span></label> </div> <div data-chakra-component="CRadioButtonGroup" role="radiogroup" class="radio-group css-0"><button type="button" tabindex="0" data-chakra-component="CButton" aria-checked="true" role="radio" ischecked="true" value="auto" class="css-1vbzfzx">
-      Авто
-      <div><div data-chakra-component="CBox" x-tooltip-anchor="tooltip-ciFh" class="css-17dcf87"><svg data-chakra-component="CIcon" viewBox="0 0 512 512" role="presentation" class="css-5ffdf css-xmst1h css-nvlef"><path fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416m0 464a256 256 0 1 0 0-512 256 256 0 1 0 0 512m-40-176a24 24 0 1 0 0 48h80a24 24 0 1 0 0-48h-8v-88a24 24 0 0 0-24-24h-48a24 24 0 1 0 0 48h24v64zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64"></path></svg></div><!----></div></button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="ru" class="css-53ty9">
-      Русский
-      <!----></button><button type="button" tabindex="-1" data-chakra-component="CButton" role="radio" value="en" class="css-53ty9">
-      Английский
-      <!----></button></div> <!----> <!----></div> <div data-v-0d633c52="" role="group" data-chakra-component="CFormControl" class="css-8xl60i" mt="auto"><button type="button" tabindex="0" disabled="disabled" data-chakra-component="CButton" class="css-jk9vzi">
-        Продолжить
-      </button></div></div></div></div></form></div></div></div></div></section> <section data-v-413af2d0="" data-v-24ea3700="" class="landing__section"><div data-v-413af2d0="" class="landing__grid partners"><div data-v-413af2d0="" class="partners__header"><h2 data-v-413af2d0="" class="partners__title">Нам доверяют команды из топовых компаний</h2></div> <div data-v-413af2d0="" class="partners__clients-grid"><div data-v-413af2d0="" class="partners__clients-row"><div data-v-413af2d0="" class="partners__client" style="width: 111px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Авито - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/avito-seeklogocom_12.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 184px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип ВКонтакте - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/VK_Full_Logo_12x.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 130px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Билайн - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/beeline_logo.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 153px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Самокат - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Samok_12x.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 126px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Лента - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Lenta_New_Logo_22x.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 162px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Skyeng - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Skyeng_Base_12x.png" class="t-lazy-image t-lazy-image-loaded"></div></div><div data-v-413af2d0="" class="partners__clients-row"><div data-v-413af2d0="" class="partners__client" style="width: 108px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Lenta.ru - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Lenta_1_12x.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 99px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Skillbox - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Skillbox_12x.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 104px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Циан - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/CIAN_BIG 1.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 167px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Сколково - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Skolkovo_Foundation_.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 77px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип РБК - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Untitled_12x.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 180px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Высшая школа экономики - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/Short_version_PANTON.png" class="t-lazy-image t-lazy-image-loaded"></div><div data-v-413af2d0="" class="partners__client" style="width: 120px;"><img data-v-413af2d0="" width="165" height="35" draggable="false" alt="Логотип Сбер - клиент сервиса расшифровки аудио и видео в текст" src="assets/about3/teamlogs/logo-sber.png" class="t-lazy-image t-lazy-image-loaded"></div></div></div></div></section></div> <section data-v-76274a94="" data-v-24ea3700="" class="landing__section"><a data-v-76274a94="" id="instruction" class="landing__anchor-link"></a> <div data-v-76274a94="" class="landing__grid instruction"><h2 data-v-76274a94="" class="landing__title">Как работает Teamlogs</h2> <div data-v-76274a94="" class="instruction__swiper-container"><div data-v-76274a94="" data-chakra-component="CBox" id="swiper-instruction" class="swiper css-13eu2ud swiper-initialized swiper-horizontal swiper-backface-hidden" overflow="inherit !important"><div class="swiper-wrapper" style="cursor: grab;"><div data-v-76274a94="" class="swiper-slide instruction__slide swiper-slide-active" style="width: 368.667px; margin-right: 15px;"><div data-v-76274a94="" class="instruction__item"><div data-v-76274a94="" class="instruction__image-wrapper"><img data-v-76274a94="" width="347" height="250" draggable="false" alt="Загрузить аудио или видео файл для расшифровки" sizes="(min-width: 1024px) 460px, (min-width: 768px) and (max-width: 1023px) 920px, 600px" src="assets/about3/teamlogs/upload_frame-600x.png" class="instruction__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/upload_frame-460x.png 460w, https://cdn.teamlogs.ru/frontend/dev/upload_frame-600x.png 600w, https://cdn.teamlogs.ru/frontend/dev/upload_frame-920x.png 920w"></div> <div data-v-76274a94="" class="instruction__content"><p data-v-76274a94="" class="instruction__step">Шаг 1</p> <h3 data-v-76274a94="" class="instruction__title">Загрузите файл</h3></div> <p data-v-76274a94="" class="instruction__description">Загрузите или перетащите файл в указанную область. Чем лучше качество аудио, тем понятнее будет итоговая расшифровка</p></div></div><div data-v-76274a94="" class="swiper-slide instruction__slide swiper-slide-next" style="width: 368.667px; margin-right: 15px;"><div data-v-76274a94="" class="instruction__item"><div data-v-76274a94="" class="instruction__image-wrapper"><img data-v-76274a94="" width="347" height="250" draggable="false" alt="Высококачественная транскрибация файла в текст в процессе" sizes="(min-width: 1024px) 460px, (min-width: 768px) and (max-width: 1023px) 920px, 600px" src="assets/about3/teamlogs/files_frame-600x.png" class="instruction__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/files_frame-460x.png 460w, https://cdn.teamlogs.ru/frontend/dev/files_frame-600x.png 600w, https://cdn.teamlogs.ru/frontend/dev/files_frame-920x.png 920w"></div> <div data-v-76274a94="" class="instruction__content"><p data-v-76274a94="" class="instruction__step">Шаг 2</p> <h3 data-v-76274a94="" class="instruction__title">Дождитесь окончания расшифровки</h3></div> <p data-v-76274a94="" class="instruction__description">Сервису нужно 3−5% времени от длительности записи, чтобы перевести ваше аудио в текст</p></div></div><div data-v-76274a94="" class="swiper-slide instruction__slide" style="width: 368.667px; margin-right: 15px;"><div data-v-76274a94="" class="instruction__item"><div data-v-76274a94="" class="instruction__image-wrapper"><img data-v-76274a94="" width="347" height="250" draggable="false" alt="Редактирование готовой расшифровки в онлайн-редакторе" sizes="(min-width: 1024px) 460px, (min-width: 768px) and (max-width: 1023px) 920px, 600px" src="assets/about3/teamlogs/transcript_frame-600x.png" class="instruction__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/transcript_frame-460x.png 460w, https://cdn.teamlogs.ru/frontend/dev/transcript_frame-600x.png 600w, https://cdn.teamlogs.ru/frontend/dev/transcript_frame-920x.png 920w"></div> <div data-v-76274a94="" class="instruction__content"><p data-v-76274a94="" class="instruction__step">Шаг 3</p> <h3 data-v-76274a94="" class="instruction__title">Редактируйте прямо в браузере</h3></div> <p data-v-76274a94="" class="instruction__description">Проверьте расшифровку, прослушайте фрагменты и внесите правки через встроенный онлайн-редактор</p></div></div><div data-v-76274a94="" class="swiper-slide instruction__slide" style="width: 368.667px; margin-right: 15px;"><div data-v-76274a94="" class="instruction__item"><div data-v-76274a94="" class="instruction__image-wrapper"><img data-v-76274a94="" width="347" height="250" draggable="false" alt="Экспорт расшифровки в форматах DOCX, XLSX или SRT" sizes="(min-width: 1024px) 460px, (min-width: 768px) and (max-width: 1023px) 920px, 600px" src="assets/about3/teamlogs/export_frame-600x.png" class="instruction__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/export_frame-460x.png 460w, https://cdn.teamlogs.ru/frontend/dev/export_frame-600x.png 600w, https://cdn.teamlogs.ru/frontend/dev/export_frame-920x.png 920w"></div> <div data-v-76274a94="" class="instruction__content"><p data-v-76274a94="" class="instruction__step">Шаг 4</p> <h3 data-v-76274a94="" class="instruction__title">Скачайте результат</h3></div> <p data-v-76274a94="" class="instruction__description">Вы можете скачать результат на своё устройство в формате DOCX, XLSX или SRT</p></div></div></div> <div data-chakra-component="CBox" class="css-eimjog"><div class="swiper-button-next"></div> <div class="swiper-button-prev swiper-button-disabled"></div></div> <div class="swiper-pagination"></div></div></div></div></section> <section data-v-52f67cfc="" data-v-24ea3700="" class="landing__section"><div data-v-52f67cfc="" class="landing__grid"><a data-v-52f67cfc="" id="features" class="landing__anchor-link"></a> <div data-v-52f67cfc="" class="landing__group"><h2 data-v-52f67cfc="" class="landing__title">Что внутри</h2> <div data-v-ca14e406="" data-v-52f67cfc="" class="landing-card"><div data-v-ca14e406="" class="landing-card__content"><div data-v-ca14e406="" class="landing-card__header"><h2 data-v-ca14e406="" class="landing-card__title">
-        Автоматическая <br data-v-ca14e406="">
-        транскрибация
-      </h2></div> <div data-v-ca14e406="" class="landing-card__features"><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">Расшифровка речи</p></div><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">Высокая точность распознавания</p></div><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">Скорость обработки — 1&nbsp;час за 3&nbsp;минуты</p></div><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">Расстановка знаков препинания</p></div><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">Разделение на спикеров</p></div><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">Тайм-коды</p></div><div data-v-ca14e406="" class="landing-card__feature"><svg data-v-ca14e406="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-ca14e406="" class="landing-card__feature-text">78 языков</p></div></div></div> <div data-v-ca14e406="" class="landing-card__image-wrapper"><img data-v-ca14e406="" draggable="false" width="630" height="560" alt="Пример расшифровки интервью с автоматическим разделением по спикерам" sizes="(min-width: 1024px) 630px, (min-width: 768px) and (max-width: 1023px) 1260px, 945px" src="assets/about3/teamlogs/automatic_transcription-945x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/automatic_transcription-630x.png 630w, https://cdn.teamlogs.ru/frontend/dev/automatic_transcription-945x.png 945w, https://cdn.teamlogs.ru/frontend/dev/automatic_transcription-1260x.png 1260w"></div></div> <div data-v-eedb7936="" data-v-52f67cfc="" class="landing-card landing-card--column"><div data-v-eedb7936="" class="landing-card__content"><div data-v-eedb7936="" class="landing-card__header"><h2 data-v-eedb7936="" class="landing-card__title">Удобный редактор</h2></div></div> <div data-v-eedb7936="" class="editor__blocks"><div data-v-eedb7936="" class="editor__block"><div data-v-eedb7936="" class="editor__block--header"><h3 data-v-eedb7936="" class="editor__block--title">Прослушивайте
-материал</h3></div> <div data-v-eedb7936="" class="editor__block-image-wrapper"><img data-v-eedb7936="" draggable="false" width="320" height="245" alt="Онлайн-редактор с возможностью прослушивания аудио во время правки текста расшифровки" src="assets/about3/teamlogs/transcript_player-600x.png" class="t-lazy-image t-lazy-image-loaded"></div></div><div data-v-eedb7936="" class="editor__block"><div data-v-eedb7936="" class="editor__block--header"><h3 data-v-eedb7936="" class="editor__block--title">Выделяйте важные
-моменты</h3></div> <div data-v-eedb7936="" class="editor__block-image-wrapper"><img data-v-eedb7936="" draggable="false" width="320" height="245" alt="Инструменты форматирования и выделения текста цветным маркером в редакторе расшифровки" src="assets/about3/teamlogs/transcript_formatter-600x.png" class="t-lazy-image t-lazy-image-loaded"></div></div><div data-v-eedb7936="" class="editor__block"><div data-v-eedb7936="" class="editor__block--header"><h3 data-v-eedb7936="" class="editor__block--title">Подписывайте
-спикеров</h3></div> <div data-v-eedb7936="" class="editor__block-image-wrapper"><img data-v-eedb7936="" draggable="false" width="320" height="245" alt="Точная разметка диалога: удобная смена и переименование спикеров в редакторе" src="assets/about3/teamlogs/transcript_speakers-600x.png" class="t-lazy-image t-lazy-image-loaded"></div></div></div></div> <div data-v-87980378="" data-v-52f67cfc="" class="landing-card"><div data-v-87980378="" class="landing-card__content"><div data-v-87980378="" class="landing-card__header"><h2 data-v-87980378="" class="landing-card__title">
-        Teamlogs
-        <img data-v-87980378="" data-chakra-component="CImage" draggable="false" class="css-be5bv5" src="assets/about3/teamlogs/teamlogs-ai.svg"></h2></div> <div data-v-87980378="" class="landing-card__features"><div data-v-87980378="" class="landing-card__feature"><svg data-v-87980378="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-87980378="" class="landing-card__feature-text">Как ChatGPT, но для ваших расшифровок</p></div><div data-v-87980378="" class="landing-card__feature"><svg data-v-87980378="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-87980378="" class="landing-card__feature-text">Ответит на вопросы по расшифровке</p></div><div data-v-87980378="" class="landing-card__feature"><svg data-v-87980378="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-87980378="" class="landing-card__feature-text">Мгновенно подготовит резюме встречи</p></div><div data-v-87980378="" class="landing-card__feature"><svg data-v-87980378="" data-chakra-component="CIcon" viewBox="0 0 14 14" role="presentation" class="landing-card__feature-icon css-5ffdf css-b4ijyr css-0">
-      <g fill="currentColor">
-        <polygon points="5.5 11.9993304 14 3.49933039 12.5 2 5.5 8.99933039 1.5 4.9968652 0 6.49933039"></polygon>
-      </g>
-    </svg> <p data-v-87980378="" class="landing-card__feature-text">Сделает контент на основе расшифровки — от статьи до постов в&nbsp;соцсети</p></div></div></div> <div data-v-87980378="" class="landing-card__image-wrapper"><div data-v-87980378="" class="blur-group"><div data-v-87980378="" class="ellipse1"></div> <div data-v-87980378="" class="ellipse2"></div></div> <img data-v-87980378="" draggable="false" width="630" height="560" alt="Нейросеть анализирует расшифрованный текст и отвечает на вопросы" sizes="(min-width: 1024px) 630px, (min-width: 768px) and (max-width: 1023px) 1260px, 945px" src="assets/about3/teamlogs/transcript_chat-945x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/transcript_chat-630x.png 630w, https://cdn.teamlogs.ru/frontend/dev/transcript_chat-945x.png 945w, https://cdn.teamlogs.ru/frontend/dev/transcript_chat-1260x.png 1260w"></div></div> <div data-v-05cb7dbb="" data-v-52f67cfc="" class="opportunities-grid"><div data-v-05cb7dbb="" class="landing-block"><svg data-v-05cb7dbb="" data-chakra-component="CIcon" viewBox="0 0 512 512" role="presentation" class="landing-block__icon css-5ffdf css-pc3ga2 css-0"><path d="M0 96C0 60.7 28.7 32 64 32l132.1 0c19.1 0 37.4 7.6 50.9 21.1L289.9 96 448 96c35.3 0 64 28.7 64 64l0 256c0 35.3-28.7 64-64 64L64 480c-35.3 0-64-28.7-64-64L0 96zM64 80c-8.8 0-16 7.2-16 16l0 320c0 8.8 7.2 16 16 16l384 0c8.8 0 16-7.2 16-16l0-256c0-8.8-7.2-16-16-16l-161.4 0c-10.6 0-20.8-4.2-28.3-11.7L213.1 87c-4.5-4.5-10.6-7-17-7L64 80z" fill="currentColor"></path></svg> <div data-v-05cb7dbb=""><h3 data-v-05cb7dbb="" class="landing-block__title">Пакетная загрузка</h3> <p data-v-05cb7dbb="" class="landing-block__description">Одновременно до 10 файлов, каждый размером до&nbsp;1,5 ГБ</p></div></div><div data-v-05cb7dbb="" class="landing-block"><svg data-v-05cb7dbb="" data-chakra-component="CIcon" viewBox="0 0 384 512" role="presentation" class="landing-block__icon css-5ffdf css-pc3ga2 css-0"><path d="M320 464c8.8 0 16-7.2 16-16l0-288-80 0c-17.7 0-32-14.3-32-32l0-80L64 48c-8.8 0-16 7.2-16 16l0 384c0 8.8 7.2 16 16 16l256 0zM0 64C0 28.7 28.7 0 64 0L229.5 0c17 0 33.3 6.7 45.3 18.7l90.5 90.5c12 12 18.7 28.3 18.7 45.3L384 448c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 64z" fill="currentColor"></path></svg> <div data-v-05cb7dbb=""><h3 data-v-05cb7dbb="" class="landing-block__title">Экспорт файлов</h3> <p data-v-05cb7dbb="" class="landing-block__description">DOCX, SRT и XLSX</p></div></div><div data-v-05cb7dbb="" class="landing-block"><svg data-v-05cb7dbb="" data-chakra-component="CIcon" viewBox="0 0 28 28" role="presentation" class="landing-block__icon css-5ffdf css-pc3ga2 css-0"><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M14.002 13.1a.9.9 0 0 1 .9.9v10.5a.9.9 0 0 1-1.8 0V14a.9.9 0 0 1 .9-.9" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M10.118 2.61A10.23 10.23 0 0 1 20.203 9.6H21a6.735 6.735 0 0 1 6.168 9.425 6.73 6.73 0 0 1-2.949 3.22.9.9 0 0 1-.861-1.58A4.934 4.934 0 0 0 21 11.4h-1.469a.9.9 0 0 1-.871-.675A8.435 8.435 0 0 0 3.685 7.862a8.43 8.43 0 0 0 .49 10.559.9.9 0 1 1-1.348 1.192 10.234 10.234 0 0 1 7.29-17.003z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path></svg> <div data-v-05cb7dbb=""><h3 data-v-05cb7dbb="" class="landing-block__title">Загрузка файлов в&nbsp;любых форматах</h3> <p data-v-05cb7dbb="" class="landing-block__description">MP3, MP4, M4A, OGG, WAV, FLAC, WMA, M4A, FLAC, AAC, WEBM</p></div></div></div> <div data-v-52f67cfc="" data-chakra-component="CFlex" class="css-1b33znm"><a data-v-52f67cfc="" type="button" tabindex="0" data-chakra-component="CButton" href="https://teamlogs.ru/#upload" class="css-1g1hamw">
-          Попробовать бесплатно
-        </a></div></div></div></section> <section data-v-2a2ad7f6="" data-v-24ea3700="" class="landing__section"><div data-v-2a2ad7f6="" class="landing__grid"><a data-v-2a2ad7f6="" id="business" class="landing__anchor-link"></a> <div data-v-2a2ad7f6="" class="landing__group"><div data-v-2a2ad7f6="" data-chakra-component="CFlex" class="css-12ttpxs"><h2 data-v-2a2ad7f6="" class="landing__title">Для бизнеса</h2> <a data-v-2a2ad7f6="" type="button" tabindex="0" data-chakra-component="CButton" href="https://teamlogs.ru/transkribacia-rashifrovka-dlya-biznesa/" target="_blank" class="css-1izwo11 css-n9blya css-1qvi0b">
-          Подробнее
-        <svg data-chakra-component="CButtonIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-3vopgu css-1me86bq css-lcwm26"><path d="M7 17L17 7M17 7H7M17 7V17" stroke="#1B1B28" stroke-opacity="0.7" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path></svg></a></div> <div data-v-2a2ad7f6="" data-chakra-component="CFlex" class="business-grid css-k008qs"><div data-v-7214fbda="" data-v-2a2ad7f6="" class="landing-card landing-card--column"><div data-v-7214fbda="" class="landing-card__content"><div data-v-7214fbda="" class="landing-card__header landing-card__header--centered"><h2 data-v-7214fbda="" class="landing-card__title">Удобная оплата</h2> <p data-v-7214fbda="" class="landing-card__description">
-        Обмен документами по ЭДО, оплата по счету для ИП и ООО.
-        Общие минуты для команды, которые не сгорают
-      </p></div></div> <div data-v-7214fbda="" data-chakra-component="CBox" class="css-uewl2b"><img data-v-7214fbda="" draggable="false" width="526" height="279" alt="Управление балансом минут для корпоративных клиентов сервиса транскрибации" sizes="(min-width: 1024px) 526px, (min-width: 768px) and (max-width: 1023px) 1052px, 789px" src="assets/about3/teamlogs/workspace_balance-526x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/workspace_balance-526x.png 526w, https://cdn.teamlogs.ru/frontend/dev/workspace_balance-789x.png 789w, https://cdn.teamlogs.ru/frontend/dev/workspace_balance-1052x.png 1052w"></div></div> <div data-v-0ac2ab6d="" data-v-2a2ad7f6="" class="landing-card landing-card--column"><div data-v-0ac2ab6d="" class="landing-card__content"><div data-v-0ac2ab6d="" class="landing-card__header landing-card__header--centered"><h2 data-v-0ac2ab6d="" class="landing-card__title">Командная работа</h2> <p data-v-0ac2ab6d="" class="landing-card__description">
-        Создайте рабочее пространство в Teamlogs и&nbsp;пригласите&nbsp;коллег
-      </p></div></div> <img data-v-0ac2ab6d="" draggable="false" width="471" height="317" alt="Рабочие пространства для совместной работы над расшифровками" sizes="(min-width: 1024px) 471px, (min-width: 768px) and (max-width: 1023px) 942px, 706px" src="assets/about3/teamlogs/workspace_card-471x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/workspace_card-471x.png 471w, https://cdn.teamlogs.ru/frontend/dev/workspace_card-706x.png 706w, https://cdn.teamlogs.ru/frontend/dev/workspace_card-942x.png 942w"></div> <div data-v-07031288="" data-v-2a2ad7f6="" class="landing-card landing-card--column"><div data-v-07031288="" class="landing-card__content"><div data-v-07031288="" class="landing-card__header landing-card__header--centered"><h2 data-v-07031288="" class="landing-card__title">Общий доступ к файлам</h2> <p data-v-07031288="" class="landing-card__description">
-        Работайте над материалами совместно, настройте&nbsp;уровни доступа
-      </p></div></div> <div data-v-07031288="" class="landing-card__image-wrapper"><img data-v-07031288="" draggable="false" width="572" height="383" alt="Настройка командного доступа к расшифровкам в рабочем пространстве" sizes="(min-width: 1024px) 572px, (min-width: 768px) and (max-width: 1023px) 1144px, 858px" src="assets/about3/teamlogs/files_sharing-572x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/files_sharing-572x.png 572w, https://cdn.teamlogs.ru/frontend/dev/files_sharing-858x.png 858w, https://cdn.teamlogs.ru/frontend/dev/files_sharing-572x.png 1144w"></div></div> <div data-v-9f93c74e="" data-v-2a2ad7f6="" class="landing-card landing-card--column"><div data-v-9f93c74e="" class="landing-card__content"><div data-v-9f93c74e="" class="landing-card__header landing-card__header--centered"><h2 data-v-9f93c74e="" class="landing-card__title">Детализация расходов</h2> <p data-v-9f93c74e="" class="landing-card__description">
-        Отслеживайте использование <br data-v-9f93c74e="">
-        минут в&nbsp;рабочем пространстве
-      </p></div></div> <div data-v-9f93c74e="" class="landing-card__image-wrapper"><img data-v-9f93c74e="" draggable="false" width="572" height="391" alt="Отслеживание использованных минут транскрибации и количества загруженных файлов для расшифровки" sizes="(min-width: 1024px) 572px, (min-width: 768px) and (max-width: 1023px) 1144px, 858px" src="assets/about3/teamlogs/workspace_analytics-572x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/workspace_analytics-572x.png 572w, https://cdn.teamlogs.ru/frontend/dev/workspace_analytics-858x.png 858w, https://cdn.teamlogs.ru/frontend/dev/workspace_analytics-572x.png 1144w"></div></div> <div data-v-1af4f3c1="" data-v-2a2ad7f6="" class="landing-card"><div data-v-1af4f3c1="" class="landing-card__content"><div data-v-1af4f3c1="" class="landing-card__header"><h2 data-v-1af4f3c1="" class="landing-card__title">Доступна интеграция по&nbsp;API</h2> <p data-v-1af4f3c1="" class="landing-card__description">
-        Простая интеграция нашего API для транскрибации позволяет добавить распознавание речи
-        в&nbsp;ваши приложения, внутренние инструменты или бизнес-процессы
-      </p></div> <div data-v-1af4f3c1=""><a data-v-1af4f3c1="" type="button" tabindex="0" data-chakra-component="CButton" href="https://teamlogs.ru/transkribacia-rechi-api" target="_blank" class="css-18voi17 css-1yad0ys css-1qvi0b">
-        Подробнее
-      <svg data-chakra-component="CButtonIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-3vopgu css-1me86bq css-lcwm26"><path d="M7 17L17 7M17 7H7M17 7V17" stroke="#1B1B28" stroke-opacity="0.7" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path></svg></a></div></div> <div data-v-1af4f3c1="" class="landing-card__image-wrapper"><img data-v-1af4f3c1="" draggable="false" width="560" height="400" alt="Пример работы с API для расшифровки речи" sizes="(min-width: 1024px) 560px, (min-width: 768px) and (max-width: 1023px) 1120px, 840px" src="assets/about3/teamlogs/api_integration-560x.png" class="landing-card__image t-lazy-image t-lazy-image-loaded" srcset="https://cdn.teamlogs.ru/frontend/dev/api_integration-560x.png 560w, https://cdn.teamlogs.ru/frontend/dev/api_integration-840x.png 840w, https://cdn.teamlogs.ru/frontend/dev/api_integration-1120x.png 1120w"></div></div></div></div></div></section> <section data-v-433508c2="" data-v-24ea3700="" class="landing__section"><div data-v-433508c2="" class="landing__grid"><a data-v-433508c2="" id="pricing" class="landing__anchor-link"></a> <div data-v-433508c2="" class="landing__group"><div data-v-433508c2="" data-chakra-component="CFlex" class="css-12ttpxs"><h2 data-v-433508c2="" class="landing__title">Сколько стоит</h2></div> <div data-v-433508c2="" class="pricing-grid"><div data-v-9d7d82be="" data-v-433508c2="" class="landing-card landing-card--column"><div data-v-9d7d82be="" class="landing-card__content"><div data-v-9d7d82be="" class="landing-card__header landing-card__header--pricing"><h2 data-v-9d7d82be="" class="landing-card__title"><span data-v-9d7d82be="">
-          Teamlogs
-          <span data-v-9d7d82be="" class="pricing__blue">Online</span></span></h2> <p data-v-9d7d82be="" class="landing-card__description">
-        Попробуйте Teamlogs бесплатно и получите 15&nbsp;тестовых&nbsp;минут.
-        Оплачивайте с российских и&nbsp;зарубежных карт или со счета организации
-      </p></div></div> <div data-v-9d7d82be="" data-chakra-component="CStack" class="css-j7qwjs css-0"><div data-chakra-component="CBox" class="css-t6dtne"><p data-v-9d7d82be="" class="pricing__price">от 6 ₽/минута</p></div><div data-v-9d7d82be="" data-chakra-component="CFlex" class="css-vxgrp0" style="gap: 20px;"><a data-v-9d7d82be="" type="button" tabindex="0" data-chakra-component="CButton" href="https://teamlogs.ru/#upload" class="css-w6lr5j">
-        Попробовать бесплатно
-      </a> <button data-v-9d7d82be="" type="button" tabindex="0" data-chakra-component="CButton" class="invoice-button css-t7j5g9">
-        Оплатить со счёта организации
-      </button></div></div></div> <div data-v-20345ef4="" data-v-433508c2="" class="landing-card landing-card--column landing-card--dark"><div data-v-20345ef4="" class="landing-card__content"><div data-v-20345ef4="" class="landing-card__header landing-card__header--pricing"><h2 data-v-20345ef4="" class="landing-card__title"><span data-v-20345ef4="">
-          Teamlogs
-          <span data-v-20345ef4="" class="pricing__green">On-premise</span></span></h2> <p data-v-20345ef4="" class="landing-card__description">
-        Мы разворачиваем полноценную версию сервиса внутри&nbsp;вашей сети, на вашем оборудовании.
-        Данные&nbsp;обрабатываются исключительно на вашей стороне,&nbsp;никто кроме вас не имеет
-        доступа к ним
-      </p></div></div> <div data-v-20345ef4="" data-chakra-component="CStack" class="css-j7qwjs css-0"><div data-v-20345ef4="" data-chakra-component="CFlex" class="css-1r0boop" style="gap: 20px;"><div data-v-20345ef4="" data-chakra-component="CAvatar" class="pricing__avatar css-1nydaep"><img data-chakra-component="CBox" alt="Менеджер, готовый помочь с расчетом стоимости On-premise решения для транскрибации речи" src="assets/about3/teamlogs/manager.png" class="css-duvrj6"></div> <p data-v-20345ef4="" data-chakra-component="CText" class="css-la0h8a"> Оставьте заявку и наш менеджер рассчитает стоимость </p></div><button data-v-20345ef4="" type="button" tabindex="0" data-chakra-component="CButton" class="css-o82ef7 css-18icq18 css-fe84q5">
-      Оставить заявку
-    </button></div></div></div></div></div></section> <section data-v-3fd9a8e4="" data-v-24ea3700="" class="landing__section"><a data-v-3fd9a8e4="" id="faq" class="landing__anchor-link"></a> <div data-v-3fd9a8e4="" data-chakra-component="CBox" class="landing__grid css-0"><div data-v-3fd9a8e4="" class="faq"><h2 data-v-3fd9a8e4="" class="landing__title" style="max-width: 400px;">
-        Часто задаваемые вопросы
-      </h2> <div data-v-3fd9a8e4="" data-chakra-component="CAccordion" class="css-wojhsb"><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-qRV" type="button" aria-expanded="true" aria-controls="accordion-panel-qRV" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Как преобразовать видео в текст?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-hrt4ut">
-      <path fill="currentColor" d="M.439,21.44a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,1,0,2.122-2.121L14.3,12.177a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.44L12.177,9.7a.25.25,0,0,1-.354,0L2.561.44A1.5,1.5,0,0,0,.439,2.561L9.7,11.823a.25.25,0,0,1,0,.354Z"></path></svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; visibility: visible; height: auto; opacity: 1;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-qRV" aria-labelledby="accordion-header-qRV" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Загрузите ваш видеофайл в Teamlogs и сервис преобразует видео в текст с высокой точностью. Проверьте качество текста в онлайн-редакторе сервиса и скачайте результат на своё устройство в формате docx, xlsx или srt</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-dNY" type="button" aria-expanded="false" aria-controls="accordion-panel-dNY" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Можно ли транскрибировать аудио в текст?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-dNY" aria-labelledby="accordion-header-dNY" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Да, Teamlogs позволяет транскрибировать аудио в текст. Это идеальное решение для журналистов, исследователей и студентов, нуждающихся в быстрой и точной транскрибации аудиозаписей</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-IlW" type="button" aria-expanded="false" aria-controls="accordion-panel-IlW" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Максимальная длительность видео для преобразования в текст?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-IlW" aria-labelledby="accordion-header-IlW" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">В Teamlogs вы можете преобразовывать в текст медиафайлы длительностью до 300 минут. Обработка часовой записи занимает 3 минуты. Сервис позволяет транскрибировать аудио и видео файлы размером до 1,5 Гб</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-ggd" type="button" aria-expanded="false" aria-controls="accordion-panel-ggd" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Какие форматы файлов принимает Teamlogs?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-ggd" aria-labelledby="accordion-header-ggd" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Сервис поддерживает все современные и популярные форматы аудио и видео: MP3, M4A, OGG, WAV, FLAC, WMA, AAC, MP4, MKV, FLV, AVI, MOV, WMV, WEBM</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-mDf" type="button" aria-expanded="false" aria-controls="accordion-panel-mDf" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Как получить тестовый доступ к Teamlogs?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-mDf" aria-labelledby="accordion-header-mDf" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Загрузите ваш видео или аудиофайл в сервис по кнопке <strong data-v-3fd9a8e4="">Загрузить файл</strong>, Teamlogs бесплатно обработает первые 15 минут. Текст будет доступен в онлайн-редакторе, где вы сможете прослушать аудио и оценить качество расшифровки речи в текст</span> <div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-164r41r"><a data-v-3fd9a8e4="" type="button" tabindex="0" data-chakra-component="CButton" href="https://teamlogs.ru/#upload" class="css-g7f59w">
-                Загрузить файл
-              </a></div> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-qrM" type="button" aria-expanded="false" aria-controls="accordion-panel-qrM" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Как я пойму что мой файл готов?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-qrM" aria-labelledby="accordion-header-qrM" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Автоматическая транскрибация занимает 3-5% от длительности файла. По завершении процесса распознавания вы получите уведомление на электронную почту</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-ryp" type="button" aria-expanded="false" aria-controls="accordion-panel-ryp" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Как мне получить больше минут для транскрибации?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-ryp" aria-labelledby="accordion-header-ryp" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Авторизуйтесь в сервисе с помощью почты или аккаунта Яндекс/Google. В правом верхнем углу нажмите кнопку <strong data-v-3fd9a8e4="">Пополнить</strong>. Сервис принимает карты банков РФ, а также предлагает оплату через SberPay и Tinkoff Pay. После оплаты минуты будут мгновенно добавлены на ваш аккаунт, а на почту придет чек</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-xjp" type="button" aria-expanded="false" aria-controls="accordion-panel-xjp" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Сгорают ли приобретенные минуты?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-xjp" aria-labelledby="accordion-header-xjp" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Минуты, приобретенные в сервисе, не сгорают и остаются на вашем аккаунте до тех пор, пока вы их не используете</span> <!----> <!----></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-txu" type="button" aria-expanded="false" aria-controls="accordion-panel-txu" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Как я могу оплатить сервис со счета ООО или ИП?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-txu" aria-labelledby="accordion-header-txu" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">Как мы работаем с организациями:
-1. Мы выставляем вам счет. <a data-v-3fd9a8e4="" data-chakra-component="CLink" target="_blank" href="https://teamlogs.ru/teamlogs-oferta" class="css-lk1zix">Договор-оферта</a>
-2. Вы оплачиваете счет и мы зачисляем купленные минуты на ваш личный аккаунт или на аккаунт организации
-3. Мы отправляем вам приглашение в ЭДО, затем обмениваемся актами</span> <!----> <div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-164r41r"><button data-v-3fd9a8e4="" type="button" tabindex="0" data-chakra-component="CButton" class="css-1kc49fg">
-                Оставить заявку на оплату со счета ООО или ИП
-              </button></div></div></div></div><div data-chakra-component="CAccordionItem" class="css-0 css-4blkg7"><button data-v-3fd9a8e4="" data-chakra-component="CAccordionHeader" id="accordion-header-lrt" type="button" aria-expanded="false" aria-controls="accordion-panel-lrt" class="css-10l3gbp"><div data-v-3fd9a8e4="" data-chakra-component="CBox" class="css-1ubsqvt">
-              Как создать корпоративный аккаунт в Teamlogs?
-            </div> <svg data-v-3fd9a8e4="" data-chakra-component="CAccordionIcon" viewBox="0 0 24 24" role="presentation" class="css-5ffdf css-1wtk1ay css-0 css-14swsnu">
-    <path fill="currentColor" d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"></path>
-    </svg></button> <div data-v-3fd9a8e4="" data-chakra-component="CCollapse" style="overflow: hidden; opacity: 0; height: 0px;"><div data-chakra-component="CAccordionPanel" id="accordion-panel-lrt" aria-labelledby="accordion-header-lrt" aria-hidden="true" role="region" class="css-to3pcl"><span data-v-3fd9a8e4="" data-chakra-component="CText" class="css-1hk5gf8">В личном аккаунте Teamlogs с помощью кнопки «Создать пространство» вы можете подключить коллег и раздать доступы к файлам. Подробнее про командную работу в сервисе <a data-v-3fd9a8e4="" data-chakra-component="CLink" target="_blank" href="https://teamlogs.ru/instruction#teamwork" class="css-lk1zix">читайте в инструкции</a></span> <!----> <!----></div></div></div></div></div></div></section> <section data-v-41ab163c="" data-v-24ea3700="" class="landing__section"><div data-v-41ab163c="" class="landing__grid"><div data-v-41ab163c="" class="rate"><div data-v-41ab163c="" class="rate__content"><h2 data-v-41ab163c="" class="rate__title">Загрузите файл и оцените работу&nbsp;Teamlogs</h2> <a data-v-41ab163c="" type="button" tabindex="0" data-chakra-component="CButton" href="https://teamlogs.ru/#upload" class="css-12wh0m3"><span data-v-41ab163c="" data-chakra-component="CText" class="css-o4epvn">Загрузить файл</span> <svg data-v-41ab163c="" data-chakra-component="CIcon" viewBox="0 0 28 28" role="presentation" class="css-5ffdf css-1wtk1ay css-0"><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M14.002 13.1a.9.9 0 0 1 .9.9v10.5a.9.9 0 0 1-1.8 0V14a.9.9 0 0 1 .9-.9" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M10.118 2.61A10.23 10.23 0 0 1 20.203 9.6H21a6.735 6.735 0 0 1 6.168 9.425 6.73 6.73 0 0 1-2.949 3.22.9.9 0 0 1-.861-1.58A4.934 4.934 0 0 0 21 11.4h-1.469a.9.9 0 0 1-.871-.675A8.435 8.435 0 0 0 3.685 7.862a8.43 8.43 0 0 0 .49 10.559.9.9 0 1 1-1.348 1.192 10.234 10.234 0 0 1 7.29-17.003z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path></svg></a></div></div></div></section> <div data-v-17915a99="" data-v-24ea3700="" class="landing_footer"><div data-v-17915a99="" class="landing__grid"><div data-v-17915a99="" class="landing__footer-content"><div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-section css-j7qwjs css-0"><p data-v-17915a99="" data-chakra-component="CText" class="landing__footer-section-title css-1tauoku">Teamlogs</p><div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-links css-j7qwjs css-0"><a data-v-17915a99="" data-chakra-component="CLink" href="https://teamlogs.ru/#instruction" class="landing__footer-link css-1imb8tu">
-            Инструкция
-          </a><a data-v-17915a99="" data-chakra-component="CLink" href="https://teamlogs.ru/#export" class="landing__footer-link css-1imb8tu">
-            Экспорт
-          </a><a data-v-17915a99="" data-chakra-component="CLink" href="https://teamlogs.ru/#pricing" class="landing__footer-link css-1imb8tu">
-            Стоимость
-          </a><a data-v-17915a99="" data-chakra-component="CLink" href="https://teamlogs.ru/#faq" class="landing__footer-link css-1imb8tu">
-            Часто задаваемые вопросы
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/audio-to-text" class="landing__footer-link css-1imb8tu">
-            Перевод аудио в текст
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/video-to-text" class="landing__footer-link css-1imb8tu">
-            Перевод видео в текст
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/service-update-history" class="landing__footer-link css-1imb8tu">
-            История обновлений
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/transkribacia-rechi-api" class="landing__footer-link css-1imb8tu">
-            Teamlogs API
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog" class="landing__footer-link css-y38yuf">
-            Блог
-          </a></div></div><div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-section css-j7qwjs css-0"><p data-v-17915a99="" data-chakra-component="CText" class="landing__footer-section-title css-1tauoku">Полезные материалы</p><div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-links css-j7qwjs css-0"><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/instruction" class="landing__footer-link css-1imb8tu">
-            Как пользоваться сервисом
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/what-is-transcription" class="landing__footer-link css-1imb8tu">
-            Что такое транскрибация?
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/what-to-transcribe-guide" class="landing__footer-link css-1imb8tu">
-            Что можно расшифровывать?
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/kak-provodit-interviy" class="landing__footer-link css-1imb8tu">
-            Как проводить интервью: 10 советов от продакта
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/interview-transcription-techniques" class="landing__footer-link css-1imb8tu">
-            Руководство по расшифровке интервью
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/kak-sdelat-analiz-interviu" class="landing__footer-link css-1imb8tu">
-            Как анализировать интервью
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/neiroset-ii-dlya-bystroi-transkribacii" class="landing__footer-link css-1imb8tu">
-            Как работать с расшифровкой с помощью нейросети?
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/kak-sozdat-rezyume-konspekt-soveshaniya" class="landing__footer-link css-1imb8tu">
-            Как создать резюме совещания
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/kak-sozdat-subtitry-k-video-neiroset-servisy" class="landing__footer-link css-1imb8tu">
-            Как сделать субтитры к видео
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/preobrazovanie-pesni-muziki-v-tekst-mgnovennyj-perevod" class="landing__footer-link css-1imb8tu">
-            Как распознать текст песни с помощью нейросети
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/kak-pisat-promty-dlya-neirosetey" class="landing__footer-link css-1imb8tu">
-            Как писать промты для нейросети: топ-10 примеров
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/blog/organizations" class="landing__footer-link css-y38yuf">
-            Работа над расшифровками в&nbsp;команде
-          </a></div></div><div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-section css-j7qwjs css-0"><p data-v-17915a99="" data-chakra-component="CText" class="landing__footer-section-title css-1tauoku">Документы</p><div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-links css-j7qwjs css-0"><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/teamlogs-oferta" class="landing__footer-link css-1imb8tu">
-            Оферта
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/privacy-policy" class="landing__footer-link css-1imb8tu">
-            Политика конфиденциальности
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/terms-and-conditions" class="landing__footer-link css-1imb8tu">
-            Пользовательское соглашение
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/refund-policy" class="landing__footer-link css-1imb8tu">
-            Правила оформления возврата денежных средств
-          </a><a data-v-17915a99="" target="_blank" rel="noopener noreferrer" data-chakra-component="CLink" href="https://teamlogs.ru/about" class="landing__footer-link css-y38yuf">
-            О нас
-          </a></div></div> <div data-v-17915a99="" data-chakra-component="CStack" class="landing__footer-section css-j7qwjs css-0"><div data-chakra-component="CBox" class="css-b3he6l"><p data-v-17915a99="" class="landing__footer-info">
-          Санкт-Петербург — Владивосток © 2025. Все права защищены.
-        </p></div><div data-chakra-component="CBox" class="css-b3he6l"><p data-v-17915a99="" class="landing__footer-info">
-          ООО «ТУДИЛАБ», ОГРН 1202500014573, ИНН 2537144032
-        </p></div><div data-chakra-component="CBox" class="css-b3he6l"><p data-v-17915a99="" class="landing__footer-info">
-          Свидетельство о государственной регистрации программы для ЭВМ №2021669213 от 25 ноября 2021 г. – «Teamlogs – расшифровка и аналитика видеозвонков»
-        </p></div><div data-chakra-component="CBox" class="css-0"><div data-v-17915a99="" class="landing__footer-social"><a data-v-17915a99="" type="button" tabindex="0" data-chakra-component="CButton" href="https://t.me/teamlogs" target="_blank" class="css-1lvzwfm"><svg data-v-17915a99="" data-chakra-component="CIcon" viewBox="0 0 30 30" role="presentation" class="css-5ffdf css-157ac76 css-l4avzm"><path fill="currentColor" d="M15.764 8.738Q12.49 10.1 2.676 14.375q-1.594.634-1.67 1.24c-.086.685.77.954 1.934 1.319q.239.073.492.157c1.146.372 2.687.808 3.488.825q1.09.021 2.435-.898 9.168-6.191 9.465-6.258c.14-.032.335-.073.466.045.13.116.118.337.104.396-.085.361-3.44 3.483-5.18 5.099-.543.503-.926.86-1.004.942-.176.182-.356.356-.528.522-1.066 1.025-1.863 1.796.045 3.052.89.587 1.607 1.074 2.317 1.558l.064.043c.799.544 1.595 1.087 2.628 1.764.261.172.512.35.757.523.93.665 1.765 1.26 2.798 1.166.598-.056 1.22-.62 1.534-2.3.742-3.977 2.204-12.587 2.543-16.137q.03-.444-.037-.883a.95.95 0 0 0-.322-.608c-.267-.219-.683-.265-.87-.262-.843.015-2.137.466-8.37 3.058"></path></svg></a> <a data-v-17915a99="" type="button" tabindex="0" data-chakra-component="CButton" href="https://vk.com/teamlogs" target="_blank" class="css-1lvzwfm"><svg data-v-17915a99="" data-chakra-component="CIcon" viewBox="0 0 30 30" role="presentation" class="css-5ffdf css-157ac76 css-l4avzm"><path fill="currentColor" d="M1.5 7.214h4.62c.153 7.724 3.56 10.995 6.258 11.67V7.214h4.35v6.661c2.665-.286 5.465-3.322 6.41-6.661h4.35a12.85 12.85 0 0 1-5.92 8.398 13.31 13.31 0 0 1 6.932 8.45h-4.79a8.325 8.325 0 0 0-6.981-6.021v6.02h-.523C6.98 24.062 1.719 17.737 1.5 7.214"></path></svg></a> <div data-v-17915a99="" class="fasie"><span data-v-17915a99="" class="fasie__text">При поддержке</span> <a data-v-17915a99="" data-chakra-component="CLink" variant="ghost" href="https://fasie.ru/" target="_blank" class="css-y38yuf"><img data-v-17915a99="" width="90px" draggable="false" alt="" src="assets/about3/teamlogs/FASIE_RU_rgb_-_.svg" class="t-lazy-image t-lazy-image-loaded"></a></div></div></div></div></div></div></div></div> <!----></div></div></div></div><div id="breadstick-kitchen" class="Breadstick"><span><span class="Breadstick__manager-top" style="width: fit-content; position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"></span><span class="Breadstick__manager-top-left" style="width: fit-content; position: fixed; z-index: 5500; top: 0px; left: 0px;"></span><span class="Breadstick__manager-top-right" style="width: fit-content; position: fixed; z-index: 5500; top: 0px; right: 0px;"></span><span class="Breadstick__manager-bottom-left" style="width: fit-content; position: fixed; z-index: 5500; bottom: 0px; left: 0px;"></span><span class="Breadstick__manager-bottom" style="width: fit-content; position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"></span><span class="Breadstick__manager-bottom-right" style="width: fit-content; position: fixed; z-index: 5500; bottom: 0px; right: 0px;"></span></span><span><span class="Breadstick__manager-top" style="width: fit-content; position: fixed; z-index: 5500; margin: 0px auto; text-align: center; top: 0px; right: 0px; left: 0px;"></span><span class="Breadstick__manager-top-left" style="width: fit-content; position: fixed; z-index: 5500; top: 0px; left: 0px;"></span><span class="Breadstick__manager-top-right" style="width: fit-content; position: fixed; z-index: 5500; top: 0px; right: 0px;"></span><span class="Breadstick__manager-bottom-left" style="width: fit-content; position: fixed; z-index: 5500; bottom: 0px; left: 0px;"></span><span class="Breadstick__manager-bottom" style="width: fit-content; position: fixed; z-index: 5500; margin: 0px auto; text-align: center; bottom: 0px; right: 0px; left: 0px;"></span><span class="Breadstick__manager-bottom-right" style="width: fit-content; position: fixed; z-index: 5500; bottom: 0px; right: 0px;"></span></span></div><span id="chakra-portal-LjyO"><div data-chakra-component="CPopper" id="tooltip-ciFh" role="tooltip" data-noop="1" data-popper-id="chakra-popper_bLhU" class="css-ow7afa css-k484uy" style="display: none;">Для каждого файла язык будет определен индивидуально
+<div class="about3-page">
+  <header class="page-header">
+    <div class="header-content">
+      <div class="logo-group">
+        <img src="assets/about3/teamlogs/logo.png" alt="Логотип сервиса расшифровки аудио и видео в текст" />
+        <span class="brand-name">Teamlogs</span>
+      </div>
+      <nav class="header-nav">
+        <a href="https://teamlogs.ru/#features" target="_blank" rel="noopener">Возможности</a>
+        <a href="https://teamlogs.ru/#instruction" target="_blank" rel="noopener">Как работает</a>
+        <a href="https://teamlogs.ru/#business" target="_blank" rel="noopener">Для бизнеса</a>
+        <a href="https://teamlogs.ru/#pricing" target="_blank" rel="noopener">Сколько стоит</a>
+      </nav>
+      <div class="header-actions">
+        <a class="btn btn-primary" href="https://teamlogs.ru/upload" target="_blank" rel="noopener">Загрузить файлы</a>
+        <a class="btn btn-secondary" href="https://teamlogs.ru/login" target="_blank" rel="noopener">Войти</a>
+      </div>
+    </div>
+  </header>
 
-Если в файле присутствуют несколько языков, текст расшифровки будет представлен на преобладающем языке<div data-chakra-component="CPopperArrow" x-arrow="true" data-popper-arrow="true" role="presentation" class="css-0"></div></div></span><div data-v-e2815288="" class="file-drop-overlay file-drop-overlay-hidden"><div data-v-e2815288="" class="file-drop-overlay__content"><svg data-v-e2815288="" data-chakra-component="CIcon" viewBox="0 0 28 28" role="presentation" class="file-drop-overlay__icon css-5ffdf css-3vopgu css-0"><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M14.002 13.1a.9.9 0 0 1 .9.9v10.5a.9.9 0 0 1-1.8 0V14a.9.9 0 0 1 .9-.9" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M10.118 2.61A10.23 10.23 0 0 1 20.203 9.6H21a6.735 6.735 0 0 1 6.168 9.425 6.73 6.73 0 0 1-2.949 3.22.9.9 0 0 1-.861-1.58A4.934 4.934 0 0 0 21 11.4h-1.469a.9.9 0 0 1-.871-.675A8.435 8.435 0 0 0 3.685 7.862a8.43 8.43 0 0 0 .49 10.559.9.9 0 1 1-1.348 1.192 10.234 10.234 0 0 1 7.29-17.003z" clip-rule="evenodd"></path><path fill="currentColor" fill-rule="evenodd" d="M13.364 13.364a.9.9 0 0 1 1.273 0l4.666 4.667a.9.9 0 1 1-1.272 1.273L14 15.273l-4.03 4.03a.9.9 0 0 1-1.274-1.273z" clip-rule="evenodd"></path></svg> <h1 data-v-e2815288="" class="file-drop-overlay__title">Перетащите файлы сюда</h1> <p data-v-e2815288="" class="file-drop-overlay__subtitle">до 1.5Гб, не более 300 минут</p></div></div>
+  <main class="page-content">
+    <section class="hero">
+      <div class="hero-text">
+        <h1>Преобразовать аудио и видео в текст</h1>
+        <p class="hero-lead">
+          Online-сервис автоматической транскрибации помогает за считанные минуты превратить записи интервью, созвонов и
+          лекций в структурированный текст.
+        </p>
+        <ul class="hero-highlights">
+          <li>Скорость обработки — 1&nbsp;час записи за 3&nbsp;минуты</li>
+          <li>Поддержка 78 языков и автоматическая расстановка тайм-кодов</li>
+          <li>Удобный редактор с подсветкой важных фрагментов</li>
+        </ul>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="https://teamlogs.ru/upload" target="_blank" rel="noopener">Загрузить файл</a>
+          <a class="btn btn-secondary" href="https://teamlogs.ru/signup" target="_blank" rel="noopener">Получить 15 минут</a>
+        </div>
+      </div>
+      <div class="hero-card">
+        <div class="card-header">Перетащите файлы сюда</div>
+        <div class="card-dropzone">
+          <p>Перетащите файлы или выберите их на устройстве</p>
+          <span>до 1,5 ГБ, не более 300 минут</span>
+          <button class="btn btn-primary" type="button">Выбрать файлы</button>
+        </div>
+        <div class="card-preview">
+          <img [src]="workflowSteps[0].image" [alt]="workflowSteps[0].title" />
+          <div class="card-preview-caption">Загрузите или перетащите файл в указанную область</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="trusted">
+      <h2>Нам доверяют команды из топовых компаний</h2>
+      <div class="logo-grid">
+        <ng-container *ngFor="let company of trustedCompanies">
+          <div class="logo-card">
+            <img [src]="company.src" [alt]="company.alt" />
+          </div>
+        </ng-container>
+      </div>
+    </section>
+
+    <section class="workflow">
+      <h2>Как работает Teamlogs</h2>
+      <div class="workflow-grid">
+        <article class="workflow-card" *ngFor="let step of workflowSteps; let index = index">
+          <div class="workflow-image">
+            <img [src]="step.image" [alt]="step.title" />
+          </div>
+          <div class="workflow-body">
+            <p class="workflow-step">Шаг {{ index + 1 }}</p>
+            <h3>{{ step.title }}</h3>
+            <p>{{ step.description }}</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="features">
+      <h2>Что внутри</h2>
+      <div class="features-layout">
+        <article class="feature-card">
+          <div class="feature-body">
+            <h3>Автоматическая транскрибация</h3>
+            <p>
+              Автоматическая транскрибация занимает всего 3–5% от длительности файла. После завершения обработки вы получаете
+              уведомление на электронную почту.
+            </p>
+            <ul>
+              <li *ngFor="let item of transcriptionFeatures">{{ item }}</li>
+            </ul>
+          </div>
+          <div class="feature-illustration">
+            <img src="assets/about3/teamlogs/automatic_transcription-945x.png" alt="Пример автоматической транскрибации" />
+          </div>
+        </article>
+
+        <article class="feature-card editor-card">
+          <div class="feature-body">
+            <h3>Удобный редактор</h3>
+            <p>
+              Проверяйте и дорабатывайте расшифровки прямо в браузере. Все изменения автоматически сохраняются и доступны всей
+              команде.
+            </p>
+            <div class="editor-grid">
+              <figure class="editor-block" *ngFor="let block of editorBlocks">
+                <figcaption>{{ block.title }}</figcaption>
+                <img [src]="block.image" [alt]="block.alt" />
+              </figure>
+            </div>
+          </div>
+        </article>
+
+        <article class="feature-card ai-card">
+          <div class="feature-body">
+            <h3>Teamlogs AI</h3>
+            <p>
+              Интеллектуальный помощник анализирует расшифрованный текст и помогает быстро подготовить резюме встречи или контент
+              для публикаций.
+            </p>
+            <ul>
+              <li *ngFor="let item of aiFeatures">{{ item }}</li>
+            </ul>
+          </div>
+          <div class="feature-illustration">
+            <img src="assets/about3/teamlogs/transcript_chat-945x.png" alt="Пример работы Teamlogs AI" />
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="teamlogs-advantages">
+      <div class="section-header">
+        <h2>Teamlogs</h2>
+        <p>Комплекс инструментов для быстрой и командной работы с расшифровками.</p>
+      </div>
+      <div class="advantage-grid">
+        <article class="advantage-card" *ngFor="let feature of teamlogsFeatures">
+          <div class="advantage-icon" aria-hidden="true">{{ feature.icon }}</div>
+          <h3>{{ feature.title }}</h3>
+          <p [innerHTML]="feature.description"></p>
+        </article>
+      </div>
+    </section>
+
+    <section class="business">
+      <div class="section-header">
+        <h2>Для бизнеса</h2>
+        <p>Настраивайте совместный доступ, следите за балансом и интегрируйте сервис в корпоративные процессы.</p>
+      </div>
+      <div class="business-grid">
+        <article class="business-card" *ngFor="let item of businessFeatures">
+          <img [src]="item.image" [alt]="item.title" />
+          <div class="business-body">
+            <h3>{{ item.title }}</h3>
+            <p [innerHTML]="item.description"></p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="pricing">
+      <h2>Сколько стоит</h2>
+      <div class="pricing-grid">
+        <article class="pricing-card" *ngFor="let plan of pricingPlans">
+          <h3>{{ plan.title }}</h3>
+          <p class="pricing-description" [innerHTML]="plan.description"></p>
+          <ul>
+            <li *ngFor="let perk of plan.perks">{{ perk }}</li>
+          </ul>
+          <a class="btn btn-primary" [href]="plan.link" target="_blank" rel="noopener">{{ plan.cta }}</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="cta-card">
+        <div class="cta-text">
+          <h2>Загрузите файл и оцените работу Teamlogs</h2>
+          <p>
+            Получите 15 тестовых минут, чтобы протестировать скорость и точность сервиса. Перетащите файл или загрузите его с
+            устройства — мы сразу начнём обработку.
+          </p>
+          <a class="btn btn-primary" href="https://teamlogs.ru/upload" target="_blank" rel="noopener">Загрузить файл</a>
+        </div>
+        <div class="cta-preview">
+          <h3>Перетащите файлы сюда</h3>
+          <img src="assets/about3/teamlogs/upload_frame-600x.png" alt="Загрузка аудио или видео" />
+        </div>
+      </div>
+    </section>
+  </main>
+</div>

--- a/Angular/youtube-downloader/src/app/about3/about3.component.ts
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.ts
@@ -1,6 +1,43 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+interface WorkflowStep {
+  readonly title: string;
+  readonly description: string;
+  readonly image: string;
+}
+
+interface GalleryItem {
+  readonly title: string;
+  readonly image: string;
+  readonly alt: string;
+}
+
+interface AdvantageItem {
+  readonly icon: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+interface BusinessFeature {
+  readonly title: string;
+  readonly description: string;
+  readonly image: string;
+}
+
+interface PricingPlan {
+  readonly title: string;
+  readonly description: string;
+  readonly perks: readonly string[];
+  readonly link: string;
+  readonly cta: string;
+}
+
+interface TrustedCompany {
+  readonly src: string;
+  readonly alt: string;
+}
+
 @Component({
   selector: 'app-about3',
   standalone: true,
@@ -8,4 +45,173 @@ import { CommonModule } from '@angular/common';
   templateUrl: './about3.component.html',
   styleUrls: ['./about3.component.css'],
 })
-export class About3Component {}
+export class About3Component {
+  readonly trustedCompanies: readonly TrustedCompany[] = [
+    {
+      src: 'assets/about3/teamlogs/avito-seeklogocom_12.png',
+      alt: 'Логотип Авито — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/VK_Full_Logo_12x.png',
+      alt: 'Логотип ВКонтакте — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/beeline_logo.png',
+      alt: 'Логотип Билайн — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/Samok_12x.png',
+      alt: 'Логотип Самокат — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/Lenta_New_Logo_22x.png',
+      alt: 'Логотип Лента — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/Skyeng_Base_12x.png',
+      alt: 'Логотип Skyeng — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/Skillbox_12x.png',
+      alt: 'Логотип Skillbox — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/CIAN_BIG 1.png',
+      alt: 'Логотип Циан — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/Skolkovo_Foundation_.png',
+      alt: 'Логотип Сколково — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/logo-sber.png',
+      alt: 'Логотип Сбер — клиент сервиса расшифровки аудио и видео в текст',
+    },
+    {
+      src: 'assets/about3/teamlogs/Untitled_12x.png',
+      alt: 'Логотип РБК — клиент сервиса расшифровки аудио и видео в текст',
+    },
+  ];
+
+  readonly workflowSteps: readonly WorkflowStep[] = [
+    {
+      title: 'Загрузите файл',
+      description:
+        'Загрузите или перетащите файл в указанную область. Чем лучше качество аудио, тем понятнее будет итоговая расшифровка.',
+      image: 'assets/about3/teamlogs/upload_frame-600x.png',
+    },
+    {
+      title: 'Дождитесь окончания расшифровки',
+      description:
+        'Сервису нужно 3−5% времени от длительности записи, чтобы перевести ваше аудио в текст.',
+      image: 'assets/about3/teamlogs/files_frame-600x.png',
+    },
+    {
+      title: 'Редактируйте прямо в браузере',
+      description:
+        'Проверьте расшифровку, прослушайте фрагменты и внесите правки через встроенный онлайн-редактор.',
+      image: 'assets/about3/teamlogs/transcript_frame-600x.png',
+    },
+    {
+      title: 'Скачайте результат',
+      description:
+        'Сохраните результат на устройство в формате DOCX, XLSX или SRT и поделитесь с коллегами.',
+      image: 'assets/about3/teamlogs/export_frame-600x.png',
+    },
+  ];
+
+  readonly transcriptionFeatures: readonly string[] = [
+    'Расшифровка речи',
+    'Высокая точность распознавания',
+    'Скорость обработки — 1 час за 3 минуты',
+    'Расстановка знаков препинания',
+    'Разделение на спикеров',
+    'Тайм-коды',
+    '78 языков',
+  ];
+
+  readonly editorBlocks: readonly GalleryItem[] = [
+    {
+      title: 'Прослушивайте материал',
+      image: 'assets/about3/teamlogs/transcript_player-600x.png',
+      alt: 'Онлайн-редактор с возможностью прослушивания аудио во время правки текста расшифровки',
+    },
+    {
+      title: 'Выделяйте важные моменты',
+      image: 'assets/about3/teamlogs/transcript_formatter-600x.png',
+      alt: 'Инструменты форматирования и выделения текста цветным маркером в редакторе расшифровки',
+    },
+    {
+      title: 'Подписывайте спикеров',
+      image: 'assets/about3/teamlogs/transcript_speakers-600x.png',
+      alt: 'Точная разметка диалога с удобной сменой и переименованием спикеров',
+    },
+  ];
+
+  readonly aiFeatures: readonly string[] = [
+    'Как ChatGPT, но для ваших расшифровок',
+    'Ответит на вопросы по расшифровке',
+    'Мгновенно подготовит резюме встречи',
+    'Сделает контент на основе расшифровки — от статьи до постов в соцсетях',
+  ];
+
+  readonly teamlogsFeatures: readonly AdvantageItem[] = [
+    {
+      icon: '①',
+      title: 'Пакетная загрузка',
+      description: 'Одновременно до 10 файлов, каждый размером до&nbsp;1,5 ГБ.',
+    },
+    {
+      icon: '②',
+      title: 'Экспорт файлов',
+      description: 'Скачивайте DOCX, SRT и XLSX для дальнейшей работы.',
+    },
+    {
+      icon: '③',
+      title: 'Любые форматы',
+      description: 'Поддерживаем MP3, MP4, WAV, FLAC, WMA, AAC, WEBM и другие форматы записи.',
+    },
+  ];
+
+  readonly businessFeatures: readonly BusinessFeature[] = [
+    {
+      title: 'Командная работа',
+      description: 'Создайте рабочее пространство в Teamlogs и пригласите коллег для совместной работы.',
+      image: 'assets/about3/teamlogs/workspace_card-471x.png',
+    },
+    {
+      title: 'Общий доступ к файлам',
+      description: 'Настройте уровни доступа и делитесь ссылками на расшифровки внутри команды.',
+      image: 'assets/about3/teamlogs/files_sharing-572x.png',
+    },
+    {
+      title: 'Детализация расходов',
+      description: 'Отслеживайте баланс минут и количество загруженных файлов в реальном времени.',
+      image: 'assets/about3/teamlogs/workspace_analytics-572x.png',
+    },
+    {
+      title: 'Доступна интеграция по API',
+      description: 'Интегрируйте распознавание речи в свои сервисы через простой REST API.',
+      image: 'assets/about3/teamlogs/api_integration-560x.png',
+    },
+  ];
+
+  readonly pricingPlans: readonly PricingPlan[] = [
+    {
+      title: 'Teamlogs Online',
+      description:
+        'Попробуйте Teamlogs бесплатно и получите 15 тестовых минут. Оплачивайте с российских и зарубежных карт или со счета организации.',
+      perks: ['15 тестовых минут на старте', 'Удобная оплата картой и по счету', 'Доступ из браузера и мобильных устройств'],
+      link: 'https://teamlogs.ru/pricing',
+      cta: 'Попробовать онлайн',
+    },
+    {
+      title: 'Teamlogs On-premise',
+      description:
+        'Полноценная версия сервиса разворачивается на ваших серверах. Данные обрабатываются внутри инфраструктуры компании.',
+      perks: ['Развертывание в частной сети', 'Работа без доступа к интернету', 'Персональная поддержка и SLA'],
+      link: 'https://teamlogs.ru/business',
+      cta: 'Получить предложение',
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- replace the embedded Teamlogs markup with a native Angular template and reusable bindings
- populate About3Component with structured content data for workflow, features, business cards, and pricing blocks
- recreate the original layout and styling with component-scoped CSS that mirrors the source page

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68da2e5fabc8833197995ed3f2581ae3