### PR TITLE
Limit fullscreen view to result content

### DIFF
--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.css
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.css
@@ -14,7 +14,7 @@
   gap: 28px;
 }
 
-.recognized-card.fullscreen {
+.result-block.fullscreen {
   position: fixed;
   inset: 0;
   width: 100vw;
@@ -27,16 +27,12 @@
   background: rgba(248, 250, 255, 0.98);
   z-index: 1100;
   overflow-y: auto;
-}
-
-.recognized-card.fullscreen .result-block {
-  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
 }
 
-.recognized-card.fullscreen .markdown-content {
+.result-block.fullscreen .markdown-content {
   flex: 1;
   max-height: none;
 }

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -1,4 +1,4 @@
-<div class="recognized-card" *ngIf="youtubeTask as task" [class.fullscreen]="isResultFullscreen">
+<div class="recognized-card" *ngIf="youtubeTask as task">
   <div class="video-summary">
     <div class="video-summary-left">
       <button
@@ -30,7 +30,7 @@
     </div>
   </div>
 
-  <section class="result-block">
+  <section class="result-block" [class.fullscreen]="isResultFullscreen">
     <div class="result-header">
       <h2>Результат</h2>
       <div class="result-actions">


### PR DESCRIPTION
## Summary
- apply the fullscreen toggle to the result section instead of the entire recognized card
- update styles so the result block fills the viewport while keeping markdown content scrollable

## Testing
- CI=true npx ng build


------
https://chatgpt.com/codex/tasks/task_e_68dea0a9e9888331ba73a968968f5e33