### PR TITLE
Add administrator-only user management panel

### DIFF
--- a/Angular/youtube-downloader/src/app/admin-users/admin-user-role-dialog.component.css
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-user-role-dialog.component.css
@@ -1,0 +1,18 @@
+.user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.roles-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.role-item {
+  display: flex;
+}

--- a/Angular/youtube-downloader/src/app/admin-users/admin-user-role-dialog.component.html
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-user-role-dialog.component.html
@@ -1,0 +1,25 @@
+<h2 mat-dialog-title>Роли пользователя</h2>
+<mat-dialog-content>
+  <div class="user-info">
+    <strong>{{ data.user.email }}</strong>
+    <span>Распознанных видео: {{ data.user.recognizedVideos }}</span>
+    <span>Зарегистрирован: {{ data.user.registeredAt | date: 'medium' }}</span>
+  </div>
+  <div class="roles-list">
+    <label
+      class="role-item"
+      *ngFor="let role of data.availableRoles"
+    >
+      <mat-checkbox
+        [checked]="isChecked(role)"
+        (change)="toggleRole(role, $event.checked)"
+      >
+        {{ role }}
+      </mat-checkbox>
+    </label>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="close()">Отмена</button>
+  <button mat-flat-button color="primary" type="button" (click)="save()">Сохранить</button>
+</mat-dialog-actions>

--- a/Angular/youtube-downloader/src/app/admin-users/admin-user-role-dialog.component.ts
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-user-role-dialog.component.ts
@@ -1,0 +1,49 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { AdminUserListItem } from '../models/admin-user.model';
+
+export interface AdminUserRoleDialogData {
+  user: AdminUserListItem;
+  availableRoles: string[];
+}
+
+@Component({
+  selector: 'app-admin-user-role-dialog',
+  standalone: true,
+  templateUrl: './admin-user-role-dialog.component.html',
+  styleUrls: ['./admin-user-role-dialog.component.css'],
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatCheckboxModule]
+})
+export class AdminUserRoleDialogComponent {
+  selected = new Set<string>();
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public readonly data: AdminUserRoleDialogData,
+    private readonly dialogRef: MatDialogRef<AdminUserRoleDialogComponent>
+  ) {
+    data.user.roles?.forEach(role => this.selected.add(role));
+  }
+
+  toggleRole(role: string, checked: boolean): void {
+    if (checked) {
+      this.selected.add(role);
+    } else {
+      this.selected.delete(role);
+    }
+  }
+
+  isChecked(role: string): boolean {
+    return this.selected.has(role);
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+
+  save(): void {
+    this.dialogRef.close({ roles: Array.from(this.selected) });
+  }
+}

