### PR TITLE
Align blog content pages with feed width

### DIFF
--- a/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-create/blog-topic-create.component.css
@@ -11,15 +11,19 @@
 }
 
 .page-content {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 72px 24px 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding: 80px 32px 120px;
 }
 
 .editor-shell {
   display: flex;
   flex-direction: column;
   gap: 32px;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .back-link {
@@ -252,6 +256,7 @@
 @media (max-width: 768px) {
   .page-content {
     padding: 56px 16px 96px;
+    gap: 64px;
   }
 
   .editor-card {

--- a/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
+++ b/Angular/youtube-downloader/src/app/blog-topic-detail/blog-topic-detail.component.css
@@ -11,15 +11,19 @@
 }
 
 .page-content {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 72px 24px 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding: 80px 32px 120px;
 }
 
 .detail-section {
   display: flex;
   flex-direction: column;
   gap: 32px;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .back-link {
@@ -355,6 +359,7 @@
 @media (max-width: 768px) {
   .page-content {
     padding: 56px 16px 96px;
+    gap: 64px;
   }
 
   .topic-card {


### PR DESCRIPTION
## Summary
- align the blog detail and create layouts with the wider /blog feed width
- ensure responsive padding keeps consistent spacing on narrow screens

## Testing
- CI=true npx ng serve --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68dedae14c248331913cde6525a7349b