### PR TITLE
Add Yandex OAuth login alongside Google

### DIFF
--- a/Angular/youtube-downloader/src/app/LoginComponent/login.component.ts
+++ b/Angular/youtube-downloader/src/app/LoginComponent/login.component.ts
@@ -11,11 +11,19 @@ import { AuthService } from '../services/AuthService.service';
     <div class="login d-flex flex-column align-items-center mt-5">
       <h2>Login</h2>
 
-      <button
-        class="btn btn-primary mt-3"
-        (click)="loginInteractive()">
-        Login with a Google ID
-      </button>
+      <div class="d-flex flex-column gap-2 mt-3 w-100" style="max-width: 320px;">
+        <button
+          class="btn btn-primary"
+          (click)="loginWithGoogle()">
+          Login with a Google ID
+        </button>
+
+        <button
+          class="btn btn-outline-secondary"
+          (click)="loginWithYandex()">
+          Login with a Yandex ID
+        </button>
+      </div>
 
       <!-- Сообщение об ошибке из callback -->
       <p *ngIf="authError" class="text-danger mt-2 text-center w-75">
@@ -42,7 +50,7 @@ export class LoginComponent implements OnInit {
       if (error) {
         this.authError = true;
         if (error === 'interaction_required') {
-          this.authErrorMessage = 'Для входа требуется взаимодействие. Пожалуйста, войдите в аккаунт Google и попробуйте снова.';
+          this.authErrorMessage = 'Для входа требуется взаимодействие. Пожалуйста, войдите в аккаунт выбранного провайдера и попробуйте снова.';
         } else {
           this.authErrorMessage = `Ошибка авторизации: ${error}. Попробуйте войти вручную.`;
         }
@@ -51,8 +59,16 @@ export class LoginComponent implements OnInit {
   }
 
   /** интерактивный вход по кнопке */
-  loginInteractive(): void {
+  loginWithGoogle(): void {
+    this.redirectToProvider('google');
+  }
+
+  loginWithYandex(): void {
+    this.redirectToProvider('yandex');
+  }
+
+  private redirectToProvider(provider: 'google' | 'yandex'): void {
     const redirect = encodeURIComponent(`${window.location.origin}/auth/callback`);
-    window.location.href = `/api/account/signin-google?returnUrl=${redirect}`;
+    window.location.href = `/api/account/signin-${provider}?returnUrl=${redirect}`;
   }
 }

--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -6,8 +6,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.2.0" />
-		<PackageReference Include="AspNet.Security.OAuth.Vkontakte" Version="9.2.0" />
+                <PackageReference Include="AngleSharp" Version="1.2.0" />
+                <PackageReference Include="AspNet.Security.OAuth.Yandex" Version="9.2.0" />
+                <PackageReference Include="AspNet.Security.OAuth.Vkontakte" Version="9.2.0" />
 		<PackageReference Include="AWSSDK.Core" Version="3.7.400.70" />
 		<PackageReference Include="AWSSDK.S3" Version="3.7.410.12" />
 		<PackageReference Include="Concentus.OggFile" Version="1.0.6" />

--- a/appsettings.json
+++ b/appsettings.json
@@ -69,6 +69,10 @@
       "ClientId": "ID",
       "ClientSecret": "ID"
     },
+    "Yandex": {
+      "ClientId": "YOUR_YANDEX_CLIENT_ID",
+      "ClientSecret": "YOUR_YANDEX_CLIENT_SECRET"
+    },
     "Vkontakte": {
       "ClientId": "YOUR_VK_CLIENT_ID",
       "ClientSecret": "YOUR_VK_CLIENT_SECRET"


### PR DESCRIPTION
## Summary
- add a reusable external-sign-in helper and expose Yandex OAuth login alongside Google
- configure the backend to use the AspNet.Security.OAuth.Yandex provider and add configuration placeholders
- update the Angular login screen to offer a Yandex button and reuse the provider redirect logic

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da476a9240833186e17d13818b5fa1