### PR TITLE
Add fullscreen toggle for recognized text panel

### DIFF
--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.css
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.css
@@ -14,6 +14,33 @@
   gap: 28px;
 }
 
+.recognized-card.fullscreen {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  border-radius: 0;
+  margin: 0;
+  padding: 32px clamp(16px, 4vw, 48px);
+  box-shadow: none;
+  border: none;
+  background: rgba(248, 250, 255, 0.98);
+  z-index: 1100;
+  overflow-y: auto;
+}
+
+.recognized-card.fullscreen .result-block {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.recognized-card.fullscreen .markdown-content {
+  flex: 1;
+  max-height: none;
+}
+
 .video-summary {
   display: flex;
   flex-wrap: wrap;

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -1,4 +1,4 @@
-<div class="recognized-card" *ngIf="youtubeTask as task">
+<div class="recognized-card" *ngIf="youtubeTask as task" [class.fullscreen]="isResultFullscreen">
   <div class="video-summary">
     <div class="video-summary-left">
       <button
@@ -59,6 +59,15 @@
         >
           <mat-icon>content_copy</mat-icon>
           <span>Копировать</span>
+        </button>
+        <button
+          class="btn btn-outline"
+          type="button"
+          (click)="toggleFullscreen()"
+          [attr.aria-pressed]="isResultFullscreen"
+        >
+          <mat-icon>{{ isResultFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
+          <span>{{ isResultFullscreen ? 'Свернуть' : 'На весь экран' }}</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a fullscreen toggle button to the recognized task result panel
- update component logic to manage fullscreen state and body scroll locking
- extend styles so the recognized text block fills the browser window in fullscreen mode

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68de8f6e83348331895bd574d906b817