### PR TITLE
Fix admin users query translation

### DIFF
--- a/Controllers/AdminUsersController.cs
+++ b/Controllers/AdminUsersController.cs
@@ -58,14 +58,16 @@ namespace YandexSpeech.Controllers
                     Count = g.Count()
                 });
 
-            var baseQuery = from user in usersQuery
-                            join count in captionCountsQuery on user.Id equals count.UserId into userCounts
-                            from count in userCounts.DefaultIfEmpty()
-                            select new
-                            {
-                                User = user,
-                                Recognized = count != null ? count.Count : 0
-                            };
+            var baseQuery = usersQuery
+                .GroupJoin(
+                    captionCountsQuery,
+                    user => user.Id,
+                    count => count.UserId,
+                    (user, counts) => new
+                    {
+                        User = user,
+                        Recognized = counts.Sum(c => (int?)c.Count) ?? 0
+                    });
 
             var totalCount = await baseQuery.CountAsync();
 


### PR DESCRIPTION
## Summary
- rewrite the admin users caption count query to use GroupJoin and aggregate counts
- ensure ordering operates on translated query results to prevent InvalidOperationException

## Testing
- dotnet build YandexSpeech.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dba2d31d18833186197b0fb2183db3