### PR TITLE
Keep YouScriptor advantage cards on one row

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -98,6 +98,17 @@ section {
   color: #1e293b;
 }
 
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.hero-actions .btn {
+  flex-shrink: 0;
+}
+
 .hero-card {
   background: #ffffff;
   border: 1px solid #e2e8f0;
@@ -348,8 +359,14 @@ section {
 
 .advantage-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 24px;
+}
+
+@media (min-width: 768px) {
+  .advantage-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .advantage-card {
@@ -550,6 +567,10 @@ section {
     font-size: 2.4rem;
   }
 
+  .hero-actions {
+    justify-content: center;
+  }
+
   .feature-card {
     grid-template-columns: 1fr;
   }
@@ -570,6 +591,11 @@ section {
 
   .btn {
     width: 100%;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .header-actions {


### PR DESCRIPTION
## Summary
- reduce the minimum column width of the advantage grid and add a tablet breakpoint
- ensure the three numbered YouScriptor feature cards stay aligned on a single row on wider screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac57599708331aaa553a196240005