### PR TITLE
Fix hero button layout in About3 component

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -98,6 +98,17 @@ section {
   color: #1e293b;
 }
 
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.hero-actions .btn {
+  flex-shrink: 0;
+}
+
 .hero-card {
   background: #ffffff;
   border: 1px solid #e2e8f0;
@@ -550,6 +561,10 @@ section {
     font-size: 2.4rem;
   }
 
+  .hero-actions {
+    justify-content: center;
+  }
+
   .feature-card {
     grid-template-columns: 1fr;
   }
@@ -570,6 +585,11 @@ section {
 
   .btn {
     width: 100%;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .header-actions {


### PR DESCRIPTION
## Summary
- lay out the hero action buttons with a flex row so the buttons stay on one line
- adjust responsive rules to center the buttons on tablets and stack them on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac57599708331aaa553a196240005