### PR TITLE
Fix duplicate assembly attribute generation

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+
+[assembly: AssemblyCompany("YandexSpeech")]
+[assembly: AssemblyProduct("YandexSpeech")]
+[assembly: AssemblyTitle("YandexSpeech")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+#else
+[assembly: AssemblyConfiguration("Release")]
+#endif

--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+        <PropertyGroup>
+                <TargetFramework>net9.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        </PropertyGroup>
 
 	<ItemGroup>
                 <PackageReference Include="AngleSharp" Version="1.2.0" />


### PR DESCRIPTION
## Summary
- disable automatic assembly attribute generation to prevent duplicate attributes
- add an explicit `Properties/AssemblyInfo.cs` that defines the assembly metadata

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dba4b4b2788331add2f498268ec89d