### PR TITLE
Fix About3 navigation links

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.html
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.html
@@ -13,8 +13,8 @@
           <li>Удобный редактор с подсветкой важных фрагментов</li>
         </ul>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="https://YouScriptor.ru/upload" target="_blank" rel="noopener">Загрузить файл</a>
-          <a class="btn btn-secondary" href="https://YouScriptor.ru/signup" target="_blank" rel="noopener">Получить 15 минут</a>
+          <a class="btn btn-primary" [routerLink]="uploadRoute">Загрузить файл</a>
+          <a class="btn btn-secondary" [routerLink]="trialRoute">Получить 15 минут</a>
         </div>
       </div>
       <div class="hero-card">
@@ -150,7 +150,7 @@
           <ul>
             <li *ngFor="let perk of plan.perks">{{ perk }}</li>
           </ul>
-          <a class="btn btn-primary" [href]="plan.link" target="_blank" rel="noopener">{{ plan.cta }}</a>
+          <a class="btn btn-primary" [routerLink]="plan.link">{{ plan.cta }}</a>
         </article>
       </div>
     </section>
@@ -163,7 +163,7 @@
             Получите 15 тестовых минут, чтобы протестировать скорость и точность сервиса. Перетащите файл или загрузите его с
             устройства — мы сразу начнём обработку.
           </p>
-          <a class="btn btn-primary" href="https://YouScriptor.ru/upload" target="_blank" rel="noopener">Загрузить файл</a>
+          <a class="btn btn-primary" [routerLink]="uploadRoute">Загрузить файл</a>
         </div>
         <div class="cta-preview">
           <h3>Перетащите файлы сюда</h3>

--- a/Angular/youtube-downloader/src/app/about3/about3.component.ts
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 
 interface WorkflowStep {
   readonly title: string;
@@ -25,11 +26,13 @@ interface BusinessFeature {
   readonly image: string;
 }
 
+type RouterCommand = string | string[];
+
 interface PricingPlan {
   readonly title: string;
   readonly description: string;
   readonly perks: readonly string[];
-  readonly link: string;
+  readonly link: RouterCommand;
   readonly cta: string;
 }
 
@@ -41,11 +44,14 @@ interface TrustedCompany {
 @Component({
   selector: 'app-about3',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './about3.component.html',
   styleUrls: ['./about3.component.css'],
 })
 export class About3Component {
+  readonly uploadRoute: RouterCommand = '/transcriptions';
+  readonly trialRoute: RouterCommand = '/billing';
+
   readonly trustedCompanies: readonly TrustedCompany[] = [
     {
       src: 'assets/about3/YouScriptor/avito-seeklogocom_12.png',
@@ -202,7 +208,7 @@ export class About3Component {
       description:
         'Попробуйте YouScriptor бесплатно и получите 15 тестовых минут. Оплачивайте с российских и зарубежных карт или со счета организации.',
       perks: ['15 тестовых минут на старте', 'Удобная оплата картой и по счету', 'Доступ из браузера и мобильных устройств'],
-      link: 'https://YouScriptor.ru/pricing',
+      link: this.trialRoute,
       cta: 'Попробовать онлайн',
     },
     {
@@ -210,7 +216,7 @@ export class About3Component {
       description:
         'Полноценная версия сервиса разворачивается на ваших серверах. Данные обрабатываются внутри инфраструктуры компании.',
       perks: ['Развертывание в частной сети', 'Работа без доступа к интернету', 'Персональная поддержка и SLA'],
-      link: 'https://YouScriptor.ru/business',
+      link: '/about',
       cta: 'Получить предложение',
     },
   ];


### PR DESCRIPTION
## Summary
- replace external YouScriptor links in About3 with internal Angular router navigation
- share reusable router targets for upload, trial, and pricing actions in the component logic
- update pricing CTA destinations to align with available in-app pages

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68dac220dac88331bbdcecff4cdf4b2d