--- a/Angular/youtube-downloader/src/app/admin-users/admin-users.component.css
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-users.component.css
@@ -1,0 +1,76 @@
+.admin-users {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.filter-card {
+  padding: 16px;
+}
+
+.filter-field {
+  width: 100%;
+}
+
+.users-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.user-card {
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.user-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
+
+.user-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.user-email {
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.user-count {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.user-meta {
+  color: rgba(0, 0, 0, 0.6);
+  margin-bottom: 8px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.user-roles mat-chip-set {
+  display: block;
+}
+
+.loader {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px 0;
+  color: rgba(0, 0, 0, 0.54);
+}

--- a/Angular/youtube-downloader/src/app/admin-users/admin-users.component.html
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-users.component.html
@@ -1,0 +1,60 @@
+<div class="admin-users">
+  <mat-card class="filter-card">
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Поиск по email</mat-label>
+      <input
+        matInput
+        type="search"
+        placeholder="Введите email..."
+        (input)="applyFilter($event)"
+        [value]="filterValue"
+      />
+      <button
+        mat-icon-button
+        matSuffix
+        *ngIf="filterValue"
+        (click)="clearFilter()"
+        aria-label="Очистить фильтр"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+  </mat-card>
+
+  <div
+    class="users-container"
+    infiniteScroll
+    [infiniteScrollDistance]="1"
+    [infiniteScrollThrottle]="200"
+    (scrolled)="onScrollDown()"
+  >
+    <ng-container *ngFor="let user of users; trackBy: trackByUserId">
+      <mat-card class="user-card" (click)="openUserDialog(user)" [attr.data-user-id]="user.id">
+        <div class="user-header">
+          <div class="user-email" title="{{ user.email }}">{{ user.email }}</div>
+          <div class="user-count" title="Распознанных видео">
+            <mat-icon color="primary">movie</mat-icon>
+            <span>{{ user.recognizedVideos }}</span>
+          </div>
+        </div>
+        <div class="user-meta">
+          <span>Дата регистрации:</span>
+          <strong>{{ user.registeredAt | date: 'medium' }}</strong>
+        </div>
+        <div class="user-roles" *ngIf="user.roles?.length">
+          <mat-chip-set>
+            <mat-chip *ngFor="let role of user.roles">{{ role }}</mat-chip>
+          </mat-chip-set>
+        </div>
+      </mat-card>
+    </ng-container>
+
+    <div class="loader" *ngIf="loading">
+      <mat-progress-spinner diameter="36" mode="indeterminate"></mat-progress-spinner>
+    </div>
+
+    <div class="empty-state" *ngIf="!loading && !users.length">
+      <p>Пользователи не найдены.</p>
+    </div>
+  </div>
+</div>

--- a/Angular/youtube-downloader/src/app/admin-users/admin-users.component.ts
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-users.component.ts
@@ -1,0 +1,138 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { AdminUsersService } from '../services/admin-users.service';
+import { AdminUserListItem } from '../models/admin-user.model';
+import { AdminUserRoleDialogComponent } from './admin-user-role-dialog.component';
+
+@Component({
+  selector: 'app-admin-users',
+  standalone: true,
+  templateUrl: './admin-users.component.html',
+  styleUrls: ['./admin-users.component.css'],
+  imports: [
+    CommonModule,
+    DatePipe,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
+    MatButtonModule,
+    MatDialogModule,
+    InfiniteScrollModule
+  ]
+})
+export class AdminUsersComponent implements OnInit {
+  users: AdminUserListItem[] = [];
+  totalCount = 0;
+  pageSize = 20;
+  pageIndex = 0;
+  filterValue = '';
+  loading = false;
+  availableRoles: string[] = [];
+
+  constructor(
+    private readonly adminUsersService: AdminUsersService,
+    private readonly dialog: MatDialog
+  ) {}
+
+  ngOnInit(): void {
+    this.loadRoles();
+    this.loadUsers();
+  }
+
+  applyFilter(event: Event): void {
+    const value = (event.target as HTMLInputElement).value.trim().toLowerCase();
+    this.filterValue = value;
+    this.pageIndex = 0;
+    this.loadUsers();
+  }
+
+  clearFilter(): void {
+    if (!this.filterValue) {
+      return;
+    }
+
+    this.filterValue = '';
+    this.pageIndex = 0;
+    this.loadUsers();
+  }
+
+  onScrollDown(): void {
+    if (this.loading) {
+      return;
+    }
+
+    if (this.users.length >= this.totalCount) {
+      return;
+    }
+
+    this.pageIndex++;
+    this.loadUsers(true);
+  }
+
+  openUserDialog(user: AdminUserListItem): void {
+    const dialogRef = this.dialog.open(AdminUserRoleDialogComponent, {
+      width: '480px',
+      data: {
+        user,
+        availableRoles: this.availableRoles
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (!result || !Array.isArray(result.roles)) {
+        return;
+      }
+
+      this.adminUsersService.updateUserRoles(user.id, result.roles).subscribe({
+        next: roles => {
+          user.roles = roles;
+        },
+        error: err => {
+          console.error('Failed to update roles', err);
+        }
+      });
+    });
+  }
+
+  trackByUserId(_: number, item: AdminUserListItem): string {
+    return item.id;
+  }
+
+  private loadUsers(append = false): void {
+    this.loading = true;
+    const page = this.pageIndex + 1;
+
+    this.adminUsersService
+      .getUsers(page, this.pageSize, this.filterValue)
+      .subscribe({
+        next: res => {
+          this.users = append ? this.users.concat(res.items) : res.items;
+          this.totalCount = res.totalCount;
+          this.loading = false;
+        },
+        error: err => {
+          console.error('Failed to load users', err);
+          this.loading = false;
+        }
+      });
+  }
+
+  private loadRoles(): void {
+    this.adminUsersService.getRoles().subscribe({
+      next: roles => (this.availableRoles = roles),
+      error: err => console.error('Failed to load roles', err)
+    });
+  }
+}

--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -5,6 +5,8 @@ import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
 import { BillingComponent } from './billing/billing.component';
 import { AuthGuard } from './services/auth.guard';
+import { RoleGuard } from './services/role.guard';
+import { AdminUsersComponent } from './admin-users/admin-users.component';
 import { AboutBusinessComponent } from './about-business/about-business.component';
 import { About1Component } from './about1/about1.component';
 import { About2Component } from './about2/about2.component';
@@ -16,6 +18,12 @@ const routes: Routes = [
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'billing', component: BillingComponent, canActivate: [AuthGuard] },
+  {
+    path: 'admin/users',
+    component: AdminUsersComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Admin'] }
+  },
   { path: 'about', component: AboutBusinessComponent },
   { path: 'about1', component: About1Component },
   { path: 'about2', component: About2Component },

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -10,6 +10,8 @@ import { AboutBusinessComponent } from './about-business/about-business.componen
 import { About1Component } from './about1/about1.component';
 import { About2Component } from './about2/about2.component';
 import { About3Component } from './about3/about3.component';
+import { RoleGuard } from './services/role.guard';
+import { AdminUsersComponent } from './admin-users/admin-users.component';
 
 export const appRoutes: Routes = [
   { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
@@ -18,6 +20,12 @@ export const appRoutes: Routes = [
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
   { path: 'billing', component: BillingComponent, canActivate: [AuthGuard] },
+  {
+    path: 'admin/users',
+    component: AdminUsersComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Admin'] }
+  },
   { path: 'about', component: AboutBusinessComponent },
   { path: 'about1', component: About1Component },
   { path: 'about2', component: About2Component },

--- a/Angular/youtube-downloader/src/app/models/admin-user.model.ts
+++ b/Angular/youtube-downloader/src/app/models/admin-user.model.ts
@@ -1,0 +1,13 @@
+export interface AdminUserListItem {
+  id: string;
+  email: string;
+  displayName: string;
+  recognizedVideos: number;
+  registeredAt: string;
+  roles: string[];
+}
+
+export interface AdminUsersPage {
+  items: AdminUserListItem[];
+  totalCount: number;
+}

--- a/Angular/youtube-downloader/src/app/services/admin-users.service.ts
+++ b/Angular/youtube-downloader/src/app/services/admin-users.service.ts
@@ -1,0 +1,31 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AdminUsersPage } from '../models/admin-user.model';
+
+@Injectable({ providedIn: 'root' })
+export class AdminUsersService {
+  private readonly apiUrl = '/api/admin/users';
+
+  constructor(private readonly http: HttpClient) {}
+
+  getUsers(page: number, pageSize: number, filter?: string): Observable<AdminUsersPage> {
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('pageSize', pageSize.toString());
+
+    if (filter) {
+      params = params.set('filter', filter);
+    }
+
+    return this.http.get<AdminUsersPage>(this.apiUrl, { params });
+  }
+
+  getRoles(): Observable<string[]> {
+    return this.http.get<string[]>(`${this.apiUrl}/roles`);
+  }
+
+  updateUserRoles(userId: string, roles: string[]): Observable<string[]> {
+    return this.http.put<string[]>(`${this.apiUrl}/${userId}/roles`, { roles });
+  }
+}

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -38,6 +38,10 @@
       <mat-icon matListItemIcon>credit_card</mat-icon>
       <span matListItemTitle>Подписки и баланс</span>
     </a>
+    <a mat-list-item *ngIf="hasRole(user, 'Admin')" (click)="navigate('/admin/users')">
+      <mat-icon matListItemIcon>group</mat-icon>
+      <span matListItemTitle>Пользователи</span>
+    </a>
     <a mat-list-item *ngIf="hasRole(user, 'Moderator')" (click)="navigate('/blog/new')">
       <mat-icon matListItemIcon>post_add</mat-icon>
       <span matListItemTitle>Новая тема</span>

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -37,6 +37,7 @@ import { AboutBusinessComponent } from './app/about-business/about-business.comp
 import { About1Component } from './app/about1/about1.component';
 import { About2Component } from './app/about2/about2.component';
 import { About3Component } from './app/about3/about3.component';
+import { AdminUsersComponent } from './app/admin-users/admin-users.component';
 
 
 
@@ -149,6 +150,12 @@ const routes: Routes = [
     path: 'billing',
     component: BillingComponent,
     canActivate: [AuthGuard]
+  },
+  {
+    path: 'admin/users',
+    component: AdminUsersComponent,
+    canActivate: [RoleGuard],
+    data: { roles: ['Admin'] }
   },
   {
     path: 'profile',

--- a/Controllers/AdminUsersController.cs
+++ b/Controllers/AdminUsersController.cs
@@ -1,0 +1,205 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using YandexSpeech.models.DB;
+using YandexSpeech.models.DTO;
+
+namespace YandexSpeech.Controllers
+{
+    [ApiController]
+    [Route("api/admin/users")]
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Roles = "Admin")]
+    public class AdminUsersController : ControllerBase
+    {
+        private readonly MyDbContext _dbContext;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
+
+        public AdminUsersController(
+            MyDbContext dbContext,
+            UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager)
+        {
+            _dbContext = dbContext;
+            _userManager = userManager;
+            _roleManager = roleManager;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<AdminUsersPageDto>> GetUsers(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20,
+            [FromQuery] string? filter = null)
+        {
+            const int maxPageSize = 100;
+            page = Math.Max(page, 1);
+            pageSize = Math.Min(Math.Max(pageSize, 1), maxPageSize);
+
+            var usersQuery = _userManager.Users.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(filter))
+            {
+                var normalized = filter.Trim().ToLower();
+                usersQuery = usersQuery.Where(u => u.Email != null && u.Email.ToLower().Contains(normalized));
+            }
+
+            var captionCountsQuery = _dbContext.YoutubeCaptionTasks
+                .Where(t => t.UserId != null && t.Done)
+                .GroupBy(t => t.UserId!)
+                .Select(g => new
+                {
+                    UserId = g.Key,
+                    Count = g.Count()
+                });
+
+            var baseQuery = from user in usersQuery
+                            join count in captionCountsQuery on user.Id equals count.UserId into userCounts
+                            from count in userCounts.DefaultIfEmpty()
+                            select new
+                            {
+                                User = user,
+                                Recognized = count != null ? count.Count : 0
+                            };
+
+            var totalCount = await baseQuery.CountAsync();
+
+            var paged = await baseQuery
+                .OrderByDescending(x => x.Recognized)
+                .ThenBy(x => x.User.Email)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Select(x => new
+                {
+                    x.User.Id,
+                    x.User.Email,
+                    x.User.DisplayName,
+                    x.User.CreatedAt,
+                    Recognized = x.Recognized
+                })
+                .ToListAsync();
+
+            var userIds = paged.Select(p => p.Id).ToList();
+
+            var rolesLookup = await _dbContext.UserRoles
+                .Where(ur => userIds.Contains(ur.UserId))
+                .Join(
+                    _dbContext.Roles,
+                    ur => ur.RoleId,
+                    r => r.Id,
+                    (ur, role) => new { ur.UserId, role.Name })
+                .GroupBy(x => x.UserId)
+                .ToDictionaryAsync(
+                    g => g.Key,
+                    g => (IReadOnlyCollection<string>)g
+                        .Where(x => x.Name != null)
+                        .Select(x => x.Name!)
+                        .ToList());
+
+            var items = paged.Select(p => new AdminUserListItemDto
+            {
+                Id = p.Id,
+                Email = p.Email ?? string.Empty,
+                DisplayName = p.DisplayName ?? string.Empty,
+                RecognizedVideos = p.Recognized,
+                RegisteredAt = p.CreatedAt,
+                Roles = rolesLookup.TryGetValue(p.Id, out var r) ? r : Array.Empty<string>()
+            }).ToList();
+
+            return Ok(new AdminUsersPageDto
+            {
+                Items = items,
+                TotalCount = totalCount
+            });
+        }
+
+        [HttpGet("roles")]
+        public async Task<ActionResult<IEnumerable<string>>> GetRoles()
+        {
+            var roles = await _roleManager.Roles
+                .Select(r => r.Name)
+                .Where(name => name != null)
+                .OrderBy(name => name)
+                .Select(name => name!)
+                .ToListAsync();
+
+            return Ok(roles);
+        }
+
+        [HttpPut("{userId}/roles")]
+        public async Task<ActionResult<IEnumerable<string>>> UpdateRoles(string userId, [FromBody] UpdateUserRolesRequest request)
+        {
+            if (request == null)
+            {
+                return BadRequest("Request body is required");
+            }
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return NotFound();
+            }
+
+            var availableRoles = await _roleManager.Roles
+                .Select(r => r.Name)
+                .Where(name => name != null)
+                .Select(name => name!)
+                .ToListAsync();
+
+            var normalizedRoles = (request.Roles ?? new List<string>())
+                .Where(r => !string.IsNullOrWhiteSpace(r))
+                .Select(r => r.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var invalidRoles = normalizedRoles
+                .Where(role => !availableRoles.Any(ar => string.Equals(ar, role, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            if (invalidRoles.Any())
+            {
+                return BadRequest(new { message = $"Unknown roles: {string.Join(", ", invalidRoles)}" });
+            }
+
+            var resolvedRoles = normalizedRoles
+                .Select(role => availableRoles.First(ar => string.Equals(ar, role, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            var currentRoles = await _userManager.GetRolesAsync(user);
+
+            var rolesToAdd = resolvedRoles
+                .Except(currentRoles, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var rolesToRemove = currentRoles
+                .Except(resolvedRoles, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (rolesToAdd.Any())
+            {
+                var addResult = await _userManager.AddToRolesAsync(user, rolesToAdd);
+                if (!addResult.Succeeded)
+                {
+                    return BadRequest(addResult.Errors);
+                }
+            }
+
+            if (rolesToRemove.Any())
+            {
+                var removeResult = await _userManager.RemoveFromRolesAsync(user, rolesToRemove);
+                if (!removeResult.Succeeded)
+                {
+                    return BadRequest(removeResult.Errors);
+                }
+            }
+
+            var updatedRoles = await _userManager.GetRolesAsync(user);
+            return Ok(updatedRoles);
+        }
+    }
+}

--- a/dbcontext.cs
+++ b/dbcontext.cs
@@ -160,6 +160,10 @@ namespace YandexSpeech
                 .WithMany()
                 .HasForeignKey(u => u.CurrentSubscriptionId)
                 .OnDelete(DeleteBehavior.SetNull);
+
+            builder.Entity<ApplicationUser>()
+                .Property(u => u.CreatedAt)
+                .HasDefaultValueSql("GETUTCDATE()");
         }
 
     }

--- a/models/DB/ApplicationUser.cs
+++ b/models/DB/ApplicationUser.cs
@@ -12,6 +12,11 @@ namespace YandexSpeech.models.DB
         public string DisplayName { get; set; } = string.Empty;
 
         /// <summary>
+        /// Дата и время регистрации пользователя (UTC).
+        /// </summary>
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
         /// Текущая активная подписка пользователя (если есть).
         /// </summary>
         public Guid? CurrentSubscriptionId { get; set; }

--- a/models/DTO/AdminUserDtos.cs
+++ b/models/DTO/AdminUserDtos.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace YandexSpeech.models.DTO
+{
+    public class AdminUserListItemDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public int RecognizedVideos { get; set; }
+        public DateTime RegisteredAt { get; set; }
+        public IReadOnlyCollection<string> Roles { get; set; } = Array.Empty<string>();
+    }
+
+    public class AdminUsersPageDto
+    {
+        public IReadOnlyCollection<AdminUserListItemDto> Items { get; set; } = Array.Empty<AdminUserListItemDto>();
+        public int TotalCount { get; set; }
+    }
+
+    public class UpdateUserRolesRequest
+    {
+        public List<string> Roles { get; set; } = new List<string>();
+    }
+}


### PR DESCRIPTION
## Summary
- add an administrator API controller and DTOs for paging through users, including role management endpoints and registration timestamps
- expose user registration metadata on ApplicationUser with a default value for new records
- implement an Angular admin-only user list with infinite scrolling, filtering, role editing dialog, and navigation access

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68db98e604388331ab72a69324c022ea