### PR TITLE
Style blog detail and topic editor to match blog aesthetic

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
@@ -1,52 +1,183 @@
-.create-topic-container {
-  max-width: 900px;
+:host {
+  display: block;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+  color: #0f172a;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+}
+
+.blog-page {
+  min-height: 100vh;
+}
+
+.page-content {
+  max-width: 960px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 72px 24px 120px;
 }
 
-.full-width {
-  width: 100%;
-}
-
-.editor-section {
-  margin-top: 16px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  padding: 12px;
-  background: #fafafa;
+.editor-shell {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 32px;
 }
 
-.editor-section.invalid {
-  border-color: #f44336;
+.back-link {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.back-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(37, 99, 235, 0.2);
+}
+
+.editor-card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 32px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.14);
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
 .editor-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.95rem;
-  color: #424242;
+  flex-direction: column;
+  gap: 18px;
 }
 
-.editor-header label {
-  font-weight: 500;
+.editor-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+.editor-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.4vw + 1.2rem, 2.6rem);
+  line-height: 1.2;
+  color: #0b1f33;
+}
+
+.editor-header p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #475569;
+  max-width: 640px;
+}
+
+.load-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding: 24px;
+  border-radius: 20px;
+  background: rgba(248, 250, 255, 0.9);
+  border: 1px solid rgba(191, 219, 254, 0.6);
+  color: #475569;
+  text-align: center;
+}
+
+.load-state.error {
+  color: #b91c1c;
+  background: rgba(254, 226, 226, 0.7);
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.editor-form {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.form-field,
+.editor-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.form-field {
+  padding: 20px;
+  border-radius: 24px;
+  background: rgba(248, 250, 255, 0.9);
+  border: 1px solid rgba(191, 219, 254, 0.6);
+}
+
+.form-field.invalid,
+.editor-section.invalid {
+  border-color: rgba(248, 113, 113, 0.5);
+  box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.15);
+}
+
+.field-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: #1f2937;
+  font-weight: 600;
 }
 
 .char-counter {
-  color: #757575;
+  color: #64748b;
   font-size: 0.85rem;
 }
 
