### PR TITLE
feat: add export format menu to transcription editor

### DIFF
--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
@@ -15,32 +15,47 @@
     <button
       mat-raised-button
       color="primary"
-      (click)="onDownloadMd()"
-      [disabled]="!hasContent() || exporting"
+      [matMenuTriggerFor]="downloadMenu"
+      [disabled]="exporting || !hasAnyDownloadOption()"
     >
       <mat-icon>download</mat-icon>
-      Скачать .md
+      Скачать
     </button>
 
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="onDownloadPdf()"
-      [disabled]="!hasContent() || exporting"
-    >
-      <mat-icon>picture_as_pdf</mat-icon>
-      PDF
-    </button>
-
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="onDownloadDocx()"
-      [disabled]="!hasContent() || exporting"
-    >
-      <mat-icon>description</mat-icon>
-      DOCX
-    </button>
+    <mat-menu #downloadMenu="matMenu">
+      <button
+        mat-menu-item
+        (click)="onDownload('md')"
+        [disabled]="exporting || !isFormatAvailable('md')"
+      >
+        <mat-icon>article</mat-icon>
+        Markdown (.md)
+      </button>
+      <button
+        mat-menu-item
+        (click)="onDownload('pdf')"
+        [disabled]="exporting || !isFormatAvailable('pdf')"
+      >
+        <mat-icon>picture_as_pdf</mat-icon>
+        PDF
+      </button>
+      <button
+        mat-menu-item
+        (click)="onDownload('docx')"
+        [disabled]="exporting || !isFormatAvailable('docx')"
+      >
+        <mat-icon>description</mat-icon>
+        Word (.docx)
+      </button>
+      <button
+        mat-menu-item
+        (click)="onDownload('srt')"
+        [disabled]="exporting || !isFormatAvailable('srt')"
+      >
+        <mat-icon>subtitles</mat-icon>
+        SRT субтитры
+      </button>
+    </mat-menu>
 
     <button
       mat-stroked-button


### PR DESCRIPTION
## Summary
- replace the individual download buttons with a single export menu in the transcription editor
- add an SRT option alongside Markdown, PDF, and Word exports
- centralize export logic with format availability checks to prevent invalid downloads

## Testing
- npm run build -- --configuration development --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68de53006de88331978d9fcf57bd4f08