### PR TITLE
Restyle recognized task page to align with transcription workspace

### DIFF
--- a/Angular/youtube-downloader/src/app/task-page/task-page.component.css
+++ b/Angular/youtube-downloader/src/app/task-page/task-page.component.css
@@ -1,14 +1,73 @@
-/* Стили для TaskPageComponent */
-.task-page-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem;
+:host {
+  display: block;
+  color: #102a43;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+  min-height: 100vh;
+}
+
+.transcription-page {
+  min-height: 100vh;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+  padding: 80px 24px 120px;
+}
+
+.recognized-section {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.info-panel {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 32px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.info-panel h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.info-panel p {
+  margin: 0;
+  font-size: 1rem;
+  color: #475569;
+}
+
+.error-state {
+  border-color: rgba(239, 68, 68, 0.45);
+  box-shadow: 0 24px 48px rgba(239, 68, 68, 0.18);
+}
+
+.error-message {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .page-content {
+    padding: 64px 16px 96px;
+    gap: 32px;
   }
-  
-  .error-message {
-    color: red;
-    font-weight: bold;
-    margin: 1rem 0;
+
+  .info-panel {
+    padding: 24px;
+    border-radius: 24px;
   }
+}
   

--- a/Angular/youtube-downloader/src/app/task-page/task-page.component.html
+++ b/Angular/youtube-downloader/src/app/task-page/task-page.component.html
@@ -1,24 +1,27 @@
-<div class="task-page-container">
+<div class="recognized-page transcription-page">
+  <main class="page-content">
+    <section class="recognized-section">
+      <ng-container *ngIf="taskDone && task; else showProgressOrError">
+        <app-task-result [youtubeTask]="task"></app-task-result>
+      </ng-container>
 
-  <!-- Отображаем TaskResultComponent, если задача завершена -->
-  <ng-container *ngIf="taskDone && task; else showProgressOrError">
-    <app-task-result [youtubeTask]="task"></app-task-result>
-  </ng-container>
+      <ng-template #showProgressOrError>
+        <ng-container *ngIf="taskErrorMessage; else showProgress">
+          <div class="info-panel error-state">
+            <h2>Возникла ошибка</h2>
+            <p class="error-message">{{ taskErrorMessage }}</p>
+          </div>
+        </ng-container>
 
-  <!-- Иначе, отображаем TaskProgressComponent или сообщение об ошибке -->
-  <ng-template #showProgressOrError>
-    <ng-container *ngIf="taskErrorMessage; else showProgress">
-      <p class="error-message">Error: {{ taskErrorMessage }}</p>
-    </ng-container>
-
-    <ng-template #showProgress>
-      <app-task-progress
-        [taskId]="taskId"
-        (taskLoaded)="onTaskLoaded($event)"
-        (taskDone)="onTaskDone($event)"
-        (taskError)="onTaskError($event)"
-      ></app-task-progress>
-    </ng-template>
-  </ng-template>
-
+        <ng-template #showProgress>
+          <app-task-progress
+            [taskId]="taskId"
+            (taskLoaded)="onTaskLoaded($event)"
+            (taskDone)="onTaskDone($event)"
+            (taskError)="onTaskError($event)"
+          ></app-task-progress>
+        </ng-template>
+      </ng-template>
+    </section>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/task-progress/task-progress.component.css
+++ b/Angular/youtube-downloader/src/app/task-progress/task-progress.component.css
@@ -1,20 +1,147 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.progress-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 32px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.progress-card.status-error {
+  border-color: rgba(239, 68, 68, 0.45);
+  box-shadow: 0 28px 48px rgba(239, 68, 68, 0.18);
+}
+
+.progress-card.status-success {
+  border-color: rgba(34, 197, 94, 0.4);
+  box-shadow: 0 28px 48px rgba(16, 185, 129, 0.18);
+}
+
+.progress-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.status-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+}
+
+.status-icon.status-success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+
+.status-icon.status-error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #dc2626;
+}
+
+.progress-title h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.progress-title p {
+  margin: 4px 0 0;
+  font-size: 1rem;
+  color: #475569;
+}
+
+.progress-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.progress-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.progress-meta > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.meta-value {
+  font-size: 1rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.progress-status {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.status-text {
+  font-size: 1.05rem;
+  color: #1e293b;
+  font-weight: 500;
+}
+
+.error-message {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: 16px;
+  padding: 16px;
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+mat-progress-bar {
+  height: 10px;
+  border-radius: 12px;
+}
+
 .spinner-container {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 200px; /* или любая подходящая высота */
+  min-height: 240px;
 }
 
-.progress-card {
-  margin: 1rem 0;
-}
+@media (max-width: 768px) {
+  .progress-card {
+    padding: 24px;
+    border-radius: 24px;
+  }
 
-mat-progress-bar {
-  margin: 1rem 0;
-}
+  .progress-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
 
-/* Icons */
-.icon-status-done   { color: #4caf50; }
-.icon-status-error  { color: #f44336; }
-@keyframes slow-rotate { from {transform:rotate(0)} to {transform:rotate(-360deg)} }
-.icon-status-pending { color:#2196f3; display:inline-block; animation:slow-rotate 5s linear infinite; }
+  .status-icon {
+    width: 52px;
+    height: 52px;
+  }
+}

--- a/Angular/youtube-downloader/src/app/task-progress/task-progress.component.html
+++ b/Angular/youtube-downloader/src/app/task-progress/task-progress.component.html
@@ -1,49 +1,59 @@
 <ng-container *ngIf="youtubeTask !== null; else loading">
-  <mat-card class="progress-card">
-    <mat-card-header>
-      <!-- Вращающаяся иконка для статуса (всегда default) -->
-      <mat-icon class="icon-status-pending">loop</mat-icon>
-      <mat-card-title>Задача в процессе...</mat-card-title>
-    </mat-card-header>
+  <div class="progress-card" [ngClass]="getCardClass(youtubeTask!.status)">
+    <div class="progress-header">
+      <span class="status-icon" [ngClass]="getIconClass(youtubeTask!.status)">
+        <mat-icon>{{ getStatusIcon(youtubeTask!.status) }}</mat-icon>
+      </span>
+      <div class="progress-title">
+        <h2>Задача обрабатывается</h2>
+        <p *ngIf="youtubeTask!.status !== null">
+          {{ getStatusText(youtubeTask!.status) }}
+        </p>
+      </div>
+    </div>
 
-    <mat-card-content>
+    <app-yandex-ad></app-yandex-ad>
 
-      <app-yandex-ad></app-yandex-ad>
-
-      <!-- Информация о начале и последнем обновлении (если нет ошибки и задача не завершена) -->
-      <div *ngIf="!youtubeTask?.done && youtubeTask?.status !== RecognizeStatus.Error">
-        <p>Время начала: {{ youtubeTask?.createdAt | localTime: 'yyyy-MM-dd HH:mm:ss' }}</p>
-        <p>Время последнего обновления: {{ youtubeTask?.modifiedAt | localTime: 'yyyy-MM-dd HH:mm:ss' }}</p>
+    <div class="progress-body">
+      <div class="progress-meta">
+        <div *ngIf="youtubeTask!.createdAt">
+          <span class="meta-label">Начало</span>
+          <span class="meta-value">{{ youtubeTask!.createdAt | localTime: 'yyyy-MM-dd HH:mm:ss' }}</span>
+        </div>
+        <div *ngIf="youtubeTask!.modifiedAt">
+          <span class="meta-label">Обновлено</span>
+          <span class="meta-value">{{ youtubeTask!.modifiedAt | localTime: 'yyyy-MM-dd HH:mm:ss' }}</span>
+        </div>
       </div>
 
-      <!-- Если статус = Error, показываем ошибку -->
-      <p *ngIf="youtubeTask?.status === RecognizeStatus.Error" style="color: red;">
-        Произошла ошибка: {{ youtubeTask?.error }}
-      </p>
+      <div class="progress-status" *ngIf="youtubeTask!.status === RecognizeStatus.Error">
+        <div class="error-message">Произошла ошибка: {{ youtubeTask!.error || 'Не удалось распознать задачу' }}</div>
+      </div>
 
-      <!-- Если нет ошибки и задача не завершена, показываем статус и прогресс -->
-      <ng-container *ngIf="youtubeTask && youtubeTask.status !== RecognizeStatus.Error && !youtubeTask.done">
-        <p>Статус: {{ getStatusText(youtubeTask?.status) }}</p>
+      <div
+        class="progress-status"
+        *ngIf="youtubeTask && youtubeTask.status !== RecognizeStatus.Error && !youtubeTask.done"
+      >
+        <span class="status-text">Текущий статус: {{ getStatusText(youtubeTask!.status) }}</span>
 
-        <!-- Полоса прогресса, если доступно -->
         <mat-progress-bar
-          *ngIf="youtubeTask?.status === RecognizeStatus.ApplyingPunctuationSegment &&
-                 youtubeTask?.segmentsTotal !== undefined &&
-                 youtubeTask?.segmentsProcessed !== undefined"
+          *ngIf="youtubeTask!.status === RecognizeStatus.ApplyingPunctuationSegment &&
+                  youtubeTask!.segmentsTotal !== undefined &&
+                  youtubeTask!.segmentsProcessed !== undefined"
           mode="determinate"
-          [value]="(youtubeTask.segmentsProcessed / youtubeTask.segmentsTotal) * 100"
+          [value]="(youtubeTask!.segmentsProcessed / youtubeTask!.segmentsTotal) * 100"
         ></mat-progress-bar>
 
-        <p *ngIf="youtubeTask?.status === RecognizeStatus.ApplyingPunctuationSegment">
-          Обработано: {{ youtubeTask?.segmentsProcessed }} из {{ youtubeTask?.segmentsTotal }}
+        <p *ngIf="youtubeTask!.status === RecognizeStatus.ApplyingPunctuationSegment">
+          Обработано: {{ youtubeTask!.segmentsProcessed }} из {{ youtubeTask!.segmentsTotal }}
         </p>
-      </ng-container>
-    </mat-card-content>
-  </mat-card>
+      </div>
+    </div>
+  </div>
 </ng-container>
 
 <ng-template #loading>
   <div class="spinner-container">
-    <mat-spinner></mat-spinner>
+    <mat-progress-spinner mode="indeterminate" diameter="48"></mat-progress-spinner>
   </div>
 </ng-template>

--- a/Angular/youtube-downloader/src/app/task-progress/task-progress.component.ts
+++ b/Angular/youtube-downloader/src/app/task-progress/task-progress.component.ts
@@ -8,7 +8,6 @@ import {
 } from '../services/subtitle.service';
 
 // Angular Material
-import { MatCardModule } from '@angular/material/card';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'; // Импорт спиннера
 import { MatIconModule } from '@angular/material/icon';
@@ -23,12 +22,10 @@ import { YandexAdComponent } from "../ydx-ad/yandex-ad.component";
   standalone: true,
   imports: [
     CommonModule,
-    MatCardModule,
     MatIconModule,
     LocalTimePipe,
     MatProgressBarModule,
-    MatProgressSpinnerModule // Добавлен сюда
-    ,
+    MatProgressSpinnerModule,
     YandexAdComponent
 ],
   templateUrl: './task-progress.component.html',
@@ -87,6 +84,41 @@ export class TaskProgressComponent implements OnInit, OnDestroy {
 
   getStatusText(status: RecognizeStatus | null | undefined): string {
     return this.subtitleService.getStatusText(status);
+  }
+
+  getStatusIcon(status: RecognizeStatus | null | undefined): string {
+    switch (status) {
+      case RecognizeStatus.Error:
+        return 'error';
+      case RecognizeStatus.Done:
+        return 'check_circle';
+      default:
+        return 'loop';
+    }
+  }
+
+  getIconClass(status: RecognizeStatus | null | undefined): string {
+    if (status === RecognizeStatus.Error) {
+      return 'status-error';
+    }
+
+    if (status === RecognizeStatus.Done) {
+      return 'status-success';
+    }
+
+    return 'status-progress';
+  }
+
+  getCardClass(status: RecognizeStatus | null | undefined): string {
+    if (status === RecognizeStatus.Error) {
+      return 'status-error';
+    }
+
+    if (status === RecognizeStatus.Done) {
+      return 'status-success';
+    }
+
+    return '';
   }
 
   private processTask(task: YoutubeCaptionTaskDto) {

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.css
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.css
@@ -1,138 +1,233 @@
-/* Базовые контейнеры */
-.container {
+:host {
+  display: block;
   width: 100%;
-  max-width: 1250px;
-  margin: 0 auto;
-  box-sizing: border-box;
 }
 
-.blogblock {
-  background: #fff;
-  padding: 10px;
-  border: 1px solid #ceced2;
-  margin-top: 12px;
-}
-
-.youtube-result-card {
-  margin-top: 1rem;
-}
-
-/* Заголовок */
-.header-flex {
+.recognized-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 32px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(226, 232, 240, 0.7);
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.video-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.video-summary-left {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
 }
 
 .yt-logo-button {
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  width: 50px;
-  height: 50px;
-  display: flex;
-  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  background: rgba(255, 255, 255, 0.96);
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.yt-logo-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(248, 113, 113, 0.25);
 }
 
 .youtube-logo {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+  width: 38px;
+  height: auto;
 }
 
-.yt-logo-button:hover .youtube-logo {
-  filter: brightness(1.2);
+.video-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 560px;
 }
 
-.title-wrapper {
-  margin-left: 1rem;
-  text-align: left;
+.promo-tagline {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 12px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.95rem;
 }
 
 .video-title {
   margin: 0;
-  font-size: 1.2rem;
-  font-weight: 600;
+  font-size: 2rem;
+  line-height: 1.25;
+  color: #0f172a;
 }
 
-/* Секция загрузки */
-.download-section {
+.video-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.video-summary-actions {
   display: flex;
   align-items: center;
-  margin: 1rem 0;
+  gap: 12px;
 }
 
-.download-text {
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
   font-size: 1rem;
-  font-weight: bold;
-  margin-right: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1d4ed8;
+  border-color: rgba(29, 78, 216, 0.25);
 }
 
-.download-icons {
+.btn mat-icon {
+  font-size: 20px;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.2);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+  transform: none;
+}
+
+.result-block {
   display: flex;
-  gap: 7px;
+  flex-direction: column;
+  gap: 20px;
+  background: rgba(248, 250, 255, 0.9);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
-/* Цвета иконок в активном состоянии */
-.icon-pdf    { color: red;    }
-.icon-word   { color: #2b579a; /* Word-синий */ }
-.icon-md     { color: green;  }
-.icon-html   { color: blue;   }
-
-/* Disabled-стиль для всех кнопок */
-button[disabled] .mat-icon,
-button[disabled] .fa-icon {
-  filter: grayscale(100%);
-  opacity: 0.6;
-  transition: filter 0.2s, opacity 0.2s;
+.result-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
-/* Markdown-контент */
+.result-header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.result-alert {
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  color: #b91c1c;
+  font-weight: 500;
+}
+
 .markdown-content {
-  font-size: 16px;
-  line-height: 1.6;
+  border-radius: 18px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  max-height: 560px;
+  overflow-y: auto;
+  font-size: 1rem;
+  line-height: 1.65;
+  color: #0f172a;
 }
 
-/* Desktop / Mobile */
-.desktop-only { display: block; }
-.mobile-only  { display: none;  }
+.empty-state {
+  padding: 32px;
+  border-radius: 18px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  text-align: center;
+  color: #475569;
+  font-weight: 500;
+}
+
+app-yandex-ad {
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .recognized-card {
+    padding: 24px;
+    border-radius: 28px;
+  }
+
+  .result-block {
+    padding: 20px;
+    border-radius: 20px;
+  }
+
+  .video-title {
+    font-size: 1.6rem;
+  }
+
+  .btn {
+    padding: 10px 20px;
+    border-radius: 16px;
+  }
+}
 
 @media (max-width: 600px) {
-  .desktop-only { display: none; }
-  .mobile-only  { display: block; }
+  .video-summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 
-  .container {
-    padding: 0;
-    max-width: 100%;
+  .video-summary-actions {
+    width: 100%;
+    justify-content: center;
   }
-  .blogblock {
-    padding: 0 !important;
-    border: none !important;
-    margin: 0 !important;
-    box-shadow: none !important;
-    background: #fff !important;
+
+  .result-actions {
+    width: 100%;
+    justify-content: center;
   }
-  .header-flex {
-    justify-content: flex-start;
-  }
-  .yt-logo-button {
-    width: 50px !important;
-  }
-  .title-wrapper {
-    margin-left: 1rem !important;
-  }
-  .video-title {
-    font-size: 1rem !important;
-  }
-  .download-icons {
-    gap: 5px;
-  }
+
   .markdown-content {
-    font-size: 14px;
-    padding: 0;
-  }
-  html, body {
-    background: #fff !important;
+    padding: 18px;
+    max-height: none;
   }
 }

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -1,192 +1,115 @@
-<div class="container">
-  <!-- Десктопная версия (с mat-card) -->
-  <div class="desktop-only">
-    <mat-card class="blogblock youtube-result-card">
-      <mat-card-header>
-        <div class="header-flex">
-          <button
-            class="yt-logo-button"
-            matRipple
-            [matRippleColor]="'rgba(0,0,0,0.15)'"
-            (click)="openVideoDialog(youtubeTask)"
-            aria-label="Open video in dialog">
-            <img src="assets/yt.webp" alt="YouTube" class="youtube-logo" />
-          </button>
-          <div class="title-wrapper">
-            <mat-card-title class="video-title">
-              {{ promoText }}
-              <br>
-              {{ youtubeTask?.title }}
-            </mat-card-title>
-            <mat-card-subtitle *ngIf="youtubeTask?.channelName">
-              Channel: {{ youtubeTask?.channelName }}
-              /
-              {{ youtubeTask?.createdAt | localTime: 'yyyy-MM-dd HH:mm' }}
-            </mat-card-subtitle>
-          </div>
-        </div>
-      </mat-card-header>
-
-      <mat-card-content>
-        <div class="download-section">
-          <span class="download-text">Download</span>
-          <div class="download-icons">
-            <!-- PDF -->
-            <button
-              mat-icon-button
-              matTooltip="Download PDF"
-              (click)="downloadAsPdf()"
-              [disabled]="isDownloading">
-              <mat-icon class="icon-pdf">picture_as_pdf</mat-icon>
-            </button>
-
-            <!-- Word -->
-            <button
-              mat-icon-button
-              matTooltip="Download Word"
-              (click)="downloadAsWord()"
-              [disabled]="isDownloading">
-              <mat-icon svgIcon="icon-msword">description</mat-icon>
-            </button>
-
-            <!-- Markdown -->
-            <button
-              mat-icon-button
-              matTooltip="Download Markdown"
-              (click)="downloadAsMd()"
-              [disabled]="isDownloading">
-              <mat-icon svgIcon="icon-markdown">description</mat-icon>
-            </button>
-
-            <!-- HTML -->
-            <button
-              mat-icon-button
-              matTooltip="Download HTML"
-              (click)="downloadAsHtml()"
-              [disabled]="isDownloading">
-              <mat-icon svgIcon="icon-html">code</mat-icon>
-            </button>
-
-            <!-- Copy to clipboard -->
-            <button
-              mat-icon-button
-              matTooltip="Copy to clipboard"
-              (click)="copyToClipboard()"
-              [disabled]="isCopying">
-              <mat-icon>content_copy</mat-icon>
-            </button>
-
-          
-             
-<button
-  mat-icon-button
-  matTooltip="Download Subtitles (SRT)"
-  (click)="downloadAsSrt()"
-  [disabled]="isDownloading || !youtubeTask?.id">
-  <mat-icon>subtitles</mat-icon>
-</button>
-
-<button
-  mat-icon-button
-  [routerLink]="['/markdown-converter', youtubeTask?.id]"
-  matTooltip="Edit in Markdown editor"
-  [disabled]="!youtubeTask?.id">
-  <mat-icon>edit</mat-icon>
-</button>
-
-
-
-
-
-          </div>
-        </div>
-
-        <hr />
-        <app-yandex-ad></app-yandex-ad>
-        <div [innerHTML]="processedMarkdown" class="markdown-content"></div>
-      </mat-card-content>
-    </mat-card>
-  </div>
-
-  <!-- Мобильная версия (без mat-card) -->
-  <div class="mobile-only">
-    <app-yandex-ad></app-yandex-ad>
-
-    <div class="blogblock">
-      <div class="header-flex">
-        <button
-          class="yt-logo-button"
-          matRipple
-          [matRippleColor]="'rgba(0,0,0,0.15)'"
-          (click)="openVideoDialog(youtubeTask)"
-          aria-label="Open video in dialog">
-          <img src="assets/yt.webp" alt="YouTube" class="youtube-logo" />
-        </button>
-        <div class="title-wrapper">
-          <h2>{{ youtubeTask?.title }}</h2>
-          <h3 *ngIf="youtubeTask?.channelName">
-            Channel: {{ youtubeTask?.channelName }}
-          </h3>
-          <h4 *ngIf="youtubeTask?.createdAt">
-            {{ youtubeTask?.createdAt | localTime: 'yyyy-MM-dd HH:mm' }}
-          </h4>
+<div class="recognized-card" *ngIf="youtubeTask as task">
+  <div class="video-summary">
+    <div class="video-summary-left">
+      <button
+        class="yt-logo-button"
+        type="button"
+        (click)="openVideoDialog(task)"
+        aria-label="Открыть видео"
+      >
+        <img src="assets/yt.webp" alt="YouTube" class="youtube-logo" />
+      </button>
+      <div class="video-text">
+        <span class="promo-tagline">{{ promoText }}</span>
+        <h1 class="video-title" *ngIf="task.title; else defaultTitle">{{ task.title }}</h1>
+        <ng-template #defaultTitle>
+          <h1 class="video-title">Результат распознавания</h1>
+        </ng-template>
+        <div class="video-meta">
+          <span *ngIf="task.channelName">Канал: {{ task.channelName }}</span>
+          <span *ngIf="task.uploadDate">· Видео от {{ task.uploadDate | localTime: 'yyyy-MM-dd' }}</span>
+          <span *ngIf="task.createdAt">· Обновлено {{ task.createdAt | localTime: 'yyyy-MM-dd HH:mm' }}</span>
         </div>
       </div>
-
-      <div class="download-section">
-        <span class="download-text">Download</span>
-        <div class="download-icons">
-          <!-- PDF -->
-          <button
-            mat-icon-button
-            matTooltip="Download PDF"
-            (click)="downloadAsPdf()"
-            [disabled]="isDownloading">
-            <mat-icon class="icon-pdf">picture_as_pdf</mat-icon>
-          </button>
-
-          <!-- Word -->
-          <button
-            mat-icon-button
-            matTooltip="Download Word"
-            (click)="downloadAsWord()"
-            [disabled]="isDownloading">
-            <mat-icon class="icon-word">description</mat-icon>
-          </button>
-
-          <!-- Markdown -->
-          <button
-            mat-icon-button
-            matTooltip="Download Markdown"
-            (click)="downloadAsMd()"
-            [disabled]="isDownloading">
-            <mat-icon class="icon-md">description</mat-icon>
-          </button>
-
-          <!-- HTML -->
-          <button
-            mat-icon-button
-            matTooltip="Download HTML"
-            (click)="downloadAsHtml()"
-            [disabled]="isDownloading">
-            <mat-icon class="icon-html">code</mat-icon>
-          </button>
-
-          <!-- Copy to clipboard -->
-          <button
-            mat-icon-button
-            matTooltip="Copy to clipboard"
-            (click)="copyHtmlToClipboard()"
-            [disabled]="isCopying">
-            <mat-icon>content_copy</mat-icon>
-          </button>
-        </div>
-      </div>
-
-      <hr />
-      <div [innerHTML]="processedMarkdown" class="markdown-content"></div>
+    </div>
+    <div class="video-summary-actions">
+      <button class="btn btn-outline" type="button" (click)="openVideoDialog(task)">
+        <mat-icon>play_circle</mat-icon>
+        <span>Смотреть видео</span>
+      </button>
     </div>
   </div>
+
+  <section class="result-block">
+    <div class="result-header">
+      <h2>Результат</h2>
+      <div class="result-actions">
+        <a
+          class="btn btn-outline"
+          *ngIf="task.id"
+          [routerLink]="['/markdown-converter', task.id]"
+        >
+          <mat-icon>edit</mat-icon>
+          <span>Редактировать</span>
+        </a>
+        <button
+          class="btn btn-outline"
+          type="button"
+          [matMenuTriggerFor]="downloadMenu"
+          [disabled]="isDownloading || !hasAnyDownloadOption"
+        >
+          <mat-icon>download</mat-icon>
+          <span>Скачать</span>
+        </button>
+        <button
+          class="btn btn-outline"
+          type="button"
+          [matMenuTriggerFor]="copyMenu"
+          [disabled]="isCopying || !hasAnyCopyOption"
+        >
+          <mat-icon>content_copy</mat-icon>
+          <span>Копировать</span>
+        </button>
+      </div>
+    </div>
+
+    <mat-menu #downloadMenu="matMenu">
+      <button mat-menu-item (click)="downloadAsPdf()" [disabled]="isDownloading || !canDownloadFromServer">
+        <mat-icon>picture_as_pdf</mat-icon>
+        <span>PDF</span>
+      </button>
+      <button mat-menu-item (click)="downloadAsWord()" [disabled]="isDownloading || !canDownloadFromServer">
+        <mat-icon>description</mat-icon>
+        <span>Word (.docx)</span>
+      </button>
+      <button mat-menu-item (click)="downloadAsSrt()" [disabled]="isDownloading || !canDownloadFromServer">
+        <mat-icon>subtitles</mat-icon>
+        <span>SRT субтитры</span>
+      </button>
+      <button mat-menu-item (click)="downloadAsMd()" [disabled]="isDownloading || !hasResultText">
+        <mat-icon>article</mat-icon>
+        <span>Markdown (.md)</span>
+      </button>
+      <button mat-menu-item (click)="downloadAsHtml()" [disabled]="isDownloading || !hasResultText">
+        <mat-icon>language</mat-icon>
+        <span>HTML</span>
+      </button>
+    </mat-menu>
+
+    <mat-menu #copyMenu="matMenu">
+      <button mat-menu-item (click)="copyToClipboard()" [disabled]="isCopying || !hasResultText">
+        <mat-icon>notes</mat-icon>
+        <span>Текст (plain)</span>
+      </button>
+      <button mat-menu-item (click)="copyHtmlToClipboard()" [disabled]="isCopying || !hasResultText">
+        <mat-icon>code</mat-icon>
+        <span>HTML</span>
+      </button>
+    </mat-menu>
+
+    <div class="result-alert" *ngIf="task.error">{{ task.error }}</div>
+
+    <app-yandex-ad></app-yandex-ad>
+
+    <div
+      class="markdown-content"
+      #markdownContent
+      [innerHTML]="processedMarkdown"
+      *ngIf="hasResultText; else emptyState"
+    ></div>
+
+    <ng-template #emptyState>
+      <div class="empty-state">Расшифровка пока недоступна.</div>
+    </ng-template>
+  </section>
 </div>
-
-

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.ts
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.ts
@@ -1,14 +1,11 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { MarkdownModule } from 'ngx-markdown';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatRippleModule } from '@angular/material/core';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatMenuModule } from '@angular/material/menu';
 import { YoutubeCaptionTaskDto } from '../services/subtitle.service';
 import { SubtitleService } from '../services/subtitle.service';
 import { MarkdownRendererService1 } from './markdown-renderer.service';
@@ -24,12 +21,9 @@ import { RouterModule } from '@angular/router'; // ⬅️ Добавить
     CommonModule,
     MarkdownModule,
     RouterModule,
-    MatCardModule,
-    MatButtonModule,
-    MatRippleModule,
     MatIconModule,
     MatDialogModule,
-    MatTooltipModule,
+    MatMenuModule,
     LocalTimePipe,
     YandexAdComponent
   ],
@@ -38,6 +32,7 @@ import { RouterModule } from '@angular/router'; // ⬅️ Добавить
 })
 export class TaskResultComponent {
   @Input() youtubeTask: YoutubeCaptionTaskDto | null = null;
+  @ViewChild('markdownContent') private markdownContentRef?: ElementRef<HTMLElement>;
   isDownloading = false;
   isCopying = false;
 
@@ -57,6 +52,22 @@ export class TaskResultComponent {
       return this.englishPromo;
     }
     return this.hasCyrillic(this.youtubeTask.result) ? this.russianPromo : this.englishPromo;
+  }
+
+  get hasResultText(): boolean {
+    return !!this.youtubeTask?.result?.trim();
+  }
+
+  get canDownloadFromServer(): boolean {
+    return !!this.youtubeTask?.id;
+  }
+
+  get hasAnyDownloadOption(): boolean {
+    return this.canDownloadFromServer || this.hasResultText;
+  }
+
+  get hasAnyCopyOption(): boolean {
+    return this.hasResultText;
   }
 
   private hasCyrillic(text: string): boolean {
@@ -94,25 +105,28 @@ export class TaskResultComponent {
   downloadAsPdf(): void {
     if (this.isDownloading || !this.youtubeTask?.id) return;
     this.isDownloading = true;
-    this.subtitleService.generatePdf(this.youtubeTask.id).subscribe(
-      blob => this.finishDownload(blob, `task-${this.youtubeTask?.title}.pdf`),
-      () => (this.isDownloading = false)
-    );
+    const base = this.getFileBaseName();
+    this.subtitleService.generatePdf(this.youtubeTask.id).subscribe({
+      next: (blob) => this.finishDownload(blob, `${base}.pdf`),
+      error: () => (this.isDownloading = false)
+    });
   }
 
   downloadAsWord(): void {
     if (this.isDownloading || !this.youtubeTask?.id) return;
     this.isDownloading = true;
-    this.subtitleService.generateWord(this.youtubeTask.id).subscribe(
-      blob => this.finishDownload(blob, `task-${this.youtubeTask?.title}.docx`),
-      () => (this.isDownloading = false)
-    );
+    const base = this.getFileBaseName();
+    this.subtitleService.generateWord(this.youtubeTask.id).subscribe({
+      next: (blob) => this.finishDownload(blob, `${base}.docx`),
+      error: () => (this.isDownloading = false)
+    });
   }
 
   downloadAsMd(): void {
     if (this.isDownloading || !this.youtubeTask?.result) return;
     this.isDownloading = true;
-    this.downloadText(this.youtubeTask.result, 'text/markdown', `task-${this.youtubeTask.title}.md`);
+    const base = this.getFileBaseName();
+    this.downloadText(this.youtubeTask.result, 'text/markdown', `${base}.md`);
     this.isDownloading = false;
   }
 
@@ -120,7 +134,8 @@ export class TaskResultComponent {
     if (this.isDownloading || !this.youtubeTask?.result) return;
     this.isDownloading = true;
     const content = this.renderMath(this.youtubeTask.result);
-    this.downloadText(content, 'text/html', `task-${this.youtubeTask.title}.html`);
+    const base = this.getFileBaseName();
+    this.downloadText(content, 'text/html', `${base}.html`);
     this.isDownloading = false;
   }
 
@@ -139,9 +154,10 @@ export class TaskResultComponent {
   copyHtmlToClipboard(): void {
     if (this.isCopying || !this.youtubeTask?.result) return;
     this.isCopying = true;
-    const html = (document.querySelector('.markdown-content') as HTMLElement)?.innerHTML || '';
-    navigator.clipboard.writeText(html)
-      .finally(() => this.isCopying = false);
+    const html = this.markdownContentRef?.nativeElement?.innerHTML?.trim() ?? '';
+    const target = html || this.youtubeTask.result;
+    navigator.clipboard.writeText(target)
+      .finally(() => (this.isCopying = false));
   }
 
   clearTaskHistory(): void {
@@ -194,5 +210,18 @@ downloadAsSrt(lang?: string): void {
       .replace(/\s+/g, ' ')
       .trim()
       .substring(0, 120);
+  }
+
+  private getFileBaseName(): string {
+    const title = this.youtubeTask?.title?.trim();
+    if (title) {
+      return this.sanitizeFileName(title);
+    }
+
+    if (this.youtubeTask?.id) {
+      return this.sanitizeFileName(`task-${this.youtubeTask.id}`);
+    }
+
+    return 'task-result';
   }
 }


### PR DESCRIPTION
## Summary
- align the recognized task page container and error messaging with the modern transcription workspace styling
- redesign the task result view to feature the new metadata header, action menus, and refreshed markdown presentation
- refresh the in-progress task panel with updated visuals and status helpers that match the revised layout

## Testing
- npm run build --prefix Angular/youtube-downloader -- --progress false

------
https://chatgpt.com/codex/tasks/task_e_68de8987e5008331a7d47920c9db8eea