### PR TITLE
Fix fullscreen layout for transcription result panel

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -408,12 +408,51 @@ section {
 }
 
 .result-block {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 20px;
   background: rgba(248, 250, 255, 0.9);
   border-radius: 24px;
   padding: 24px;
   border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.result-block.fullscreen {
+  position: fixed;
+  inset: 32px;
+  margin: 0;
+  width: auto;
+  max-width: none;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px;
+  border-radius: 28px;
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+}
+
+.result-block.fullscreen .result-actions {
+  justify-content: flex-end;
+}
+
+.result-block.fullscreen .markdown-content,
+.result-block.fullscreen pre {
+  max-height: none;
+  height: 100%;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+@media (max-width: 1024px) {
+  .result-block.fullscreen {
+    inset: 16px;
+    padding: 24px;
+    max-height: calc(100vh - 32px);
+  }
 }
 
 .result-header {


### PR DESCRIPTION
## Summary
- convert the transcription result panel to a flex layout so fullscreen mode stretches correctly
- add fixed-position fullscreen styling with responsive padding and scrolling content handling

## Testing
- CI=true npx ng serve --host 0.0.0.0 --port 4200 --disable-host-check

------
https://chatgpt.com/codex/tasks/task_e_68df5c1d909c8331bb7fcc49042f540e