### PR TITLE
Add background download support for OpenAI transcription URLs

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -348,6 +348,10 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
       return 'error';
     }
 
+    if (task.status === OpenAiTranscriptionStatus.Downloading) {
+      return 'cloud_download';
+    }
+
     if (task.done) {
       return 'check_circle';
     }
@@ -387,6 +391,7 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
         return 'status-done';
       case OpenAiTranscriptionStatus.Error:
         return 'status-error';
+      case OpenAiTranscriptionStatus.Downloading:
       case OpenAiTranscriptionStatus.Converting:
       case OpenAiTranscriptionStatus.Transcribing:
       case OpenAiTranscriptionStatus.Segmenting:

--- a/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
+++ b/Angular/youtube-downloader/src/app/services/openai-transcription.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 export enum OpenAiTranscriptionStatus {
   Created = 0,
+  Downloading = 5,
   Converting = 10,
   Transcribing = 20,
   Segmenting = 25,
@@ -123,6 +124,8 @@ export class OpenAiTranscriptionService {
     switch (status) {
       case OpenAiTranscriptionStatus.Created:
         return 'В очереди';
+      case OpenAiTranscriptionStatus.Downloading:
+        return 'Загрузка файла';
       case OpenAiTranscriptionStatus.Converting:
         return 'Преобразование аудио';
       case OpenAiTranscriptionStatus.Transcribing:

--- a/Migrations/20251011000000_add_source_file_url.cs
+++ b/Migrations/20251011000000_add_source_file_url.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace YandexSpeech.Migrations
+{
+    public partial class AddSourceFileUrl : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SourceFileUrl",
+                table: "OpenAiTranscriptionTasks",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourceFileUrl",
+                table: "OpenAiTranscriptionTasks");
+        }
+    }
+}

--- a/Migrations/MyDbContextModelSnapshot.cs
+++ b/Migrations/MyDbContextModelSnapshot.cs
@@ -572,6 +572,9 @@ namespace YandexSpeech.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<string>("SourceFileUrl")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<int>("Status")
                         .HasColumnType("int");
 

--- a/models/DB/OpenAiTranscriptionTask.cs
+++ b/models/DB/OpenAiTranscriptionTask.cs
@@ -8,6 +8,7 @@ namespace YandexSpeech.models.DB
     public enum OpenAiTranscriptionStatus
     {
         Created = 0,
+        Downloading = 5,
         Converting = 10,
         Transcribing = 20,
         Segmenting = 25,
@@ -33,6 +34,8 @@ namespace YandexSpeech.models.DB
 
         [Required]
         public string SourceFilePath { get; set; } = null!;
+
+        public string? SourceFileUrl { get; set; }
 
         public string? ConvertedFilePath { get; set; }
 

--- a/services/IntegratedFormattingOpenAiTranscriptionService.cs
+++ b/services/IntegratedFormattingOpenAiTranscriptionService.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -17,8 +18,17 @@ namespace YandexSpeech.services
             IConfiguration configuration,
             ILoggerFactory loggerFactory,
             IPunctuationService punctuationService,
-            IWhisperTranscriptionService whisperTranscriptionService)
-            : base(dbContext, configuration, loggerFactory.CreateLogger<OpenAiTranscriptionService>(), punctuationService, whisperTranscriptionService)
+            IWhisperTranscriptionService whisperTranscriptionService,
+            IHttpClientFactory httpClientFactory,
+            IYandexDiskDownloadService yandexDiskDownloadService)
+            : base(
+                dbContext,
+                configuration,
+                loggerFactory.CreateLogger<OpenAiTranscriptionService>(),
+                punctuationService,
+                whisperTranscriptionService,
+                httpClientFactory,
+                yandexDiskDownloadService)
         {
         }
 

--- a/services/Interface/IOpenAiTranscriptionService.cs
+++ b/services/Interface/IOpenAiTranscriptionService.cs
@@ -8,7 +8,8 @@ namespace YandexSpeech.services
         Task<OpenAiTranscriptionTask> StartTranscriptionAsync(
             string sourceFilePath,
             string createdBy,
-            string? clarification = null);
+            string? clarification = null,
+            string? sourceFileUrl = null);
         Task<OpenAiTranscriptionTask?> PrepareForContinuationAsync(string taskId);
         Task<OpenAiTranscriptionTask?> ContinueTranscriptionAsync(string taskId);
     }

--- a/services/OpenAiTranscriptionFileHelper.cs
+++ b/services/OpenAiTranscriptionFileHelper.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace YandexSpeech.services
+{
+    internal static class OpenAiTranscriptionFileHelper
+    {
+        public static string GenerateStoredFilePath(string uploadsDirectory, string sanitizedName)
+        {
+            var storedFileName = $"{DateTime.UtcNow:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}__{sanitizedName}";
+            return Path.Combine(uploadsDirectory, storedFileName);
+        }
+
+        public static string SanitizeFileName(string? fileName)
+        {
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var cleaned = new string((fileName ?? string.Empty).Where(c => !invalidChars.Contains(c)).ToArray());
+            if (string.IsNullOrWhiteSpace(cleaned))
+            {
+                cleaned = "audio";
+            }
+
+            var extension = Path.GetExtension(cleaned);
+            var nameWithoutExtension = Path.GetFileNameWithoutExtension(cleaned);
+
+            if (nameWithoutExtension.Length > 80)
+            {
+                nameWithoutExtension = nameWithoutExtension[..80];
+            }
+
+            return string.IsNullOrEmpty(extension)
+                ? nameWithoutExtension
+                : $"{nameWithoutExtension}{extension}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate external transcription URLs without downloading the file in the controller and share file name helpers
- extend the OpenAI transcription service with a background download step and persist the source URL for retries
- expose the new "downloading" status in the Angular UI and update tests/migrations accordingly

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd3b9e4dc8331bde57a6143f81788