### PR TITLE
Remove blog editor text length limit

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
@@ -37,7 +37,7 @@
         <div class="editor-section" [class.invalid]="topicForm.controls['text'].invalid && topicForm.controls['text'].touched">
           <div class="editor-header">
             <label for="topic-text">Текст</label>
-            <span class="char-counter">{{ textLength }}/10000</span>
+            <span class="char-counter">{{ textLength }}</span>
           </div>
           <md-editor
             id="topic-text"

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
@@ -33,7 +33,6 @@ import { MarkdownRendererService1 } from '../task-result/markdown-renderer.servi
 })
 export class BlogTopicCreateComponent implements OnInit {
   private readonly titleMaxLength = 256;
-  private readonly textMaxLength = 10000;
 
   readonly topicForm: FormGroup;
 
@@ -68,7 +67,7 @@ export class BlogTopicCreateComponent implements OnInit {
   ) {
     this.topicForm = this.fb.group({
       title: ['', [Validators.required, Validators.maxLength(this.titleMaxLength)]],
-      text: ['', [Validators.required, Validators.maxLength(this.textMaxLength)]]
+      text: ['', [Validators.required]]
     });
   }
 


### PR DESCRIPTION
## Summary
- remove the max length validation from the blog topic editor so longer posts can be saved
- adjust the editor counter to display only the current character count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8156aa608331a4bd7e5bce694514