### PR TITLE
Restyle transcriptions page

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -1,69 +1,323 @@
+:host {
+  display: block;
+  color: #102a43;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+  min-height: 100vh;
+}
+
 .transcription-page {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 16px;
+  min-height: 100vh;
 }
 
-.upload-card {
+.page-content {
   display: flex;
   flex-direction: column;
+  gap: 96px;
+  padding: 80px 32px 120px;
+}
+
+section {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: center;
+}
+
+.hero-text h1 {
+  font-size: 3rem;
+  line-height: 1.15;
+  margin-bottom: 24px;
+  color: #0f172a;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 24px;
+  max-width: 560px;
+  color: #334155;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 32px;
+  display: grid;
+  gap: 14px;
+}
+
+.hero-highlights li {
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
   gap: 16px;
+  align-items: center;
 }
 
-.upload-card-text {
-  display: flex;
-  flex-direction: column;
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  font-size: 1rem;
 }
 
-.upload-actions {
-  display: flex;
-  justify-content: flex-start;
+.btn mat-icon {
+  font-size: 20px;
 }
 
-.upload-card-text h2 {
-  margin: 0;
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(46, 130, 255, 0.35);
 }
 
-.upload-hint {
-  margin: 0;
-  color: rgba(0, 0, 0, 0.65);
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(46, 130, 255, 0.45);
 }
 
-.upload-caption {
-  font-size: 0.9rem;
-  color: rgba(0, 0, 0, 0.6);
+.btn-secondary {
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+  border-color: rgba(29, 78, 216, 0.3);
 }
 
-.layout {
+.btn-secondary:hover:not(:disabled) {
+  background: rgba(29, 78, 216, 0.12);
+  transform: translateY(-2px);
+}
+
+.btn-outline {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(59, 130, 246, 0.25);
+  color: #1d4ed8;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  border-radius: 14px;
+}
+
+.btn-outline:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 32px;
+  padding: 36px;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-}
-
-.tasks-card,
-.details-card {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  gap: 28px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
 }
 
 .card-header {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-dropzone {
+  background: #f8fbff;
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px dashed rgba(148, 163, 184, 0.7);
+  text-align: center;
+  display: grid;
+  gap: 12px;
+  color: #0f172a;
+}
+
+.card-dropzone span {
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.card-preview {
+  background: #f1f5f9;
+  border-radius: 20px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+}
+
+.card-preview img {
+  width: min(100%, 320px);
+  border-radius: 16px;
+  box-shadow: 0 20px 32px rgba(15, 23, 42, 0.16);
+}
+
+.card-preview-caption {
+  font-size: 0.95rem;
+  color: #475569;
+  text-align: center;
+}
+
+.section-header {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.section-header h2 {
+  font-size: 2.4rem;
+  color: #0b1f33;
+  margin: 0;
+}
+
+.section-header p {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #42526b;
+  max-width: 720px;
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 32px;
+  align-items: start;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 12px;
+}
+
+.panel-header h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #0f172a;
+}
+
+.panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.8);
+  color: #1d4ed8;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.icon-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.icon-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tasks-list .mat-mdc-list-item {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 255, 0.9);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease;
+  padding-inline: 18px;
+}
+
+.tasks-list .mat-mdc-list-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(29, 78, 216, 0.16);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.tasks-list .mat-mdc-list-item.active {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 20px 36px rgba(46, 130, 255, 0.32);
+  border-color: transparent;
+}
+
+.tasks-list .mat-mdc-list-item.active mat-icon {
+  color: #ffffff;
+}
+
+.tasks-list mat-icon {
+  color: #1d4ed8;
 }
 
 .empty-state {
   text-align: center;
-  padding: 24px 12px;
-  color: rgba(0, 0, 0, 0.6);
+  padding: 24px 16px;
+  background: rgba(248, 250, 255, 0.8);
+  border-radius: 24px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  display: grid;
+  gap: 8px;
+  color: #475569;
 }
 
-.error {
-  color: #d32f2f;
+.empty-state h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
 }
 
 .loading-state {
@@ -71,58 +325,81 @@
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  padding: 32px 0;
-  color: rgba(0, 0, 0, 0.6);
+  padding: 40px 0;
+  color: #475569;
+}
+
+.details-panel {
+  min-height: 460px;
 }
 
 .details-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-}
-
-.clarification-display {
-  background-color: rgba(0, 0, 0, 0.03);
-  padding: 8px 12px;
-  border-radius: 6px;
-  display: inline-flex;
-  gap: 6px;
   flex-wrap: wrap;
 }
 
+.details-title {
+  display: grid;
+  gap: 12px;
+}
+
+.details-title h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.clarification-display {
+  background: rgba(59, 130, 246, 0.08);
+  padding: 10px 14px;
+  border-radius: 14px;
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+  color: #1e3a8a;
+}
+
 .status-chip {
-  font-size: 0.85rem;
-  padding: 4px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
   border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  font-weight: 600;
 }
 
 .status-done {
-  background-color: rgba(76, 175, 80, 0.1);
-  color: #2e7d32;
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
 }
 
 .status-error {
-  background-color: rgba(244, 67, 54, 0.12);
-  color: #c62828;
+  background: rgba(239, 68, 68, 0.2);
+  color: #b91c1c;
 }
 
 .status-progress {
-  background-color: rgba(63, 81, 181, 0.12);
-  color: #283593;
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
 }
 
 .status-pending {
-  background-color: rgba(0, 0, 0, 0.06);
-  color: rgba(0, 0, 0, 0.6);
+  background: rgba(148, 163, 184, 0.24);
+  color: #475569;
 }
 
 .details-actions {
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 .inline-spinner {
@@ -130,67 +407,27 @@
   height: 28px !important;
 }
 
-.steps-section h3,
-.result-block h3 {
-  margin-top: 0;
+.result-block {
+  display: grid;
+  gap: 20px;
+  background: rgba(248, 250, 255, 0.9);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
-.steps-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.result-header {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.steps-list li {
-  display: flex;
-  gap: 12px;
-  align-items: flex-start;
-  padding: 12px;
-  border-radius: 8px;
-  background-color: rgba(0, 0, 0, 0.02);
-}
-
-.steps-list li.step-completed {
-  background-color: rgba(76, 175, 80, 0.08);
-}
-
-.steps-list li.step-progress {
-  background-color: rgba(33, 150, 243, 0.08);
-}
-
-.steps-list li.step-error {
-  background-color: rgba(244, 67, 54, 0.08);
-}
-
-.steps-list li.step-pending {
-  background-color: rgba(0, 0, 0, 0.03);
-}
-
-.step-content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.step-title {
-  font-weight: 600;
-}
-
-.step-meta {
-  font-size: 0.9rem;
-  color: rgba(0, 0, 0, 0.65);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
   align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
-.step-error {
-  font-size: 0.85rem;
-  color: #c62828;
+.result-header h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
 }
 
 .result-actions {
@@ -200,37 +437,174 @@
 }
 
 .markdown-content {
-  border: 0px solid rgba(0, 0, 0, 0.12);
-  border-radius: 8px;
-  padding: 16px;
-  background-color: transparent;
+  border-radius: 18px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  max-height: 480px;
+  overflow-y: auto;
 }
 
 pre {
-  background: transparent;
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  padding: 16px;
-  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 18px;
+  border-radius: 18px;
   overflow-x: auto;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.steps-section {
+  display: grid;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.steps-section h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.steps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.steps-list li {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 14px;
+  align-items: flex-start;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(241, 245, 249, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.steps-list li.step-completed {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.steps-list li.step-progress {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(37, 99, 235, 0.35);
+}
+
+.steps-list li.step-error {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(220, 38, 38, 0.4);
+}
+
+.steps-list li.step-pending {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.step-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1d4ed8;
+}
+
+.step-content {
+  display: grid;
+  gap: 6px;
+}
+
+.step-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.step-meta {
+  font-size: 0.9rem;
+  color: #475569;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.step-error {
+  font-size: 0.85rem;
+  color: #b91c1c;
+}
+
+.error {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    border-radius: 28px;
+  }
 }
 
 @media (max-width: 768px) {
+  .page-content {
+    padding: 48px 20px 80px;
+    gap: 64px;
+  }
+
+  .hero-text h1 {
+    font-size: 2.4rem;
+  }
+
+  .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .btn-secondary {
+    text-align: center;
+  }
+
+  .hero-actions {
+    width: 100%;
+  }
+
   .result-actions {
     flex-direction: column;
     align-items: stretch;
   }
 }
 
-@media (min-width: 960px) {
-  .layout {
-    display: grid;
-    grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-    align-items: start;
+@media (max-width: 480px) {
+  .page-content {
+    padding: 40px 16px 64px;
   }
 
-  .tasks-card,
-  .details-card,
-  .empty-details {
-    height: 100%;
+  .hero-card,
+  .panel {
+    padding: 24px;
+  }
+
+  .workspace-grid {
+    gap: 24px;
   }
 }

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -1,194 +1,238 @@
 <div class="transcription-page">
-  <mat-card class="upload-card">
-    <div class="upload-card-text">
-      <h2>Новая расшифровка</h2>
-      <p class="upload-hint">
-        Загрузите аудио или видео файл с компьютера или укажите прямую ссылку (Яндекс.Диск и т.д.),
-        чтобы отправить его в обработку через OpenAI.
-      </p>
-    </div>
-    <div class="upload-actions">
-      <button mat-raised-button color="primary" (click)="openUploadDialog()" [disabled]="uploading">
-        <mat-icon>cloud_upload</mat-icon>
-        <span>Загрузить</span>
-      </button>
-    </div>    
-  </mat-card>
-
-  <div class="layout">
-    <mat-card class="tasks-card">
-      <div class="card-header">
-        <h2>Мои расшифровки</h2>
-        <button mat-icon-button (click)="loadTasks()" [disabled]="uploading">
-          <mat-icon>refresh</mat-icon>
-        </button>
-      </div>
-      <div class="error" *ngIf="listError">{{ listError }}</div>
-      <mat-nav-list *ngIf="tasks.length; else emptyTasks">
-        <a
-          mat-list-item
-          *ngFor="let task of tasks; trackBy: trackTask"
-          (click)="selectTask(task)"
-          [class.active]="task.id === selectedTaskId"
-        >
-          <mat-icon matListItemIcon>{{ getTaskIcon(task) }}</mat-icon>
-          <span matListItemTitle>{{ task.displayName }}</span>
-          <span matListItemLine>
-            {{ getStatusText(task.status) }} · {{ task.modifiedAt | localTime }}
-          </span>
-        </a>
-      </mat-nav-list>
-      <ng-template #emptyTasks>
-        <div class="empty-state">Здесь появятся ваши распознанные файлы.</div>
-      </ng-template>
-    </mat-card>
-
-    <mat-card class="details-card" *ngIf="selectedTaskId; else selectPrompt">
-      <ng-container *ngIf="detailsLoading; else taskDetails">
-        <div class="loading-state">
-          <mat-progress-spinner mode="indeterminate" diameter="40"></mat-progress-spinner>
-          <p>Загружаем данные задачи…</p>
+  <main class="page-content">
+    <section class="hero">
+      <div class="hero-text">
+        <h1>Создавайте расшифровки в пару кликов</h1>
+        <p class="hero-lead">
+          YouScriptor автоматически распознаёт речь, добавляет тайм-коды и помогает командам быстрее готовить отчёты,
+          протоколы и статьи.
+        </p>
+        <ul class="hero-highlights">
+          <li *ngFor="let highlight of heroHighlights">{{ highlight }}</li>
+        </ul>
+        <div class="hero-actions">
+          <button class="btn btn-primary" type="button" (click)="openUploadDialog()" [disabled]="uploading">
+            <mat-icon>cloud_upload</mat-icon>
+            <span>Загрузить файл</span>
+          </button>
+          <a class="btn btn-secondary" [routerLink]="['/about3']">Узнать о возможностях</a>
         </div>
-      </ng-container>
-
-      <ng-template #taskDetails>
-        <ng-container *ngIf="selectedTask; else detailsErrorBlock">
-          <div class="details-header">
-            <h2>{{ selectedTask.displayName }}</h2>
-            <span class="status-chip" [ngClass]="getStatusClass(selectedTask.status)">
-              {{ getStatusText(selectedTask.status) }}
-            </span>
+      </div>
+      <div class="hero-card">
+        <div class="card-header">Перетащите файлы сюда</div>
+        <div class="card-dropzone">
+          <p>Загрузите аудио или видео и получите чистый текст с автоматической разметкой и форматированием.</p>
+          <span>Поддерживаем файлы до 1,5 ГБ и длительностью до 300 минут.</span>
+          <button class="btn btn-primary" type="button" (click)="openUploadDialog()" [disabled]="uploading">
+            <mat-icon>cloud_upload</mat-icon>
+            <span>Начать загрузку</span>
+          </button>
+        </div>
+        <div class="card-preview">
+          <img src="assets/about3/YouScriptor/upload_frame-600x.png" alt="Загрузка файлов в YouScriptor" />
+          <div class="card-preview-caption">
+            Загруженные файлы попадут в очередь, а статус задач обновится автоматически.
           </div>
+        </div>
+      </div>
+    </section>
 
-          <div class="clarification-display" *ngIf="selectedTask.clarification">
-            <strong>Уточнение:</strong>
-            <span>{{ selectedTask.clarification }}</span>
-          </div>
-
-          <div class="error" *ngIf="selectedTask.error && !isTaskCompleted(selectedTask)">
-            {{ selectedTask.error }}
-          </div>
-
-          <ng-container *ngIf="isTaskCompleted(selectedTask); else processingView">
-            <section class="result-block">
-              <h3>Результат</h3>
-              <div class="result-actions">
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
-                >
-                  <mat-icon>edit</mat-icon>
-                  <span>Редактировать</span>
-                </button>
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  (click)="exportDocx()"
-                  [disabled]="exportingDocx"
-                >
-                  <mat-icon>description</mat-icon>
-                  <span>Word</span>
-                </button>
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  (click)="exportPdf()"
-                  [disabled]="exportingPdf"
-                >
-                  <mat-icon>picture_as_pdf</mat-icon>
-                  <span>PDF</span>
-                </button>
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  (click)="downloadMarkdown()"
-                  [disabled]="!hasMarkdown()"
-                >
-                  <mat-icon>code</mat-icon>
-                  <span>Markdown</span>
-                </button>
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  (click)="downloadSrt()"
-                  [disabled]="!canDownloadSrt() || downloadingSrt"
-                >
-                  <mat-icon>subtitles</mat-icon>
-                  <span>SRT</span>
-                </button>
-              </div>
-              <div class="error" *ngIf="exportError">{{ exportError }}</div>
-              <div
-                class="markdown-content"
-                *ngIf="renderedMarkdown; else plainResult"
-                [innerHTML]="renderedMarkdown"
-              ></div>
-              <ng-template #plainResult>
-                <pre *ngIf="hasMarkdown(); else recognizedFallback">{{ markdownContent }}</pre>
-              </ng-template>
-              <ng-template #recognizedFallback>
-                <pre *ngIf="selectedTask.recognizedText; else emptyResult">{{ selectedTask.recognizedText }}</pre>
-              </ng-template>
-              <ng-template #emptyResult>
-                <div class="empty-state">Результат пока недоступен.</div>
-              </ng-template>
-            </section>
-          </ng-container>
-
-          <ng-template #processingView>
-            <div
-              class="details-actions"
-              *ngIf="selectedTask.status === OpenAiTranscriptionStatus.Error"
+    <section class="workspace">
+      <div class="section-header">
+        <h2>Рабочая область</h2>
+        <p>Следите за прогрессом распознавания, возобновляйте остановленные задачи и скачивайте готовые результаты.</p>
+      </div>
+      <div class="workspace-grid">
+        <div class="panel tasks-panel">
+          <div class="panel-header">
+            <h3>Мои расшифровки</h3>
+            <button
+              class="icon-button"
+              type="button"
+              (click)="loadTasks()"
+              [disabled]="uploading"
+              aria-label="Обновить список"
             >
-              <button
-                mat-stroked-button
-                color="primary"
-                (click)="continueTask()"
-                [disabled]="continueInProgress"
+              <mat-icon>refresh</mat-icon>
+            </button>
+          </div>
+          <div class="panel-body">
+            <div class="error" *ngIf="listError">{{ listError }}</div>
+            <mat-nav-list class="tasks-list" *ngIf="tasks.length; else emptyTasks">
+              <a
+                mat-list-item
+                class="task-item"
+                *ngFor="let task of tasks; trackBy: trackTask"
+                (click)="selectTask(task)"
+                [class.active]="task.id === selectedTaskId"
               >
-                <mat-icon>play_arrow</mat-icon>
-                <span>Продолжить задачу</span>
-              </button>
-              <mat-progress-spinner
-                *ngIf="continueInProgress"
-                mode="indeterminate"
-                diameter="28"
-                class="inline-spinner"
-              ></mat-progress-spinner>
-              <div class="error" *ngIf="continueError">{{ continueError }}</div>
-            </div>
+                <mat-icon matListItemIcon>{{ getTaskIcon(task) }}</mat-icon>
+                <span matListItemTitle>{{ task.displayName }}</span>
+                <span matListItemLine>{{ getStatusText(task.status) }} · {{ task.modifiedAt | localTime }}</span>
+              </a>
+            </mat-nav-list>
+            <ng-template #emptyTasks>
+              <div class="empty-state">
+                <h4>Здесь появятся ваши файлы</h4>
+                <p>Загрузите первый документ, чтобы начать распознавание.</p>
+              </div>
+            </ng-template>
+          </div>
+        </div>
 
-            <section class="steps-section" *ngIf="selectedTask.steps.length">
-              <h3>Прогресс обработки</h3>
-              <ul class="steps-list">
-                <li *ngFor="let step of selectedTask.steps; trackBy: trackStep" [ngClass]="getStepClass(step.status)">
-                  <mat-icon>{{ getStepIcon(step.status) }}</mat-icon>
-                  <div class="step-content">
-                    <div class="step-title">{{ getStatusText(step.step) }}</div>
-                    <div class="step-meta">
-                      <span>{{ getStepStatusText(step.status) }}</span>
-                      <span *ngIf="step.startedAt">· {{ step.startedAt | localTime }}</span>
-                      <span *ngIf="step.finishedAt">· {{ step.finishedAt | localTime }}</span>
+        <ng-container *ngIf="selectedTaskId; else selectPrompt">
+          <div class="panel details-panel">
+            <ng-container *ngIf="detailsLoading; else taskDetails">
+              <div class="loading-state">
+                <mat-progress-spinner mode="indeterminate" diameter="40"></mat-progress-spinner>
+                <p>Загружаем данные задачи…</p>
+              </div>
+            </ng-container>
+
+            <ng-template #taskDetails>
+              <ng-container *ngIf="selectedTask; else detailsErrorBlock">
+                <div class="details-header">
+                  <div class="details-title">
+                    <h3>{{ selectedTask.displayName }}</h3>
+                    <div class="clarification-display" *ngIf="selectedTask.clarification">
+                      <strong>Уточнение:</strong>
+                      <span>{{ selectedTask.clarification }}</span>
                     </div>
-                    <div class="step-error" *ngIf="step.error">{{ step.error }}</div>
                   </div>
-                </li>
-              </ul>
-            </section>
-          </ng-template>
+                  <span class="status-chip" [ngClass]="getStatusClass(selectedTask.status)">
+                    {{ getStatusText(selectedTask.status) }}
+                  </span>
+                </div>
+
+                <div class="error" *ngIf="selectedTask.error && !isTaskCompleted(selectedTask)">{{ selectedTask.error }}</div>
+
+                <ng-container *ngIf="isTaskCompleted(selectedTask); else processingView">
+                  <section class="result-block">
+                    <div class="result-header">
+                      <h4>Результат</h4>
+                      <div class="result-actions">
+                        <button
+                          class="btn btn-outline"
+                          type="button"
+                          [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
+                        >
+                          <mat-icon>edit</mat-icon>
+                          <span>Редактировать</span>
+                        </button>
+                        <button
+                          class="btn btn-outline"
+                          type="button"
+                          (click)="exportDocx()"
+                          [disabled]="exportingDocx"
+                        >
+                          <mat-icon>description</mat-icon>
+                          <span>Word</span>
+                        </button>
+                        <button
+                          class="btn btn-outline"
+                          type="button"
+                          (click)="exportPdf()"
+                          [disabled]="exportingPdf"
+                        >
+                          <mat-icon>picture_as_pdf</mat-icon>
+                          <span>PDF</span>
+                        </button>
+                        <button
+                          class="btn btn-outline"
+                          type="button"
+                          (click)="downloadMarkdown()"
+                          [disabled]="!hasMarkdown()"
+                        >
+                          <mat-icon>code</mat-icon>
+                          <span>Markdown</span>
+                        </button>
+                        <button
+                          class="btn btn-outline"
+                          type="button"
+                          (click)="downloadSrt()"
+                          [disabled]="!canDownloadSrt() || downloadingSrt"
+                        >
+                          <mat-icon>subtitles</mat-icon>
+                          <span>SRT</span>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="error" *ngIf="exportError">{{ exportError }}</div>
+                    <div
+                      class="markdown-content"
+                      *ngIf="renderedMarkdown; else plainResult"
+                      [innerHTML]="renderedMarkdown"
+                    ></div>
+                    <ng-template #plainResult>
+                      <pre *ngIf="hasMarkdown(); else recognizedFallback">{{ markdownContent }}</pre>
+                    </ng-template>
+                    <ng-template #recognizedFallback>
+                      <pre *ngIf="selectedTask.recognizedText; else emptyResult">{{ selectedTask.recognizedText }}</pre>
+                    </ng-template>
+                    <ng-template #emptyResult>
+                      <div class="empty-state">Результат пока недоступен.</div>
+                    </ng-template>
+                  </section>
+                </ng-container>
+
+                <ng-template #processingView>
+                  <div class="details-actions" *ngIf="selectedTask.status === OpenAiTranscriptionStatus.Error">
+                    <button
+                      class="btn btn-outline"
+                      type="button"
+                      (click)="continueTask()"
+                      [disabled]="continueInProgress"
+                    >
+                      <mat-icon>play_arrow</mat-icon>
+                      <span>Продолжить задачу</span>
+                    </button>
+                    <mat-progress-spinner
+                      *ngIf="continueInProgress"
+                      mode="indeterminate"
+                      diameter="28"
+                      class="inline-spinner"
+                    ></mat-progress-spinner>
+                    <div class="error" *ngIf="continueError">{{ continueError }}</div>
+                  </div>
+
+                  <section class="steps-section" *ngIf="selectedTask.steps.length">
+                    <h4>Прогресс обработки</h4>
+                    <ul class="steps-list">
+                      <li *ngFor="let step of selectedTask.steps; trackBy: trackStep" [ngClass]="getStepClass(step.status)">
+                        <span class="step-icon">
+                          <mat-icon>{{ getStepIcon(step.status) }}</mat-icon>
+                        </span>
+                        <div class="step-content">
+                          <div class="step-title">{{ getStatusText(step.step) }}</div>
+                          <div class="step-meta">
+                            <span>{{ getStepStatusText(step.status) }}</span>
+                            <span *ngIf="step.startedAt">· {{ step.startedAt | localTime }}</span>
+                            <span *ngIf="step.finishedAt">· {{ step.finishedAt | localTime }}</span>
+                          </div>
+                          <div class="step-error" *ngIf="step.error">{{ step.error }}</div>
+                        </div>
+                      </li>
+                    </ul>
+                  </section>
+                </ng-template>
+              </ng-container>
+
+              <ng-template #detailsErrorBlock>
+                <div class="error">{{ detailsError }}</div>
+              </ng-template>
+            </ng-template>
+          </div>
         </ng-container>
 
-        <ng-template #detailsErrorBlock>
-          <div class="error">{{ detailsError }}</div>
+        <ng-template #selectPrompt>
+          <div class="panel details-panel empty-details">
+            <div class="empty-state">
+              <h4>Выберите задачу</h4>
+              <p>Мы покажем ход обработки и готовый текст, как только вы выберете файл из списка.</p>
+            </div>
+          </div>
         </ng-template>
-      </ng-template>
-    </mat-card>
-
-    <ng-template #selectPrompt>
-      <mat-card class="details-card empty-details">
-        <div class="empty-state">Выберите задачу, чтобы посмотреть подробности.</div>
-      </mat-card>
-    </ng-template>
-  </div>
+      </div>
+    </section>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -27,8 +25,6 @@ import { OpenAiTranscriptionUploadDialogComponent } from './openai-transcription
   standalone: true,
   imports: [
     CommonModule,
-    MatCardModule,
-    MatButtonModule,
     MatIconModule,
     MatListModule,
     MatProgressSpinnerModule,
@@ -58,6 +54,11 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
 
   readonly OpenAiTranscriptionStatus = OpenAiTranscriptionStatus;
   readonly OpenAiTranscriptionStepStatus = OpenAiTranscriptionStepStatus;
+  readonly heroHighlights = [
+    'Скорость обработки — 1 час записи за 3 минуты',
+    'Поддержка 78 языков и автоматические тайм-коды',
+    'Удобный редактор с командной работой и AI-помощником',
+  ];
 
   private pollSubscription?: Subscription;
 


### PR DESCRIPTION
## Summary
- rebuild the /transcriptions page structure with a hero and workspace layout that matches the visual language of /about3
- refresh action controls, empty states, and task details markup to fit the new design system
- add supporting data and extensive component-scoped styling for the updated presentation

## Testing
- CI=1 npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68de40261eb083318f06f886c07c3a35