### PR TITLE
Restyle profile page to match transcription layout

### DIFF
--- a/Angular/youtube-downloader/src/app/profile/profile.component.css
+++ b/Angular/youtube-downloader/src/app/profile/profile.component.css
@@ -1,7 +1,220 @@
-.profile-shell {
-  max-width: 600px;
-  margin: 32px auto;
-  padding: 0 16px;
+:host {
+  display: block;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  color: #102a43;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+  min-height: 100vh;
+}
+
+.profile-page {
+  min-height: 100vh;
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding: 80px 32px 120px;
+}
+
+section {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 48px;
+  align-items: center;
+}
+
+.hero-text h1 {
+  font-size: 3rem;
+  line-height: 1.15;
+  margin-bottom: 24px;
+  color: #0f172a;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 24px;
+  max-width: 560px;
+  color: #334155;
+}
+
+.hero-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 32px;
+  display: grid;
+  gap: 14px;
+}
+
+.hero-highlights li {
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.btn mat-icon {
+  font-size: 20px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #3ec7ff, #2a6bff);
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(46, 130, 255, 0.35);
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(46, 130, 255, 0.45);
+}
+
+.btn-secondary {
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+  border-color: rgba(29, 78, 216, 0.3);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: rgba(29, 78, 216, 0.12);
+  transform: translateY(-2px);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+  transform: none;
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  border-radius: 32px;
+  padding: 36px;
+  display: grid;
+  gap: 18px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+}
+
+.card-header {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.card-value {
+  font-size: 2.6rem;
+  font-weight: 700;
+  color: #1d4ed8;
+  letter-spacing: -0.02em;
+}
+
+.card-description {
+  font-size: 1rem;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.card-footnote {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.profile-settings .section-header {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.profile-settings .section-header h2 {
+  font-size: 2.4rem;
+  color: #0b1f33;
+  margin: 0;
+}
+
+.profile-settings .section-header p {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #42526b;
+  max-width: 720px;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 32px;
+  align-items: start;
+}
+
+.settings-card,
+.tips-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  min-height: 160px;
+  font-size: 1rem;
+  color: #475569;
+}
+
+.state mat-progress-spinner {
+  --mdc-circular-progress-active-indicator-color: #2563eb;
+}
+
+.state-error {
+  color: #b91c1c;
+}
+
+.state-error mat-icon {
+  color: #ef4444;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .full-width {
@@ -10,24 +223,79 @@
 
 .actions {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
   gap: 16px;
-  margin-top: 16px;
-}
-
-.actions .error {
-  color: #d32f2f;
-}
-
-.actions .success {
-  color: #2e7d32;
-}
-
-.state {
-  display: flex;
-  justify-content: center;
   align-items: center;
-  min-height: 120px;
-  font-size: 16px;
-  color: rgba(0, 0, 0, 0.6);
+}
+
+.status-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 24px;
+}
+
+.status-messages .error {
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.status-messages .success {
+  color: #16a34a;
+  font-weight: 500;
+}
+
+.tips-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #0f172a;
+}
+
+.tips-card ul {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+  color: #475569;
+}
+
+.tips-card li::marker {
+  color: #3b82f6;
+}
+
+@media (max-width: 960px) {
+  .page-content {
+    padding: 64px 20px 96px;
+    gap: 72px;
+  }
+
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-text h1 {
+    font-size: 2.2rem;
+  }
+
+  .card-value {
+    font-size: 2.2rem;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .status-messages {
+    width: 100%;
+    text-align: center;
+    align-items: center;
+  }
 }

--- a/Angular/youtube-downloader/src/app/profile/profile.component.html
+++ b/Angular/youtube-downloader/src/app/profile/profile.component.html
@@ -1,30 +1,92 @@
-<div class="profile-shell">
-  <mat-card>
-    <mat-card-title>Профиль</mat-card-title>
-    <mat-card-content>
-      <div class="state" *ngIf="loading">
-        <mat-spinner diameter="40"></mat-spinner>
-      </div>
-      <div class="state" *ngIf="loadError && !loading">{{ loadError }}</div>
-
-      <form *ngIf="!loading && !loadError" [formGroup]="form" (ngSubmit)="submit()">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Отображаемое имя</mat-label>
-          <input matInput formControlName="displayName" maxlength="100" />
-          <mat-error *ngIf="form.controls.displayName.hasError('required')">
-            Введите отображаемое имя.
-          </mat-error>
-          <mat-hint align="end">Максимум 100 символов.</mat-hint>
-        </mat-form-field>
-
-        <div class="actions">
-          <span class="error" *ngIf="saveError">{{ saveError }}</span>
-          <span class="success" *ngIf="saveSuccess && !saveError">Изменения сохранены.</span>
-          <button mat-flat-button color="primary" type="submit" [disabled]="saving">
-            {{ saving ? 'Сохранение…' : 'Сохранить' }}
+<div class="profile-page">
+  <main class="page-content">
+    <section class="hero">
+      <div class="hero-text">
+        <h1>Управляйте профилем в едином рабочем пространстве</h1>
+        <p class="hero-lead">
+          Обновляйте отображаемое имя, чтобы коллеги видели актуальные данные в расшифровках и комментариях. Все
+          изменения синхронизируются моментально.
+        </p>
+        <ul class="hero-highlights">
+          <li>Единый профиль для всех сервисов YouScriptor</li>
+          <li>Автоматическое обновление данных в задачах по расшифровке</li>
+          <li>Защищённое хранение и обработка персональной информации</li>
+        </ul>
+        <div class="hero-actions">
+          <a class="btn btn-primary" [routerLink]="['/transcriptions']">
+            <mat-icon>arrow_back</mat-icon>
+            <span>К расшифровкам</span>
+          </a>
+          <button class="btn btn-secondary" type="button" (click)="fetchProfile()" [disabled]="loading">
+            <mat-icon>refresh</mat-icon>
+            <span>Обновить данные</span>
           </button>
         </div>
-      </form>
-    </mat-card-content>
-  </mat-card>
+      </div>
+      <div class="hero-card">
+        <div class="card-header">Текущее отображаемое имя</div>
+        <div class="card-value">{{ displayNameValue || '—' }}</div>
+        <div class="card-description">
+          Оно используется в расшифровках, комментариях и уведомлениях команды. Изменяйте его, если хотите поменять,
+          как вас видят коллеги.
+        </div>
+        <div class="card-footnote">Последнее обновление подтянется автоматически после сохранения.</div>
+      </div>
+    </section>
+
+    <section class="profile-settings">
+      <div class="section-header">
+        <h2>Настройки профиля</h2>
+        <p>
+          Введите отображаемое имя — оно появится в списке задач и в совместной работе над документами. Максимальная
+          длина имени — 100 символов.
+        </p>
+      </div>
+
+      <div class="settings-grid">
+        <div class="settings-card">
+          <div class="state" *ngIf="loading">
+            <mat-progress-spinner mode="indeterminate" diameter="48"></mat-progress-spinner>
+            <span>Загружаем профиль…</span>
+          </div>
+
+          <div class="state state-error" *ngIf="loadError && !loading">
+            <mat-icon>error_outline</mat-icon>
+            <span>{{ loadError }}</span>
+          </div>
+
+          <form class="settings-form" *ngIf="!loading && !loadError" [formGroup]="form" (ngSubmit)="submit()">
+            <mat-form-field appearance="outline" class="full-width">
+              <mat-label>Отображаемое имя</mat-label>
+              <input matInput formControlName="displayName" maxlength="100" />
+              <mat-error *ngIf="form.controls.displayName.hasError('required')">
+                Введите отображаемое имя.
+              </mat-error>
+              <mat-hint align="end">Максимум 100 символов.</mat-hint>
+            </mat-form-field>
+
+            <div class="actions">
+              <div class="status-messages">
+                <span class="error" *ngIf="saveError">{{ saveError }}</span>
+                <span class="success" *ngIf="saveSuccess && !saveError">Изменения сохранены.</span>
+              </div>
+              <button class="btn btn-primary" type="submit" [disabled]="saving">
+                <mat-icon *ngIf="saving">hourglass_top</mat-icon>
+                <span>{{ saving ? 'Сохранение…' : 'Сохранить изменения' }}</span>
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div class="tips-card">
+          <h3>Советы по оформлению</h3>
+          <ul>
+            <li>Используйте реальное имя или псевдоним, который узнают коллеги.</li>
+            <li>Не добавляйте контактные данные — для них есть профиль организации.</li>
+            <li>Обновляйте имя перед публикацией расшифровок или отчётов.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </main>
 </div>

--- a/Angular/youtube-downloader/src/app/profile/profile.component.ts
+++ b/Angular/youtube-downloader/src/app/profile/profile.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { RouterLink } from '@angular/router';
 
 import { AccountService } from '../services/account.service';
 import { AuthService } from '../services/AuthService.service';
@@ -16,11 +17,12 @@ import { AuthService } from '../services/AuthService.service';
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    MatCardModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
-    MatProgressSpinnerModule
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    RouterLink
   ],
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.css']
@@ -46,7 +48,15 @@ export class ProfileComponent implements OnInit {
     this.fetchProfile();
   }
 
+  get displayNameValue(): string {
+    return this.form.controls.displayName.value.trim();
+  }
+
   fetchProfile(): void {
+    if (this.loading) {
+      return;
+    }
+
     this.loading = true;
     this.loadError = '';
     this.accountService.getProfile().subscribe({


### PR DESCRIPTION
## Summary
- redesign the profile page layout with a hero section, call-to-action buttons, and refreshed copy consistent with the transcriptions workspace
- apply gradient background, pill buttons, and responsive cards mirroring the updated transcription styling
- extend the profile component to expose the current display name in the hero card and support refreshed interactions

## Testing
- `npm run build -- --configuration development --progress=false`


------
https://chatgpt.com/codex/tasks/task_e_68df4c70d8248331b0263bf600b79a5f