### PR TITLE
Restyle recognition tasks page to align with About3 design

### DIFF
--- a/Angular/youtube-downloader/src/app/recognition-tasks/recognition-tasks.component.css
+++ b/Angular/youtube-downloader/src/app/recognition-tasks/recognition-tasks.component.css
@@ -1,21 +1,373 @@
-.tasks-table {
-    width: 100%;
-    overflow: auto;
-  }
-  
-  .mat-elevation-z8 {
-    margin-top: 20px;
-  }
-  
-  /* recognition-tasks.component.css */
-
-.markdown-container {
-  transition: max-height 0.3s ease;
-  /* Чтобы был плавный переход при разворачивании */
-  overflow: hidden;
+:host {
+  display: block;
+  color: #102a43;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.08), transparent 45%),
+    radial-gradient(circle at bottom left, rgba(14, 116, 144, 0.08), transparent 40%),
+    #f8fafc;
 }
 
-/* Когда свернуто, показываем ограниченный размер, например, 200px */
-.collapsed {
+.tasks-page {
+  min-height: 100vh;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding: 72px 32px 120px;
+}
+
+section {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(46, 130, 255, 0.35);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(46, 130, 255, 0.45);
+}
+
+.btn-secondary {
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  border-color: rgba(29, 78, 216, 0.18);
+}
+
+.btn-secondary:hover {
+  background: rgba(37, 99, 235, 0.15);
+  transform: translateY(-2px);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: center;
+  color: inherit;
+}
+
+.hero--compact .hero-text h1 {
+  font-size: 2.8rem;
+  line-height: 1.15;
+  margin-bottom: 20px;
+  color: #0f172a;
+}
+
+.hero-lead {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin-bottom: 20px;
+  max-width: 520px;
+  color: #334155;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 28px;
+  display: grid;
+  gap: 12px;
+}
+
+.hero-highlights li {
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.12);
+  border-radius: 16px;
+  padding: 12px 18px;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.hero-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 32px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+}
+
+.tasks-hero-card.empty {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.stat {
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 20px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-value {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.hero-hint {
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.section-header h2 {
+  font-size: 2rem;
+  color: #0b1f33;
+}
+
+.section-header p {
+  color: #475569;
+  max-width: 640px;
+  line-height: 1.6;
+}
+
+.tasks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.task-card {
+  background: #ffffff;
+  border-radius: 28px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 46px rgba(15, 23, 42, 0.12);
+}
+
+.task-card.done {
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.task-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-pill {
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.status-pill[data-status='Completed'],
+.status-pill[data-status='Done'],
+.status-pill[data-status='SUCCESS'],
+.status-pill[data-status='success'],
+.status-pill[data-status='done'],
+.task-card.done .status-pill {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+
+.status-pill[data-status='Failed'],
+.status-pill[data-status='Error'],
+.status-pill[data-status='failed'],
+.status-pill[data-status='error'] {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.task-language {
+  font-size: 0.95rem;
+  color: #475569;
+  font-weight: 500;
+}
+
+.task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.task-meta span::before {
+  content: '•';
+  margin: 0 8px;
+  color: rgba(99, 102, 241, 0.35);
+}
+
+.task-meta span:first-child::before {
+  content: '';
+  margin: 0;
+}
+
+.task-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #1f2937;
+}
+
+.task-result {
+  max-height: 260px;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  border-radius: 16px;
+  background: #f8fafc;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.task-result.collapsed {
   max-height: 200px;
+}
+
+.task-result ::ng-deep p {
+  margin: 0 0 12px;
+}
+
+.task-result ::ng-deep h1,
+.task-result ::ng-deep h2,
+.task-result ::ng-deep h3 {
+  margin-top: 16px;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.task-result ::ng-deep ul {
+  padding-left: 20px;
+  margin: 0 0 12px;
+}
+
+.task-error {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+.task-awaiting {
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 500;
+}
+
+.task-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.empty-state {
+  max-width: 520px;
+  margin: 0 auto;
+  text-align: center;
+  background: #ffffff;
+  border-radius: 32px;
+  padding: 48px 32px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.empty-state h3 {
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+  color: #0f172a;
+}
+
+.empty-state p {
+  color: #475569;
+  margin-bottom: 24px;
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .page-content {
+    padding: 64px 24px 100px;
+    gap: 72px;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-content {
+    padding: 48px 18px 80px;
+    gap: 56px;
+  }
+
+  .tasks-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .task-card {
+    padding: 24px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/Angular/youtube-downloader/src/app/recognition-tasks/recognition-tasks.component.html
+++ b/Angular/youtube-downloader/src/app/recognition-tasks/recognition-tasks.component.html
@@ -1,70 +1,104 @@
-<!-- recognition-tasks.component.html -->
-<div class="tasks-table">
-  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
-
-    <!-- Status Column -->
-    <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> Status </th>
-      <td mat-cell *matCellDef="let task">{{ task.status }}</td>
-    </ng-container>
-
-    <!-- Done Column -->
-    <ng-container matColumnDef="done">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> Done </th>
-      <td mat-cell *matCellDef="let task">{{ task.done ? 'Yes' : 'No' }}</td>
-    </ng-container>
-
-    <!-- Created At Column -->
-    <ng-container matColumnDef="createdAt">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> Created At </th>
-      <td mat-cell *matCellDef="let task">{{ task.createdAt | date }}  {{ task.uploadDate  |  localTime: 'yyyy-MM-dd HH:mm:ss' }}</td>
-    </ng-container>
-
-    <!-- Language Column -->
-    <ng-container matColumnDef="language">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> Language </th>
-      <td mat-cell *matCellDef="let task">
-        {{ task.language }}
-      </td>
-    </ng-container>
-
-    <!-- Result Column (Markdown, с toggling) -->
-    <ng-container matColumnDef="result">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> Result </th>
-      <td mat-cell *matCellDef="let task">
-        <div
-        class="markdown-container"
-        [ngClass]="{ collapsed: !isExpanded(task.id) }"
-      >
-        <markdown [data]="task.result"></markdown>
-      </div>
-      
-
-        <!-- Кнопки управления -->
-        <div style="margin-top: 8px;">
-          <button mat-button color="primary" (click)="toggleExpand(task.id)">
-            <!-- Меняем подпись в зависимости от состояния -->
-            {{ isExpanded(task.id) ? 'Свернуть' : 'Развернуть' }}
-          </button>
-
-          <!-- Ссылка для открытия полной страницы -->
-          <a
-            [routerLink]="['/recognized', task.id]"
-            style="margin-left: 8px; text-decoration: underline; cursor: pointer;"
-          >
-            Перейти к полной версии
-          </a>
+<div class="tasks-page">
+  <main class="page-content">
+    <section class="hero hero--compact">
+      <div class="hero-text">
+        <h1>История расшифровок</h1>
+        <p class="hero-lead">
+          Все ваши задачи из YouScriptor в одном месте. Отслеживайте прогресс, возвращайтесь к готовым результатам и
+          продолжайте работу там, где остановились.
+        </p>
+        <ul class="hero-highlights" *ngIf="totalTasks">
+          <li><strong>{{ completedTasks }}</strong> готовых задач</li>
+          <li><strong>{{ totalTasks - completedTasks }}</strong> в обработке</li>
+        </ul>
+        <div class="hero-actions">
+          <a class="btn btn-primary" [routerLink]="['/upload']">Загрузить новую запись</a>
+          <a class="btn btn-secondary" [routerLink]="['/about3']">О сервисе</a>
         </div>
-      </td>
-    </ng-container>
+      </div>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-  </table>
+      <div class="hero-card tasks-hero-card" *ngIf="totalTasks; else emptyState">
+        <div class="stats-grid">
+          <div class="stat">
+            <span class="stat-label">Всего задач</span>
+            <span class="stat-value">{{ totalTasks }}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">Завершено</span>
+            <span class="stat-value">{{ completedTasks }}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">Последнее обновление</span>
+            <span class="stat-value">{{ latestUpdate ? (latestUpdate | date: 'd MMM, HH:mm') : '—' }}</span>
+          </div>
+        </div>
+        <p class="hero-hint">
+          Результаты автоматически сохраняются и доступны в любое время. Нажмите на задачу, чтобы посмотреть расшифровку.
+        </p>
+      </div>
+    </section>
 
-  <mat-paginator
-    [pageSize]="15"
-    [pageSizeOptions]="[5, 10, 15]"
-    showFirstLastButtons
-  ></mat-paginator>
+    <ng-template #emptyState>
+      <div class="hero-card tasks-hero-card empty">
+        <h2>Здесь появятся ваши задачи</h2>
+        <p>Как только вы отправите первый файл, мы покажем прогресс и готовые результаты.</p>
+        <a class="btn btn-primary" [routerLink]="['/upload']">Загрузить файл</a>
+      </div>
+    </ng-template>
+
+    <section class="tasks-section">
+      <div class="section-header">
+        <h2>Ваши файлы и задачи</h2>
+        <p>
+          Управляйте расшифровками: проверяйте статус обработки, редактируйте готовый текст и скачивайте результат в пару
+          кликов.
+        </p>
+      </div>
+
+      <div class="tasks-grid" *ngIf="tasks.length; else noTasks">
+        <article class="task-card" *ngFor="let task of tasks" [ngClass]="{ done: task.done }">
+          <header class="task-header">
+            <span class="status-pill" [attr.data-status]="task.status || 'unknown'">{{ task.status || '—' }}</span>
+            <span class="task-language" *ngIf="task.language">{{ task.language }}</span>
+          </header>
+
+          <div class="task-meta">
+            <span *ngIf="task.createdAt">Создана {{ formatLocal(task.createdAt, { day: '2-digit', month: 'long' }) }}</span>
+            <span *ngIf="task.uploadDate">Загружено {{ formatLocal(task.uploadDate) }}</span>
+            <span *ngIf="task.createdBy">Автор: {{ task.createdBy }}</span>
+          </div>
+
+          <div class="task-body" *ngIf="task.result || task.error; else awaiting">
+            <div
+              class="task-result"
+              [ngClass]="{ collapsed: !isExpanded(task.id) }"
+              *ngIf="task.result"
+            >
+              <markdown [data]="task.result"></markdown>
+            </div>
+            <p class="task-error" *ngIf="task.error">{{ task.error }}</p>
+          </div>
+
+          <ng-template #awaiting>
+            <p class="task-awaiting">Результат будет готов после завершения обработки.</p>
+          </ng-template>
+
+          <footer class="task-actions">
+            <button class="btn btn-secondary" type="button" (click)="toggleExpand(task.id)" *ngIf="task.result">
+              {{ isExpanded(task.id) ? 'Свернуть' : 'Развернуть' }}
+            </button>
+            <a class="btn btn-primary" [routerLink]="['/recognized', task.id]">Открыть задачу</a>
+          </footer>
+        </article>
+      </div>
+    </section>
+
+    <ng-template #noTasks>
+      <div class="empty-state">
+        <h3>Пока нет задач</h3>
+        <p>Загрузите аудио или видео, чтобы начать расшифровку и увидеть прогресс здесь.</p>
+        <a class="btn btn-primary" [routerLink]="['/upload']">Создать задачу</a>
+      </div>
+    </ng-template>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/recognition-tasks/recognition-tasks.component.ts
+++ b/Angular/youtube-downloader/src/app/recognition-tasks/recognition-tasks.component.ts
@@ -1,55 +1,32 @@
 // recognition-tasks.component.ts
-import { Component, OnInit, ViewChild } from '@angular/core';
-import { MatTableDataSource } from '@angular/material/table';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatSort } from '@angular/material/sort';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatSortModule } from '@angular/material/sort';
 import { HttpClientModule } from '@angular/common/http';
+import { RouterModule } from '@angular/router';
+import { MarkdownModule } from 'ngx-markdown';
 import {
   RecognitionService,
   SpeechRecognitionTaskDto,
 } from '../services/recognition.service';
-import { MarkdownModule } from 'ngx-markdown';
-import { RouterModule } from '@angular/router';
-import { LocalTimePipe } from '../pipe/local-time.pipe';
 
 @Component({
   selector: 'app-recognition-tasks',
   standalone: true,
-  imports: [
-    LocalTimePipe,
-    CommonModule,
-    MatTableModule,
-    MatPaginatorModule,
-    MatSortModule,
-    HttpClientModule,
-    MarkdownModule,
-    RouterModule, // для routerLink
-  ],
+  imports: [CommonModule, HttpClientModule, MarkdownModule, RouterModule],
   templateUrl: './recognition-tasks.component.html',
   styleUrls: ['./recognition-tasks.component.css'],
 })
 export class RecognitionTasksComponent implements OnInit {
-  displayedColumns: string[] = [
-    'status',
-    'done',
-    'createdAt',
-    'language',
-    'result',
-  ];
-  dataSource = new MatTableDataSource<SpeechRecognitionTaskDto>();
+  tasks: SpeechRecognitionTaskDto[] = [];
+  totalTasks = 0;
+  completedTasks = 0;
+  latestUpdate?: Date;
 
   /**
    * Set со списком "развёрнутых" задач.
    * Если taskId присутствует здесь, значит показываем полный текст.
    */
   expandedTasks = new Set<string>();
-
-  @ViewChild(MatPaginator) paginator!: MatPaginator;
-  @ViewChild(MatSort) sort!: MatSort;
 
   constructor(private recognitionService: RecognitionService) {}
 
@@ -59,9 +36,10 @@ export class RecognitionTasksComponent implements OnInit {
 
   loadTasks(): void {
     this.recognitionService.getAllTasks().subscribe((tasks) => {
-      this.dataSource.data = tasks;
-      this.dataSource.paginator = this.paginator;
-      this.dataSource.sort = this.sort;
+      this.tasks = tasks;
+      this.totalTasks = tasks.length;
+      this.completedTasks = tasks.filter((task) => task.done).length;
+      this.latestUpdate = this.resolveLatestDate(tasks);
     });
   }
 
@@ -77,11 +55,57 @@ export class RecognitionTasksComponent implements OnInit {
    */
   toggleExpand(taskId: string): void {
     if (this.isExpanded(taskId)) {
-      // Если уже развёрнут, сворачиваем
       this.expandedTasks.delete(taskId);
     } else {
-      // Если свёрнут, разворачиваем
       this.expandedTasks.add(taskId);
     }
+  }
+
+  formatLocal(dateString: string | null, format: Intl.DateTimeFormatOptions = {}): string {
+    if (!dateString) {
+      return '—';
+    }
+
+    let normalized = dateString;
+    if (!normalized.includes('T')) {
+      normalized = normalized.replace(' ', 'T');
+    }
+    if (!normalized.endsWith('Z') && !normalized.includes('+')) {
+      normalized = `${normalized}Z`;
+    }
+
+    const date = new Date(normalized);
+
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+
+    return new Intl.DateTimeFormat('ru-RU', {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      ...format,
+    }).format(date);
+  }
+
+  private resolveLatestDate(tasks: SpeechRecognitionTaskDto[]): Date | undefined {
+    const timestamps = tasks
+      .map((task) => task.uploadDate || task.createdAt)
+      .filter((dateString): dateString is string => !!dateString)
+      .map((dateString) => {
+        if (dateString.includes('T') || dateString.endsWith('Z') || dateString.includes('+')) {
+          return new Date(dateString);
+        }
+        return new Date(`${dateString.replace(' ', 'T')}Z`);
+      })
+      .filter((date) => !isNaN(date.getTime()));
+
+    if (!timestamps.length) {
+      return undefined;
+    }
+
+    return new Date(Math.max(...timestamps.map((date) => date.getTime())));
   }
 }


### PR DESCRIPTION
## Summary
- restyle the recognition tasks page with hero, stats, and card-based layout that aligns with the About3 aesthetic
- replace the material table with responsive cards, dynamic task counts, and improved date formatting
- apply comprehensive styling updates for buttons, sections, and empty states to match the About3 visual language

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68dec537ba848331b652a056624c9805