### PR TITLE
Add fullscreen view toggle to transcription results

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -416,6 +416,34 @@ section {
   border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
+.result-block.fullscreen {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  border-radius: 0;
+  margin: 0;
+  padding: 32px clamp(16px, 4vw, 48px);
+  box-shadow: none;
+  border: none;
+  background: rgba(248, 250, 255, 0.98);
+  z-index: 1100;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.result-block.fullscreen .markdown-content {
+  flex: 1;
+  max-height: none;
+}
+
+.result-block.fullscreen pre {
+  flex: 1;
+  max-height: none;
+}
+
 .result-header {
   display: flex;
   align-items: center;

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -107,7 +107,7 @@
                 <div class="error" *ngIf="selectedTask.error && !isTaskCompleted(selectedTask)">{{ selectedTask.error }}</div>
 
                 <ng-container *ngIf="isTaskCompleted(selectedTask); else processingView">
-                  <section class="result-block">
+                  <section class="result-block" [class.fullscreen]="isResultFullscreen">
                     <div class="result-header">
                       <h4>Результат</h4>
                       <div class="result-actions">
@@ -136,6 +136,15 @@
                         >
                           <mat-icon>content_copy</mat-icon>
                           <span>Копировать</span>
+                        </button>
+                        <button
+                          class="btn btn-outline"
+                          type="button"
+                          (click)="toggleResultFullscreen()"
+                          [attr.aria-pressed]="isResultFullscreen"
+                        >
+                          <mat-icon>{{ isResultFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
+                          <span>{{ isResultFullscreen ? 'Свернуть' : 'На весь экран' }}</span>
                         </button>
                       </div>
                     </div>

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -58,6 +58,8 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
   copying = false;
   renderedMarkdown: SafeHtml | null = null;
   private markdownSource = '';
+  isResultFullscreen = false;
+  private originalBodyOverflow: string | null = null;
 
   readonly OpenAiTranscriptionStatus = OpenAiTranscriptionStatus;
   readonly OpenAiTranscriptionStepStatus = OpenAiTranscriptionStepStatus;
@@ -87,6 +89,7 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopPolling();
+    this.resetFullscreenState();
   }
 
   openUploadDialog(): void {
@@ -156,6 +159,7 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
     this.selectedTask = null;
     this.detailsError = null;
     this.updateRenderedMarkdown(null);
+    this.resetFullscreenState();
     this.startPolling();
   }
 
@@ -444,6 +448,38 @@ export class OpenAiTranscriptionComponent implements OnInit, OnDestroy {
       default:
         finalize();
         return;
+    }
+  }
+
+  toggleResultFullscreen(): void {
+    this.isResultFullscreen = !this.isResultFullscreen;
+    this.updateBodyScrollLock();
+  }
+
+  private resetFullscreenState(): void {
+    if (this.isResultFullscreen) {
+      this.isResultFullscreen = false;
+      this.updateBodyScrollLock();
+    }
+  }
+
+  private updateBodyScrollLock(): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    if (this.isResultFullscreen) {
+      if (this.originalBodyOverflow === null) {
+        this.originalBodyOverflow = document.body.style.overflow || '';
+      }
+      document.body.style.overflow = 'hidden';
+    } else {
+      if (this.originalBodyOverflow !== null) {
+        document.body.style.overflow = this.originalBodyOverflow;
+        this.originalBodyOverflow = null;
+      } else {
+        document.body.style.removeProperty('overflow');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add a fullscreen toggle button to the transcription results action bar
- manage fullscreen state and body scroll locking when entering or leaving the view
- style the result panel so content expands to fill the viewport in fullscreen mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df4d2a2dc083319faad375fcff40c7