### PR TITLE
Align blog feed with transcription page design

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.css
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.css
@@ -1,29 +1,278 @@
-.page-shell {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+:host {
+  display: block;
+  color: #0f172a;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+  min-height: 100vh;
 }
 
-.topic-creation mat-card {
-  background: #fafafa;
+.blog-page {
+  min-height: 100vh;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding: 80px 32px 120px;
+}
+
+section {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: center;
+}
+
+.hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(37, 99, 235, 0.85);
+  display: inline-block;
+  margin-bottom: 16px;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.6rem, 3vw + 1.6rem, 3.4rem);
+  line-height: 1.15;
+  margin: 0 0 20px;
+  color: #0b1f33;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 24px;
+  max-width: 560px;
+  color: #334155;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 32px;
+  display: grid;
+  gap: 14px;
+}
+
+.hero-highlights li {
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.btn:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(46, 130, 255, 0.35);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(46, 130, 255, 0.45);
+}
+
+.btn-secondary {
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+  border-color: rgba(29, 78, 216, 0.3);
+}
+
+.btn-secondary:hover {
+  background: rgba(29, 78, 216, 0.12);
+  transform: translateY(-2px);
+}
+
+.btn-outline {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(59, 130, 246, 0.25);
+  color: #1d4ed8;
+  padding: 10px 20px;
+  border-radius: 16px;
+  font-size: 0.95rem;
+}
+
+.btn-outline:hover {
+  background: rgba(59, 130, 246, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.btn-danger {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.26);
+  border-radius: 16px;
+  color: #b91c1c;
+  padding: 10px 20px;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.2);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(239, 68, 68, 0.18);
+}
+
+.btn:disabled,
+.btn-danger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 32px;
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+}
+
+.card-badge {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+  border-radius: 999px;
+  padding: 8px 16px;
+  align-self: flex-start;
+}
+
+.hero-card h3 {
+  margin: 0;
+  font-size: 1.7rem;
+  color: #0f172a;
+}
+
+.hero-card p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.card-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.card-list li {
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.1);
+  color: #1e293b;
+  font-weight: 500;
+}
+
+.card-actions {
+  margin-top: auto;
+}
+
+.feed-section {
+  position: relative;
+}
+
+.section-header {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.section-header h2 {
+  font-size: 2.4rem;
+  color: #0b1f33;
+  margin: 0;
+}
+
+.section-header p {
+  margin: 0;
+  font-size: 1rem;
+  color: #475569;
+  max-width: 640px;
 }
 
 .feed-state {
   text-align: center;
-  color: #666;
+  color: #475569;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 20px;
+  margin-bottom: 24px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
 }
 
-.blog-container {
+.topics-list {
   display: flex;
   flex-direction: column;
   gap: 24px;
 }
 
-.blog-card {
+.topic-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 28px;
+  padding: 28px 32px;
+  box-shadow: 0 28px 56px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(6px);
+}
+
+.topic-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.topic-header h3 {
   margin: 0;
+  font-size: 1.8rem;
+  color: #0f172a;
 }
 
 .topic-meta {
@@ -32,46 +281,72 @@
   align-items: baseline;
   font-size: 0.95rem;
   flex-wrap: wrap;
-}
-
-.topic-meta span {
-  color: #777;
+  color: #566174;
 }
 
 .topic-author {
-  color: #2f3034;
+  color: #1e293b;
+  font-weight: 600;
 }
 
-.content {
-  margin-top: 12px;
-  line-height: 1.6;
+.topic-comments-count {
+  background: rgba(59, 130, 246, 0.12);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+  color: #1d4ed8;
+}
+
+.topic-content {
+  margin-top: 20px;
+  line-height: 1.7;
+  color: #1f2937;
   overflow: hidden;
 }
 
-.content.collapsed {
-  max-height: 220px;
+.topic-content :where(p, ul, ol) {
+  margin-bottom: 16px;
+}
+
+.topic-content.collapsed {
+  max-height: 240px;
   position: relative;
 }
 
-.content.collapsed::after {
+.topic-content.collapsed::after {
   content: '';
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
-  height: 60px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 100%);
+  height: 72px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.95) 100%);
 }
 
-.card-actions {
+.topic-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
   align-items: center;
-  margin-top: 16px;
+  margin-top: 24px;
 }
 
-.card-actions .toggle {
+.text-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #2563eb;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.text-button:hover {
+  color: #1d4ed8;
+}
+
+.toggle {
   margin-right: auto;
 }
 
@@ -79,12 +354,12 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-left: auto;
   flex-wrap: wrap;
+  margin-left: auto;
 }
 
 .action-error {
-  color: #c62828;
+  color: #b91c1c;
   font-size: 0.9rem;
 }
 
@@ -94,7 +369,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  color: #757575;
+  color: #475569;
   font-size: 0.95rem;
 }
 
@@ -110,17 +385,68 @@
   padding: 32px 0;
 }
 
