### PR TITLE
Refactor admin users list into infinite table

### DIFF
--- a/Angular/youtube-downloader/src/app/admin-users/admin-users.component.css
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-users.component.css
@@ -4,63 +4,57 @@
   gap: 16px;
 }
 
-.filter-card {
-  padding: 16px;
+.table-card {
+  width: 100%;
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .filter-field {
   width: 100%;
 }
 
-.users-container {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  max-height: calc(100vh - 200px);
-  overflow-y: auto;
-  padding-right: 8px;
+.users-table {
+  width: 100%;
 }
 
-.user-card {
+.users-table th.mat-header-cell {
+  font-weight: 600;
+}
+
+.clickable-row {
   cursor: pointer;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: background-color 0.2s ease;
 }
 
-.user-card:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  transform: translateY(-2px);
+.clickable-row:hover {
+  background-color: rgba(0, 0, 0, 0.04);
 }
 
-.user-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 8px;
+.clickable-cell {
+  cursor: pointer;
 }
 
-.user-email {
+.email-wrapper {
   font-weight: 600;
-  word-break: break-all;
+  word-break: break-word;
 }
 
-.user-count {
-  display: flex;
+.videos-count {
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   font-weight: 600;
 }
 
-.user-meta {
-  color: rgba(0, 0, 0, 0.6);
-  margin-bottom: 8px;
-  display: flex;
-  gap: 6px;
-  align-items: baseline;
-}
-
-.user-roles mat-chip-set {
-  display: block;
+.roles-cell mat-chip-set {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .loader {

--- a/Angular/youtube-downloader/src/app/admin-users/admin-users.component.html
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-users.component.html
@@ -1,60 +1,87 @@
 <div class="admin-users">
-  <mat-card class="filter-card">
-    <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>Поиск по email</mat-label>
-      <input
-        matInput
-        type="search"
-        placeholder="Введите email..."
-        (input)="applyFilter($event)"
-        [value]="filterValue"
-      />
-      <button
-        mat-icon-button
-        matSuffix
-        *ngIf="filterValue"
-        (click)="clearFilter()"
-        aria-label="Очистить фильтр"
-      >
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
+  <mat-card class="table-card">
+    <mat-card-header>
+      <mat-card-title>Пользователи</mat-card-title>
+    </mat-card-header>
+
+    <mat-card-content
+      class="card-content"
+      infiniteScroll
+      [scrollWindow]="true"
+      [infiniteScrollDistance]="1"
+      [infiniteScrollThrottle]="200"
+      (scrolled)="onScrollDown()"
+    >
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Поиск по email</mat-label>
+        <input
+          matInput
+          type="search"
+          placeholder="Введите email..."
+          (input)="applyFilter($event)"
+          [value]="filterValue"
+        />
+        <button
+          mat-icon-button
+          matSuffix
+          *ngIf="filterValue"
+          (click)="clearFilter()"
+          aria-label="Очистить фильтр"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+
+      <table mat-table [dataSource]="users" class="users-table" *ngIf="users.length; else emptyState">
+        <ng-container matColumnDef="email">
+          <th mat-header-cell *matHeaderCellDef>Email</th>
+          <td mat-cell *matCellDef="let user" class="clickable-cell">
+            <div class="email-wrapper" [title]="user.email">{{ user.email }}</div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="registeredAt">
+          <th mat-header-cell *matHeaderCellDef>Дата регистрации</th>
+          <td mat-cell *matCellDef="let user" class="clickable-cell">
+            {{ user.registeredAt | date: 'medium' }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="recognizedVideos">
+          <th mat-header-cell *matHeaderCellDef>Распознанные видео</th>
+          <td mat-cell *matCellDef="let user" class="clickable-cell">
+            <div class="videos-count">
+              <mat-icon color="primary">movie</mat-icon>
+              <span>{{ user.recognizedVideos }}</span>
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="roles">
+          <th mat-header-cell *matHeaderCellDef>Роли</th>
+          <td mat-cell *matCellDef="let user" class="clickable-cell roles-cell">
+            <ng-container *ngIf="user.roles?.length; else noRoles">
+              <mat-chip-set>
+                <mat-chip *ngFor="let role of user.roles">{{ role }}</mat-chip>
+              </mat-chip-set>
+            </ng-container>
+            <ng-template #noRoles>—</ng-template>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" class="clickable-row" (click)="openUserDialog(row)"></tr>
+      </table>
+
+      <div class="loader" *ngIf="loading">
+        <mat-progress-spinner diameter="36" mode="indeterminate"></mat-progress-spinner>
+      </div>
+    </mat-card-content>
   </mat-card>
-
-  <div
-    class="users-container"
-    infiniteScroll
-    [infiniteScrollDistance]="1"
-    [infiniteScrollThrottle]="200"
-    (scrolled)="onScrollDown()"
-  >
-    <ng-container *ngFor="let user of users; trackBy: trackByUserId">
-      <mat-card class="user-card" (click)="openUserDialog(user)" [attr.data-user-id]="user.id">
-        <div class="user-header">
-          <div class="user-email" title="{{ user.email }}">{{ user.email }}</div>
-          <div class="user-count" title="Распознанных видео">
-            <mat-icon color="primary">movie</mat-icon>
-            <span>{{ user.recognizedVideos }}</span>
-          </div>
-        </div>
-        <div class="user-meta">
-          <span>Дата регистрации:</span>
-          <strong>{{ user.registeredAt | date: 'medium' }}</strong>
-        </div>
-        <div class="user-roles" *ngIf="user.roles?.length">
-          <mat-chip-set>
-            <mat-chip *ngFor="let role of user.roles">{{ role }}</mat-chip>
-          </mat-chip-set>
-        </div>
-      </mat-card>
-    </ng-container>
-
-    <div class="loader" *ngIf="loading">
-      <mat-progress-spinner diameter="36" mode="indeterminate"></mat-progress-spinner>
-    </div>
-
-    <div class="empty-state" *ngIf="!loading && !users.length">
-      <p>Пользователи не найдены.</p>
-    </div>
-  </div>
 </div>
+
+<ng-template #emptyState>
+  <div class="empty-state" *ngIf="!loading">
+    <p>Пользователи не найдены.</p>
+  </div>
+</ng-template>

--- a/Angular/youtube-downloader/src/app/admin-users/admin-users.component.ts
+++ b/Angular/youtube-downloader/src/app/admin-users/admin-users.component.ts
@@ -9,6 +9,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { MatTableModule } from '@angular/material/table';
 import { AdminUsersService } from '../services/admin-users.service';
 import { AdminUserListItem } from '../models/admin-user.model';
 import { AdminUserRoleDialogComponent } from './admin-user-role-dialog.component';
@@ -29,7 +30,8 @@ import { AdminUserRoleDialogComponent } from './admin-user-role-dialog.component
     MatChipsModule,
     MatButtonModule,
     MatDialogModule,
-    InfiniteScrollModule
+    InfiniteScrollModule,
+    MatTableModule
   ]
 })
 export class AdminUsersComponent implements OnInit {
@@ -40,6 +42,7 @@ export class AdminUsersComponent implements OnInit {
   filterValue = '';
   loading = false;
   availableRoles: string[] = [];
+  displayedColumns: string[] = ['email', 'registeredAt', 'recognizedVideos', 'roles'];
 
   constructor(
     private readonly adminUsersService: AdminUsersService,
@@ -104,10 +107,6 @@ export class AdminUsersComponent implements OnInit {
         }
       });
     });
-  }
-
-  trackByUserId(_: number, item: AdminUserListItem): string {
-    return item.id;
   }
 
   private loadUsers(append = false): void {


### PR DESCRIPTION
## Summary
- replace the admin users card feed with a Material table that mirrors the /tasks infinite-scroll experience
- add column definitions, roles display, and refreshed styling for the tabular layout

## Testing
- CI=true npm run start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68dba6f184388331aa56017b6e574869