### PR TITLE
Update About3 hero styles for light background

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -1,6 +1,7 @@
+
 :host {
   display: block;
-  color: #0b1f33;
+  color: #102a43;
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
   background: transparent;
 }
@@ -35,12 +36,12 @@
 
 .btn-secondary {
   background: transparent;
-  color: #f4f9ff;
-  border-color: rgba(255, 255, 255, 0.4);
+  color: #1d4ed8;
+  border-color: rgba(29, 78, 216, 0.4);
 }
 
 .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(37, 99, 235, 0.08);
   transform: translateY(-2px);
 }
 
@@ -56,18 +57,20 @@ section {
   margin: 0 auto;
 }
 
+
 .hero {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 48px;
   align-items: center;
-  color: #f4f9ff;
+  color: inherit;
 }
 
 .hero-text h1 {
   font-size: 3rem;
   line-height: 1.15;
   margin-bottom: 24px;
+  color: #0f172a;
 }
 
 .hero-lead {
@@ -75,6 +78,7 @@ section {
   line-height: 1.6;
   margin-bottom: 24px;
   max-width: 560px;
+  color: #334155;
 }
 
 .hero-highlights {
@@ -86,21 +90,23 @@ section {
 }
 
 .hero-highlights li {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.15);
   border-radius: 16px;
   padding: 12px 18px;
   font-weight: 500;
+  color: #1e293b;
 }
 
 .hero-card {
-  background: rgba(9, 26, 58, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
   border-radius: 32px;
   padding: 32px;
   display: flex;
   flex-direction: column;
   gap: 24px;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
 }
 
 .card-header {
@@ -109,22 +115,23 @@ section {
 }
 
 .card-dropzone {
-  background: rgba(18, 55, 110, 0.85);
+  background: #f8fbff;
   border-radius: 24px;
   padding: 24px;
-  border: 1px dashed rgba(255, 255, 255, 0.32);
+  border: 1px dashed rgba(148, 163, 184, 0.7);
   text-align: center;
   display: grid;
   gap: 12px;
+  color: #0f172a;
 }
 
 .card-dropzone span {
-  color: rgba(255, 255, 255, 0.7);
+  color: #64748b;
   font-size: 0.9rem;
 }
 
 .card-preview {
-  background: rgba(255, 255, 255, 0.08);
+  background: #f1f5f9;
   border-radius: 20px;
   padding: 18px;
   display: grid;
@@ -135,12 +142,12 @@ section {
 .card-preview img {
   width: min(100%, 320px);
   border-radius: 16px;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.16);
 }
 
 .card-preview-caption {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: #475569;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- adjust About3 hero typography and surface colors to suit the new light background
- refresh secondary button, dropzone, and preview styling for better contrast

## Testing
- CI=1 npm run start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68da378f73308331905016bec4634a3e