### PR TITLE
feat: improve mobile layout for recognized page

### DIFF
--- a/Angular/youtube-downloader/src/app/task-page/task-page.component.css
+++ b/Angular/youtube-downloader/src/app/task-page/task-page.component.css
@@ -70,4 +70,15 @@
     border-radius: 24px;
   }
 }
+
+@media (max-width: 600px) {
+  .page-content {
+    padding: 48px 12px 72px;
+    gap: 24px;
+  }
+
+  .recognized-section {
+    gap: 20px;
+  }
+}
   

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.css
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.css
@@ -237,20 +237,61 @@ app-yandex-ad {
   .video-summary {
     flex-direction: column;
     align-items: flex-start;
+    gap: 16px;
   }
 
   .video-summary-actions {
     width: 100%;
-    justify-content: center;
+    justify-content: flex-start;
   }
 
   .result-actions {
     width: 100%;
-    justify-content: center;
+    justify-content: flex-start;
+    gap: 8px;
   }
 
   .markdown-content {
-    padding: 18px;
+    padding: 0 8px;
     max-height: none;
+    background: transparent;
+    border: none;
+  }
+
+  .recognized-card {
+    padding: 16px;
+    border-radius: 20px;
+    box-shadow: none;
+    border: none;
+    background: transparent;
+    gap: 20px;
+  }
+
+  .result-block {
+    padding: 0;
+    border-radius: 0;
+    background: transparent;
+    border: none;
+    gap: 16px;
+  }
+
+  .result-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .btn {
+    padding: 10px;
+    border-radius: 14px;
+    min-width: 44px;
+    height: 44px;
+  }
+
+  .btn mat-icon {
+    font-size: 24px;
+  }
+
+  .btn span {
+    display: none;
   }
 }

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -23,7 +23,12 @@
       </div>
     </div>
     <div class="video-summary-actions">
-      <button class="btn btn-outline" type="button" (click)="openVideoDialog(task)">
+      <button
+        class="btn btn-outline"
+        type="button"
+        (click)="openVideoDialog(task)"
+        aria-label="Смотреть видео"
+      >
         <mat-icon>play_circle</mat-icon>
         <span>Смотреть видео</span>
       </button>
@@ -38,6 +43,7 @@
           class="btn btn-outline"
           *ngIf="task.id"
           [routerLink]="['/markdown-converter', task.id]"
+          aria-label="Редактировать"
         >
           <mat-icon>edit</mat-icon>
           <span>Редактировать</span>
@@ -47,6 +53,7 @@
           type="button"
           [matMenuTriggerFor]="downloadMenu"
           [disabled]="isDownloading || !hasAnyDownloadOption"
+          aria-label="Скачать"
         >
           <mat-icon>download</mat-icon>
           <span>Скачать</span>
@@ -56,6 +63,7 @@
           type="button"
           [matMenuTriggerFor]="copyMenu"
           [disabled]="isCopying || !hasAnyCopyOption"
+          aria-label="Копировать"
         >
           <mat-icon>content_copy</mat-icon>
           <span>Копировать</span>
@@ -65,6 +73,7 @@
           type="button"
           (click)="toggleFullscreen()"
           [attr.aria-pressed]="isResultFullscreen"
+          [attr.aria-label]="isResultFullscreen ? 'Свернуть результат' : 'Открыть результат на весь экран'"
         >
           <mat-icon>{{ isResultFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
           <span>{{ isResultFullscreen ? 'Свернуть' : 'На весь экран' }}</span>


### PR DESCRIPTION
## Summary
- add aria-labels to recognized task action buttons so their intent remains clear when labels are hidden on mobile
- simplify mobile styling for the recognized result block by removing heavy backgrounds, reducing padding, and spacing icon buttons consistently
- tighten small-screen padding on the recognized page container for a more compact layout

## Testing
- npm run build -- --configuration production --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68df4c12f74483318710ab7a11485102