### PR TITLE
Skip Angular build when building Debug configuration

### DIFF
--- a/YandexSpeech.csproj
+++ b/YandexSpeech.csproj
@@ -45,21 +45,21 @@
 		<AngularDistDir>$(AngularProjectDir)dist/youtube-downloader/</AngularDistDir>
 	</PropertyGroup>
 
-	<Target Name="BuildAngularApp" Condition="'$(DesignTimeBuild)' != 'true'" BeforeTargets="Build">
-		<Message Importance="high" Text="Building Angular client application..." />
-		<Exec WorkingDirectory="$(AngularProjectDir)" Command="npm install" Condition="!Exists('$(AngularProjectDir)node_modules')" />
-		<Exec WorkingDirectory="$(AngularProjectDir)" Command="npm run build -- --configuration production --progress false" />
-	</Target>
+        <Target Name="BuildAngularApp" Condition="'$(DesignTimeBuild)' != 'true' and '$(Configuration)' != 'Debug'" BeforeTargets="Build">
+                <Message Importance="high" Text="Building Angular client application..." />
+                <Exec WorkingDirectory="$(AngularProjectDir)" Command="npm install" Condition="!Exists('$(AngularProjectDir)node_modules')" />
+                <Exec WorkingDirectory="$(AngularProjectDir)" Command="npm run build -- --configuration production --progress false" />
+        </Target>
 
-	<Target Name="CopyAngularDistToProject" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="BuildAngularApp" AfterTargets="Build" BeforeTargets="Publish">
-		<ItemGroup>
-			<AngularDistFiles Include="$(AngularDistDir)**/*.*" />
-		</ItemGroup>
-		<RemoveDir Directories="$(ProjectDir)wwwroot" />
-		<Copy SourceFiles="@(AngularDistFiles)" DestinationFiles="@(AngularDistFiles->'$(ProjectDir)wwwroot\\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
-	</Target>
+        <Target Name="CopyAngularDistToProject" Condition="'$(DesignTimeBuild)' != 'true' and '$(Configuration)' != 'Debug'" DependsOnTargets="BuildAngularApp" AfterTargets="Build" BeforeTargets="Publish">
+                <ItemGroup>
+                        <AngularDistFiles Include="$(AngularDistDir)**/*.*" />
+                </ItemGroup>
+                <RemoveDir Directories="$(ProjectDir)wwwroot" />
+                <Copy SourceFiles="@(AngularDistFiles)" DestinationFiles="@(AngularDistFiles->'$(ProjectDir)wwwroot\\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+        </Target>
 
-        <Target Name="CopyAngularDistToPublish" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="BuildAngularApp" AfterTargets="Publish">
+        <Target Name="CopyAngularDistToPublish" Condition="'$(DesignTimeBuild)' != 'true' and '$(Configuration)' != 'Debug'" DependsOnTargets="BuildAngularApp" AfterTargets="Publish">
                 <ItemGroup>
                         <AngularDistFiles Include="$(AngularDistDir)**/*.*" />
                 </ItemGroup>


### PR DESCRIPTION
## Summary
- prevent the Angular SPA build and copy targets from running when the Debug configuration is used

## Testing
- dotnet build -c Debug *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df530ee2088331a0bb2d10731ce197