### PR TITLE
Set home page and background to transcription style

### DIFF
--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -13,7 +13,7 @@ import { About2Component } from './about2/about2.component';
 import { About3Component } from './about3/about3.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
+  { path: '', component: OpenAiTranscriptionComponent },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },

--- a/Angular/youtube-downloader/src/app/app.component.css
+++ b/Angular/youtube-downloader/src/app/app.component.css
@@ -16,7 +16,8 @@ html, body {
 .app-content {
   display: flex;
   flex-direction: column;
-  background: #f5f4ef;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
 }
 
 .app-header {

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -14,7 +14,7 @@ import { RoleGuard } from './services/role.guard';
 import { AdminUsersComponent } from './admin-users/admin-users.component';
 
 export const appRoutes: Routes = [
-  { path: '', redirectTo: 'youtube-downloader', pathMatch: 'full' },
+  { path: '', component: OpenAiTranscriptionComponent },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: SubtitlesTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },

--- a/Angular/youtube-downloader/src/styles.css
+++ b/Angular/youtube-downloader/src/styles.css
@@ -6,7 +6,7 @@ body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;
   min-height: 100vh;
-  background: #f5f4ef;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
 }
 
 /* Если нужно, можно убрать или откорректировать стили для контейнеров Angular Material */
@@ -196,7 +196,7 @@ blockquote {
 
 @media (max-width: 600px) {
   html, body {
-    background: #fff !important;
+    background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%) !important;
   }
   .blogblock,
   .wblogblock,


### PR DESCRIPTION
## Summary
- route the root path to the OpenAI transcription workspace so `/` matches the `/transcriptions` experience
- update the application shell background to use the transcription gradient across the full viewport
- apply the same gradient globally so every page inherits the `/transcriptions` look and feel

## Testing
- Not run (project has no lint script)


------
https://chatgpt.com/codex/tasks/task_e_68de81ef4f8083319cb44cbaf1242626