### PR TITLE
Enhance transcription export and copy options

### DIFF
--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
@@ -60,12 +60,55 @@
     <button
       mat-stroked-button
       color="primary"
-      (click)="onCopyBbcode()"
-      [disabled]="!hasContent() || exporting"
+      [matMenuTriggerFor]="copyMenu"
+      [disabled]="exporting || !hasAnyCopyOption()"
     >
       <mat-icon>content_copy</mat-icon>
-      BBCode
+      Копировать
     </button>
+
+    <mat-menu #copyMenu="matMenu">
+      <button
+        mat-menu-item
+        (click)="onCopy('txt')"
+        [disabled]="exporting || !isCopyFormatAvailable('txt')"
+      >
+        <mat-icon>notes</mat-icon>
+        Текст (plain)
+      </button>
+      <button
+        mat-menu-item
+        (click)="onCopy('markdown')"
+        [disabled]="exporting || !isCopyFormatAvailable('markdown')"
+      >
+        <mat-icon>code</mat-icon>
+        Markdown
+      </button>
+      <button
+        mat-menu-item
+        (click)="onCopy('html')"
+        [disabled]="exporting || !isCopyFormatAvailable('html')"
+      >
+        <mat-icon>language</mat-icon>
+        HTML
+      </button>
+      <button
+        mat-menu-item
+        (click)="onCopy('bbcode')"
+        [disabled]="exporting || !isCopyFormatAvailable('bbcode')"
+      >
+        <mat-icon>format_quote</mat-icon>
+        BBCode
+      </button>
+      <button
+        mat-menu-item
+        (click)="onCopy('srt')"
+        [disabled]="exporting || !isCopyFormatAvailable('srt')"
+      >
+        <mat-icon>subtitles</mat-icon>
+        SRT субтитры
+      </button>
+    </mat-menu>
 
     <span class="spacer"></span>
 


### PR DESCRIPTION
## Summary
- expand export handling to support multiple download formats through a single menu
- add granular copy actions for plain text, markdown, HTML, BBCode, and SRT content with availability guards
- update the editor toolbar UI to surface the new download and copy options via material menus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de5ebdf61c8331bbdd1324c374825c