-@media (max-width: 768px) {
-  .page-shell {
-    padding: 12px;
-    gap: 16px;
+@media (max-width: 1024px) {
+  .page-content {
+    padding: 72px 24px 96px;
   }
 
-  .blog-container {
-    gap: 16px;
+  .hero {
+    gap: 32px;
   }
 
-  .topic-creation mat-card {
-    padding: 12px;
+  .topic-card {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 860px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-content {
+    padding: 56px 18px 80px;
+    gap: 72px;
+  }
+
+  .section-header h2 {
+    font-size: 2rem;
+  }
+
+  .hero-highlights li {
+    border-radius: 12px;
+    padding: 12px 14px;
+  }
+
+  .btn,
+  .btn-outline,
+  .btn-danger {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .moderation-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .toggle {
+    margin-right: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .topic-card {
+    padding: 20px 18px;
+  }
+
+  .topic-header h3 {
+    font-size: 1.5rem;
   }
 }

--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.html
@@ -1,86 +1,111 @@
-<div class="page-shell">
-  <section class="topic-creation" *ngIf="canCreateTopics">
-    <mat-card>
-      <mat-card-title>Новая тема</mat-card-title>
-      <mat-card-content>
-        <p>Используйте редактор с поддержкой Markdown и LaTeX, чтобы оформить новую публикацию.</p>
-        <button mat-flat-button color="primary" [routerLink]="['/blog/new']">
-          Открыть редактор
-        </button>
-      </mat-card-content>
-    </mat-card>
-  </section>
-
-  <div class="feed-state" *ngIf="feedError">{{ feedError }}</div>
-  <div class="feed-state" *ngIf="!loading && initialLoad && topics.length === 0 && !feedError">
-    Пока нет тем. Создайте первую!
-  </div>
-
-  <div
-    class="blog-container"
-    infiniteScroll
-    [scrollWindow]="true"
-    [infiniteScrollDistance]="2"
-    [infiniteScrollThrottle]="200"
-    [infiniteScrollDisabled]="loading || allLoaded"
-    (scrolled)="onScrollDown()"
-  >
-    <mat-card class="blog-card" *ngFor="let topic of topics; trackBy: trackByTopicId">
-      <mat-card-header>
-        <mat-card-title>{{ topic.header }}</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="topic-meta">
-          <b class="topic-author">{{ topic.user }}</b>
-          <span>{{ topic.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
-          <span class="topic-comments-count" *ngIf="topic.commentCount > 0">
-            Комментариев: {{ topic.commentCount }}
-          </span>
+<div class="blog-page">
+  <main class="page-content">
+    <section class="hero">
+      <div class="hero-text">
+        <span class="hero-eyebrow">сообщество youtscriptor</span>
+        <h1>Блог о создании и использовании расшифровок</h1>
+        <p class="hero-lead">
+          Делимся практиками, новыми функциями и историями команд, которые ускоряют работу с аудио и видео при помощи
+          YouScriptor.
+        </p>
+        <ul class="hero-highlights">
+          <li *ngFor="let highlight of heroHighlights">{{ highlight }}</li>
+        </ul>
+        <div class="hero-actions">
+          <ng-container *ngIf="canCreateTopics; else exploreLink">
+            <a class="btn btn-primary" [routerLink]="['/blog/new']">Новая публикация</a>
+          </ng-container>
+          <ng-template #exploreLink>
+            <a class="btn btn-primary" href="#topics">Читать статьи</a>
+          </ng-template>
+          <a class="btn btn-secondary" [routerLink]="['/transcriptions']">К расшифровкам</a>
         </div>
+      </div>
 
-        <div class="content" [class.collapsed]="topic.collapsed" [innerHTML]="topic.renderedText"></div>
+      <div class="hero-card">
+        <div class="card-badge">Комьюнити</div>
+        <h3>Обменивайтесь опытом и идеями</h3>
+        <p>
+          Создавайте публикации, рассказывайте о кейсах внедрения и находите ответы на вопросы о работе с сервисом.
+        </p>
+        <ul class="card-list">
+          <li *ngFor="let point of cardHighlights">{{ point }}</li>
+        </ul>
+        <div class="card-actions" *ngIf="canCreateTopics">
+          <a class="btn btn-outline" [routerLink]="['/blog/new']">Опубликовать статью</a>
+        </div>
+      </div>
+    </section>
 
-        <div class="card-actions">
-          <button
-            mat-button
-            color="primary"
-            class="toggle"
-            *ngIf="topic.textIsTooLong"
-            (click)="toggleCollapse(topic)"
-          >
-            {{ topic.collapsed ? 'Развернуть' : 'Свернуть' }}
-          </button>
-          <a mat-stroked-button color="primary" [routerLink]="['/blog', topic.slug]">
-            Читать полностью
-          </a>
-          <div class="moderation-actions" *ngIf="isModerator">
-            <span class="action-error" *ngIf="topic.actionError">{{ topic.actionError }}</span>
-            <button mat-stroked-button color="primary" (click)="editTopic(topic)">
-              Редактировать
-            </button>
-            <button
-              mat-stroked-button
-              color="warn"
-              (click)="deleteTopic(topic)"
-              [disabled]="topic.deleting"
-            >
-              {{ topic.deleting ? 'Удаление…' : 'Удалить' }}
-            </button>
+    <section class="feed-section" id="topics">
+      <div class="section-header">
+        <h2>Последние публикации</h2>
+        <p>Читайте новости продукта, рекомендации экспертов и инструкции по работе с расшифровками.</p>
+      </div>
+
+      <div class="feed-state" *ngIf="feedError">{{ feedError }}</div>
+      <div class="feed-state" *ngIf="!loading && initialLoad && topics.length === 0 && !feedError">
+        Пока нет тем. Создайте первую!
+      </div>
+
+      <div
+        class="topics-list"
+        infiniteScroll
+        [scrollWindow]="true"
+        [infiniteScrollDistance]="2"
+        [infiniteScrollThrottle]="200"
+        [infiniteScrollDisabled]="loading || allLoaded"
+        (scrolled)="onScrollDown()"
+      >
+        <article class="topic-card" *ngFor="let topic of topics; trackBy: trackByTopicId">
+          <div class="topic-header">
+            <h3>{{ topic.header }}</h3>
+            <div class="topic-meta">
+              <span class="topic-author">{{ topic.user }}</span>
+              <span>{{ topic.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
+              <span class="topic-comments-count" *ngIf="topic.commentCount > 0">
+                Комментариев: {{ topic.commentCount }}
+              </span>
+            </div>
           </div>
+
+          <div class="topic-content" [class.collapsed]="topic.collapsed" [innerHTML]="topic.renderedText"></div>
+
+          <div class="topic-actions">
+            <button
+              class="text-button toggle"
+              type="button"
+              *ngIf="topic.textIsTooLong"
+              (click)="toggleCollapse(topic)"
+            >
+              {{ topic.collapsed ? 'Развернуть' : 'Свернуть' }}
+            </button>
+            <a class="btn btn-outline" [routerLink]="['/blog', topic.slug]">Читать полностью</a>
+            <div class="moderation-actions" *ngIf="isModerator">
+              <span class="action-error" *ngIf="topic.actionError">{{ topic.actionError }}</span>
+              <button class="btn btn-outline" type="button" (click)="editTopic(topic)">Редактировать</button>
+              <button
+                class="btn btn-danger"
+                type="button"
+                (click)="deleteTopic(topic)"
+                [disabled]="topic.deleting"
+              >
+                {{ topic.deleting ? 'Удаление…' : 'Удалить' }}
+              </button>
+            </div>
+          </div>
+        </article>
+
+        <div class="feed-loader" *ngIf="loading && topics.length > 0">
+          <mat-spinner diameter="36"></mat-spinner>
         </div>
-      </mat-card-content>
-    </mat-card>
 
-    <div class="feed-loader" *ngIf="loading && topics.length > 0">
-      <mat-spinner diameter="36"></mat-spinner>
-    </div>
+        <div class="feed-end" *ngIf="allLoaded && topics.length > 0">Больше нет записей</div>
+      </div>
 
-    <div class="feed-end" *ngIf="allLoaded && topics.length > 0">
-      Больше нет записей
-    </div>
-  </div>
-
-  <div class="initial-loader" *ngIf="loading && topics.length === 0">
-    <mat-spinner diameter="40"></mat-spinner>
-  </div>
+      <div class="initial-loader" *ngIf="loading && topics.length === 0">
+        <mat-spinner diameter="40"></mat-spinner>
+      </div>
+    </section>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-feed/blog-feed.component.ts
@@ -1,7 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, OnInit } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { finalize } from 'rxjs/operators';
@@ -24,8 +22,6 @@ interface BlogTopicViewModel extends BlogTopic {
   standalone: true,
   imports: [
     CommonModule,
-    MatCardModule,
-    MatButtonModule,
     MatProgressSpinnerModule,
     InfiniteScrollModule,
     RouterModule
@@ -46,6 +42,18 @@ export class BlogFeedComponent implements OnInit {
 
   canCreateTopics = false;
   isModerator = false;
+
+  readonly heroHighlights = [
+    'Новости продукта и команды YouScriptor',
+    'Гайды по работе с расшифровками и контентом',
+    'Истории клиентов и лучшие практики'
+  ];
+
+  readonly cardHighlights = [
+    'Интервью и обзоры функций',
+    'Инструкции по автоматизации процессов',
+    'Советы экспертов и сообществ'
+  ];
 
   constructor(
     private readonly blogService: BlogService,


### PR DESCRIPTION
## Summary
- restyle the blog feed page with a hero, gradients, and glassmorphism elements aligned with the transcriptions experience
- swap Material cards and stroked buttons for custom button styles and refreshed topic cards
- expose reusable highlight copy arrays in the blog feed component for the hero and supporting card

## Testing
- npm run build -- --configuration production

------
https://chatgpt.com/codex/tasks/task_e_68deca1694808331b41626909b5264fd