### PR TITLE
Remove About3 header and gradient background

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -2,83 +2,11 @@
   display: block;
   color: #0b1f33;
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
-  background: linear-gradient(180deg, #0a1f44 0%, #0e325d 35%, #ffffff 100%);
+  background: transparent;
 }
 
 .about3-page {
   min-height: 100vh;
-}
-
-.page-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: rgba(6, 20, 48, 0.92);
-  backdrop-filter: blur(14px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
-}
-
-.header-content {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px 32px;
-  gap: 24px;
-  color: #f4f9ff;
-}
-
-.logo-group {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.logo-group img {
-  width: 44px;
-  height: 44px;
-}
-
-.brand-name {
-  font-size: 1.1rem;
-}
-
-.header-nav {
-  display: flex;
-  align-items: center;
-  gap: 24px;
-  font-size: 0.95rem;
-}
-
-.header-nav a {
-  color: inherit;
-  text-decoration: none;
-  position: relative;
-}
-
-.header-nav a::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -6px;
-  width: 100%;
-  height: 2px;
-  background: transparent;
-  transition: background 0.2s ease;
-}
-
-.header-nav a:hover::after {
-  background: #66d4ff;
-}
-
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
 }
 
 .btn {

--- a/Angular/youtube-downloader/src/app/about3/about3.component.html
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.html
@@ -1,23 +1,4 @@
 <div class="about3-page">
-  <header class="page-header">
-    <div class="header-content">
-      <div class="logo-group">
-        <img src="assets/about3/teamlogs/logo.png" alt="Логотип сервиса расшифровки аудио и видео в текст" />
-        <span class="brand-name">Teamlogs</span>
-      </div>
-      <nav class="header-nav">
-        <a href="https://teamlogs.ru/#features" target="_blank" rel="noopener">Возможности</a>
-        <a href="https://teamlogs.ru/#instruction" target="_blank" rel="noopener">Как работает</a>
-        <a href="https://teamlogs.ru/#business" target="_blank" rel="noopener">Для бизнеса</a>
-        <a href="https://teamlogs.ru/#pricing" target="_blank" rel="noopener">Сколько стоит</a>
-      </nav>
-      <div class="header-actions">
-        <a class="btn btn-primary" href="https://teamlogs.ru/upload" target="_blank" rel="noopener">Загрузить файлы</a>
-        <a class="btn btn-secondary" href="https://teamlogs.ru/login" target="_blank" rel="noopener">Войти</a>
-      </div>
-    </div>
-  </header>
-
   <main class="page-content">
     <section class="hero">
       <div class="hero-text">


### PR DESCRIPTION
## Summary
- remove the Teamlogs top navigation from About3Component
- switch the About3 component host background to transparent and drop unused header styles

## Testing
- CI=true npm run start -- --host 0.0.0.0 --port 4200 (manually stopped after verifying UI)

------
https://chatgpt.com/codex/tasks/task_e_68da34b773948331bcdf208439ad5541