-.editor-error {
-  color: #c62828;
+.text-input {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(255, 255, 255, 0.9);
+  font-family: inherit;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  color: #0f172a;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.editor-section {
+  padding: 20px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.field-hint {
   font-size: 0.85rem;
+  color: #64748b;
+}
+
+.field-error {
+  font-size: 0.85rem;
+  color: #b91c1c;
 }
 
 .form-actions {
-  margin-top: 24px;
   display: flex;
   align-items: center;
   gap: 16px;
@@ -54,31 +185,83 @@
 }
 
 .error {
-  color: #c62828;
+  color: #b91c1c;
   font-size: 0.9rem;
 }
 
-.load-state {
-  margin: 24px 0;
-  display: flex;
-  justify-content: center;
+.btn {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  color: #666;
-  flex-wrap: wrap;
-  text-align: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  font-size: 0.98rem;
 }
 
-.load-state.error {
-  color: #c62828;
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(46, 130, 255, 0.35);
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(46, 130, 255, 0.45);
+}
+
+.btn-outline {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(59, 130, 246, 0.25);
+  color: #1d4ed8;
+  padding: 10px 22px;
+}
+
+.btn-outline:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.text-button {
+  background: none;
+  border: none;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s ease;
+}
+
+.text-button:hover:not(:disabled) {
+  color: #1e3a8a;
 }
 
 @media (max-width: 768px) {
-  .create-topic-container {
-    padding: 12px;
+  .page-content {
+    padding: 56px 16px 96px;
   }
 
+  .editor-card {
+    padding: 28px;
+    gap: 24px;
+  }
+
+  .form-field,
   .editor-section {
-    padding: 8px;
+    padding: 16px;
+    border-radius: 20px;
   }
 }

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.html
@@ -1,67 +1,83 @@
-<div class="create-topic-container">
-  <mat-card>
-    <mat-card-header>
-      <mat-card-title>
-        {{ isEditMode ? 'Редактирование темы' : 'Новая тема' }}
-      </mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="load-state" *ngIf="loadingTopic">
-        <mat-spinner diameter="40"></mat-spinner>
-      </div>
-      <div class="load-state error" *ngIf="loadError">
-        <span>{{ loadError }}</span>
-        <button
-          mat-stroked-button
-          type="button"
-          (click)="retryLoad()"
-          *ngIf="isEditMode"
+<div class="blog-page">
+  <main class="page-content">
+    <section class="editor-shell">
+      <a class="back-link" [routerLink]="['/blog']">← Вернуться к блогу</a>
+
+      <div class="editor-card">
+        <header class="editor-header">
+          <span class="editor-eyebrow">{{ isEditMode ? 'Редактирование' : 'Новая публикация' }}</span>
+          <h1>{{ isEditMode ? 'Обновите материал' : 'Поделитесь своей историей' }}</h1>
+          <p>
+            Заполните форму ниже, чтобы {{ isEditMode ? 'обновить тему' : 'создать новую тему' }} сообщества. Опубликуйте
+            практики, кейсы и рекомендации.
+          </p>
+        </header>
+
+        <div class="load-state" *ngIf="loadingTopic">
+          <mat-spinner diameter="44"></mat-spinner>
+        </div>
+
+        <div class="load-state error" *ngIf="loadError">
+          <span>{{ loadError }}</span>
+          <button class="btn btn-outline" type="button" (click)="retryLoad()" *ngIf="isEditMode">
+            Повторить
+          </button>
+        </div>
+
+        <form
+          class="editor-form"
+          *ngIf="!loadingTopic && (!isEditMode || !loadError)"
+          [formGroup]="topicForm"
+          (ngSubmit)="onSubmit()"
         >
-          Повторить
-        </button>
+          <div class="form-field" [class.invalid]="topicForm.controls['title'].invalid && topicForm.controls['title'].touched">
+            <div class="field-header">
+              <label for="topic-title">Заголовок</label>
+              <span class="char-counter">{{ titleLength }}/256</span>
+            </div>
+            <input
+              id="topic-title"
+              type="text"
+              maxlength="256"
+              formControlName="title"
+              class="text-input"
+              placeholder="Например, Как мы ускорили разметку подкастов"
+            />
+            <div class="field-error" *ngIf="topicForm.controls['title'].hasError('required') && topicForm.controls['title'].touched">
+              Укажите заголовок
+            </div>
+          </div>
+
+          <div class="editor-section" [class.invalid]="topicForm.controls['text'].invalid && topicForm.controls['text'].touched">
+            <div class="field-header">
+              <label for="topic-text">Текст</label>
+              <span class="char-counter">{{ textLength }}</span>
+            </div>
+            <md-editor
+              id="topic-text"
+              formControlName="text"
+              preview="vertical"
+              height="'420px'"
+              [options]="editorOptions"
+              [preRender]="preRender"
+            ></md-editor>
+            <div class="field-hint">Используйте Markdown, чтобы структурировать материал.</div>
+            <div class="field-error" *ngIf="topicForm.controls['text'].hasError('required') && topicForm.controls['text'].touched">
+              Укажите текст темы
+            </div>
+          </div>
+
+          <div class="form-actions">
+            <button class="text-button" type="button" (click)="onCancel()" [disabled]="submitting">
+              Отмена
+            </button>
+            <span class="error" *ngIf="submitError">{{ submitError }}</span>
+            <button class="btn btn-primary" type="submit" [disabled]="submitting">
+              {{ isEditMode ? 'Сохранить' : 'Опубликовать' }}
+            </button>
+          </div>
+        </form>
       </div>
-      <form
-        *ngIf="!loadingTopic && (!isEditMode || !loadError)"
-        [formGroup]="topicForm"
-        (ngSubmit)="onSubmit()"
-      >
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Заголовок</mat-label>
-          <input matInput formControlName="title" maxlength="256" />
-          <mat-hint align="end">{{ titleLength }}/256</mat-hint>
-          <mat-error *ngIf="topicForm.controls['title'].hasError('required')">
-            Укажите заголовок
-          </mat-error>
-        </mat-form-field>
-
-        <div class="editor-section" [class.invalid]="topicForm.controls['text'].invalid && topicForm.controls['text'].touched">
-          <div class="editor-header">
-            <label for="topic-text">Текст</label>
-            <span class="char-counter">{{ textLength }}</span>
-          </div>
-          <md-editor
-            id="topic-text"
-            formControlName="text"
-            preview="vertical"
-            height="'420px'"
-            [options]="editorOptions"
-            [preRender]="preRender"
-          ></md-editor>
-          <div class="editor-error" *ngIf="topicForm.controls['text'].hasError('required') && topicForm.controls['text'].touched">
-            Укажите текст темы
-          </div>
-        </div>
-
-        <div class="form-actions">
-          <button mat-stroked-button type="button" (click)="onCancel()" [disabled]="submitting">
-            Отмена
-          </button>
-          <span class="error" *ngIf="submitError">{{ submitError }}</span>
-          <button mat-flat-button color="primary" type="submit" [disabled]="submitting">
-            {{ isEditMode ? 'Сохранить' : 'Опубликовать' }}
-          </button>
-        </div>
-      </form>
-    </mat-card-content>
-  </mat-card>
+    </section>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.ts
@@ -1,11 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { LMarkdownEditorModule } from 'ngx-markdown-editor';
@@ -20,10 +16,7 @@ import { MarkdownRendererService1 } from '../task-result/markdown-renderer.servi
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    MatCardModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
+    RouterModule,
     MatSnackBarModule,
     MatProgressSpinnerModule,
     LMarkdownEditorModule

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
@@ -1,116 +1,331 @@
-.topic-shell {
-  max-width: 900px;
+:host {
+  display: block;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+  color: #0f172a;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+}
+
+.blog-page {
+  min-height: 100vh;
+}
+
+.page-content {
+  max-width: 960px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 72px 24px 120px;
+}
+
+.detail-section {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 32px;
 }
 
 .back-link {
   align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.state {
+.back-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(37, 99, 235, 0.2);
+}
+
+.state-card {
   display: flex;
   justify-content: center;
   align-items: center;
-  color: #666;
-  font-size: 1rem;
+  padding: 32px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  color: #475569;
+  text-align: center;
+}
+
+.state-card.error {
+  color: #b91c1c;
 }
 
 .topic-card {
-  padding-bottom: 8px;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 32px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.14);
+  padding: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.topic-header {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.topic-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+.topic-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.4vw + 1.2rem, 2.8rem);
+  line-height: 1.2;
+  color: #0b1f33;
 }
 
 .topic-meta {
   display: flex;
-  gap: 12px;
   flex-wrap: wrap;
+  gap: 12px;
   font-size: 0.95rem;
+  color: #475569;
 }
 
 .topic-author {
   font-weight: 600;
+  color: #1e293b;
+}
+
+.topic-comments {
+  color: #1d4ed8;
+  font-weight: 500;
 }
 
 .topic-content {
-  line-height: 1.7;
+  line-height: 1.8;
   display: block;
   overflow-wrap: anywhere;
+  color: #1e293b;
+  font-size: 1.04rem;
+}
+
+.topic-content h2,
+.topic-content h3,
+.topic-content h4 {
+  color: #0f172a;
+}
+
+.topic-content a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.topic-content a:hover {
+  text-decoration: underline;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  font-size: 0.98rem;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(46, 130, 255, 0.35);
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(46, 130, 255, 0.45);
+}
+
+.btn-outline {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(59, 130, 246, 0.25);
+  color: #1d4ed8;
+  padding: 10px 22px;
+}
+
+.btn-outline:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.btn-danger {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.26);
+  border-radius: 16px;
+  color: #b91c1c;
+  padding: 10px 22px;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.2);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(239, 68, 68, 0.18);
+}
+
+.text-button {
+  background: transparent;
+  border: none;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s ease;
+}
+
+.text-button:hover:not(:disabled) {
+  color: #1e3a8a;
+}
+
+.text-button.danger {
+  color: #b91c1c;
+}
+
+.text-button.danger:hover:not(:disabled) {
+  color: #991b1b;
 }
 
 .topic-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   flex-wrap: wrap;
-  margin: 16px 0;
 }
 
 .actions-spacer {
   flex: 1 1 auto;
 }
 
+.divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(226, 232, 240, 0), rgba(148, 163, 184, 0.6), rgba(226, 232, 240, 0));
+}
+
 .comments {
-  margin-top: 24px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 24px;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.section-header p {
+  margin: 4px 0 0;
+  color: #475569;
+  font-size: 0.95rem;
 }
 
 .comment {
-  padding-bottom: 12px;
-  border-bottom: 1px solid #ececec;
-}
-
-.comment:last-child {
-  border-bottom: none;
+  background: rgba(248, 250, 255, 0.9);
+  border: 1px solid rgba(191, 219, 254, 0.6);
+  border-radius: 20px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .comment-header {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
-  color: #757575;
+  gap: 8px;
+  color: #475569;
   font-size: 0.9rem;
-  margin-bottom: 4px;
+}
+
+.comment-author {
+  font-weight: 600;
+  color: #1e293b;
 }
 
 .comment-text {
   white-space: pre-wrap;
+  color: #1f2937;
+  line-height: 1.6;
 }
 
 .comment-controls,
 .comment-edit-actions {
-  margin-top: 12px;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   flex-wrap: wrap;
 }
 
 .comment-edit-section {
-  margin-top: 8px;
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.controls-spacer {
-  flex: 1 1 auto;
-}
-
-.empty {
-  color: #888;
+.field-label {
+  font-weight: 600;
+  color: #1f2937;
   font-size: 0.95rem;
 }
 
-.full-width {
+.text-field {
   width: 100%;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(255, 255, 255, 0.9);
+  font-family: inherit;
+  font-size: 0.98rem;
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  color: #0f172a;
+}
+
+.text-field:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.empty {
+  color: #64748b;
+  font-size: 0.95rem;
 }
 
 .comment-form {
-  margin-top: 24px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -124,24 +339,35 @@
 }
 
 .error {
-  color: #c62828;
+  color: #b91c1c;
   font-size: 0.9rem;
 }
 
 .login-hint {
-  margin-top: 16px;
-  color: #888;
+  color: #475569;
+  font-size: 0.95rem;
+  padding: 20px 24px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+  border-radius: 18px;
 }
 
 @media (max-width: 768px) {
-  .topic-shell {
-    padding: 12px;
-    gap: 16px;
+  .page-content {
+    padding: 56px 16px 96px;
   }
 
-  .comment-header {
-    flex-direction: column;
-    gap: 4px;
-    align-items: flex-start;
+  .topic-card {
+    padding: 28px;
+    gap: 28px;
+    border-radius: 24px;
+  }
+
+  .topic-header h1 {
+    font-size: 2.1rem;
+  }
+
+  .comment {
+    padding: 16px;
   }
 }

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.html
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.html
@@ -1,142 +1,144 @@
-<div class="topic-shell">
-  <a mat-button color="primary" class="back-link" [routerLink]="['/blog']">
-    ← Вернуться к блогу
-  </a>
+<div class="blog-page">
+  <main class="page-content">
+    <section class="detail-section">
+      <a class="back-link" [routerLink]="['/blog']">← Вернуться к блогу</a>
 
-  <div class="state" *ngIf="loadError">{{ loadError }}</div>
+      <div class="state-card error" *ngIf="loadError">{{ loadError }}</div>
 
-  <div class="state" *ngIf="loading">
-    <mat-spinner diameter="48"></mat-spinner>
-  </div>
-
-  <mat-card class="topic-card" *ngIf="!loading && topic">
-    <mat-card-header>
-      <mat-card-title>{{ topic.header }}</mat-card-title>
-      <mat-card-subtitle>
-        <div class="topic-meta">
-          <span class="topic-author">{{ topic.user }}</span>
-          <span>{{ topic.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
-          <span *ngIf="topic.commentCount > 0">Комментариев: {{ topic.commentCount }}</span>
-        </div>
-      </mat-card-subtitle>
-    </mat-card-header>
-
-    <mat-card-content>
-      <div class="topic-content" [innerHTML]="topic.renderedText"></div>
-
-      <div class="topic-actions" *ngIf="isModerator">
-        <span class="error" *ngIf="topic.topicActionError">{{ topic.topicActionError }}</span>
-        <span class="actions-spacer"></span>
-        <button mat-stroked-button color="primary" (click)="editTopic(topic)">
-          Редактировать тему
-        </button>
-        <button
-          mat-stroked-button
-          color="warn"
-          (click)="deleteTopic(topic)"
-          [disabled]="topic.deletingTopic"
-        >
-          {{ topic.deletingTopic ? 'Удаление…' : 'Удалить тему' }}
-        </button>
+      <div class="state-card loading" *ngIf="loading">
+        <mat-spinner diameter="48"></mat-spinner>
       </div>
 
-      <mat-divider></mat-divider>
-
-      <section class="comments">
-        <h3>Комментарии</h3>
-        <div class="comment" *ngFor="let comment of topic.comments; trackBy: trackByCommentId">
-          <div class="comment-header">
-            <b>{{ comment.user }}</b>
-            <span>{{ comment.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
+      <article class="topic-card" *ngIf="!loading && topic">
+        <header class="topic-header">
+          <span class="topic-eyebrow">Публикация сообщества</span>
+          <h1>{{ topic.header }}</h1>
+          <div class="topic-meta">
+            <span class="topic-author">{{ topic.user }}</span>
+            <span>{{ topic.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
+            <span class="topic-comments" *ngIf="topic.commentCount > 0">
+              Комментариев: {{ topic.commentCount }}
+            </span>
           </div>
-          <ng-container *ngIf="comment.editing; else viewComment">
-            <div class="comment-edit-section">
-              <mat-form-field appearance="outline" class="full-width">
-                <mat-label>Текст комментария</mat-label>
+        </header>
+
+        <div class="topic-content" [innerHTML]="topic.renderedText"></div>
+
+        <div class="topic-actions" *ngIf="isModerator">
+          <span class="error" *ngIf="topic.topicActionError">{{ topic.topicActionError }}</span>
+          <span class="actions-spacer"></span>
+          <button class="btn btn-outline" type="button" (click)="editTopic(topic)">
+            Редактировать тему
+          </button>
+          <button
+            class="btn btn-danger"
+            type="button"
+            (click)="deleteTopic(topic)"
+            [disabled]="topic.deletingTopic"
+          >
+            {{ topic.deletingTopic ? 'Удаление…' : 'Удалить тему' }}
+          </button>
+        </div>
+
+        <div class="divider"></div>
+
+        <section class="comments">
+          <div class="section-header">
+            <h2>Комментарии</h2>
+            <p>Присоединяйтесь к обсуждению и делитесь своим опытом.</p>
+          </div>
+          <div class="comment" *ngFor="let comment of topic.comments; trackBy: trackByCommentId">
+            <div class="comment-header">
+              <div class="comment-author">{{ comment.user }}</div>
+              <span class="comment-date">{{ comment.createdAt | date: 'd MMM yyyy, H:mm' }}</span>
+            </div>
+            <ng-container *ngIf="comment.editing; else viewComment">
+              <div class="comment-edit-section">
+                <label class="field-label" for="comment-{{ comment.id }}">Текст комментария</label>
                 <textarea
-                  matInput
+                  id="comment-{{ comment.id }}"
+                  class="text-field"
                   rows="4"
                   maxlength="2000"
                   [(ngModel)]="comment.editText"
                   [ngModelOptions]="{ standalone: true }"
                 ></textarea>
-              </mat-form-field>
-              <div class="comment-edit-actions">
+                <div class="comment-edit-actions">
+                  <span class="error" *ngIf="comment.actionError">{{ comment.actionError }}</span>
+                  <span class="controls-spacer"></span>
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                    (click)="saveComment(topic, comment)"
+                    [disabled]="comment.submittingEdit"
+                  >
+                    Сохранить
+                  </button>
+                  <button
+                    class="text-button"
+                    type="button"
+                    (click)="cancelEditComment(comment)"
+                    [disabled]="comment.submittingEdit"
+                  >
+                    Отмена
+                  </button>
+                </div>
+              </div>
+            </ng-container>
+            <ng-template #viewComment>
+              <div class="comment-text">{{ comment.text }}</div>
+              <div class="comment-controls" *ngIf="canEditComment(comment) || canDeleteComment(comment)">
                 <span class="error" *ngIf="comment.actionError">{{ comment.actionError }}</span>
                 <span class="controls-spacer"></span>
                 <button
-                  mat-flat-button
-                  color="primary"
-                  (click)="saveComment(topic, comment)"
-                  [disabled]="comment.submittingEdit"
+                  class="text-button"
+                  type="button"
+                  *ngIf="canEditComment(comment)"
+                  (click)="startEditComment(comment)"
+                  [disabled]="comment.editing"
                 >
-                  Сохранить
+                  Редактировать
                 </button>
                 <button
-                  mat-button
+                  class="text-button danger"
                   type="button"
-                  (click)="cancelEditComment(comment)"
-                  [disabled]="comment.submittingEdit"
+                  *ngIf="canDeleteComment(comment)"
+                  (click)="deleteComment(topic, comment)"
+                  [disabled]="comment.deleting"
                 >
-                  Отмена
+                  {{ comment.deleting ? 'Удаление…' : 'Удалить' }}
                 </button>
               </div>
-            </div>
-          </ng-container>
-          <ng-template #viewComment>
-            <div class="comment-text">{{ comment.text }}</div>
-            <div class="comment-controls" *ngIf="canEditComment(comment) || canDeleteComment(comment)">
-              <span class="error" *ngIf="comment.actionError">{{ comment.actionError }}</span>
-              <span class="controls-spacer"></span>
-              <button
-                mat-button
-                color="primary"
-                *ngIf="canEditComment(comment)"
-                (click)="startEditComment(comment)"
-                [disabled]="comment.editing"
-              >
-                Редактировать
-              </button>
-              <button
-                mat-button
-                color="warn"
-                *ngIf="canDeleteComment(comment)"
-                (click)="deleteComment(topic, comment)"
-                [disabled]="comment.deleting"
-              >
-                {{ comment.deleting ? 'Удаление…' : 'Удалить' }}
-              </button>
-            </div>
-          </ng-template>
-        </div>
-        <div class="empty" *ngIf="topic.comments.length === 0">
-          Пока нет комментариев
-        </div>
-      </section>
+            </ng-template>
+          </div>
+          <div class="empty" *ngIf="topic.comments.length === 0">
+            Пока нет комментариев
+          </div>
+        </section>
 
-      <mat-divider></mat-divider>
+        <div class="divider"></div>
 
-      <section class="comment-form" *ngIf="currentUser; else loginHint">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Комментарий</mat-label>
+        <section class="comment-form" *ngIf="currentUser; else loginHint">
+          <label class="field-label" for="new-comment">Комментарий</label>
           <textarea
-            matInput
+            id="new-comment"
+            class="text-field"
             rows="4"
             maxlength="2000"
             [(ngModel)]="topic.newComment"
             [ngModelOptions]="{ standalone: true }"
           ></textarea>
-        </mat-form-field>
-        <div class="comment-actions">
-          <span class="error" *ngIf="topic.commentError">{{ topic.commentError }}</span>
-          <button mat-raised-button color="primary" (click)="submitComment(topic)" [disabled]="topic.submittingComment">
-            Отправить
-          </button>
-        </div>
-      </section>
-      <ng-template #loginHint>
-        <div class="login-hint">Чтобы оставить комментарий, войдите в систему.</div>
-      </ng-template>
-    </mat-card-content>
-  </mat-card>
+          <div class="comment-actions">
+            <span class="error" *ngIf="topic.commentError">{{ topic.commentError }}</span>
+            <button class="btn btn-primary" type="button" (click)="submitComment(topic)" [disabled]="topic.submittingComment">
+              Отправить
+            </button>
+          </div>
+        </section>
+        <ng-template #loginHint>
+          <div class="login-hint">Чтобы оставить комментарий, войдите в систему.</div>
+        </ng-template>
+      </article>
+    </section>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.ts
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.ts
@@ -5,11 +5,6 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { finalize } from 'rxjs/operators';
 
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { BlogService, BlogTopic, BlogComment } from '../services/blog.service';
@@ -41,11 +36,6 @@ interface BlogTopicDetailViewModel extends BlogTopic {
     CommonModule,
     FormsModule,
     RouterModule,
-    MatCardModule,
-    MatButtonModule,
-    MatDividerModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatProgressSpinnerModule
   ],
   templateUrl: './blog-topic-detail.component.html',


### PR DESCRIPTION
## Summary
- restyle the blog topic detail view to use the new blog-themed layout, typography, and buttons
- redesign the blog topic creation and editing form with matching styles, markdown guidance, and error handling
- remove unused Angular Material modules from the updated components after the markup changes

## Testing
- ng serve --host 0.0.0.0 --port 4300

------
https://chatgpt.com/codex/tasks/task_e_68ded618b9b88331b639a72d7fbf37d6