### PR TITLE
Adjust transcription workspace layout

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -23,6 +23,10 @@ section {
   width: 100%;
 }
 
+.workspace {
+  max-width: 1400px;
+}
+
 .hero {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -207,9 +211,13 @@ section {
 
 .workspace-grid {
   display: grid;
-  grid-template-columns: 320px minmax(0, 1fr);
-  gap: 32px;
+  grid-template-columns: 380px minmax(0, 1fr);
+  gap: 36px;
   align-items: start;
+}
+
+.tasks-panel {
+  min-width: 360px;
 }
 
 .panel {
@@ -330,7 +338,7 @@ section {
 }
 
 .details-panel {
-  min-height: 460px;
+  min-height: 560px;
 }
 
 .details-header {
@@ -480,7 +488,7 @@ section {
   padding: 24px;
   background: rgba(255, 255, 255, 0.85);
   border: 1px solid rgba(226, 232, 240, 0.8);
-  max-height: 480px;
+  max-height: 600px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- widen the "Мои расшифровки" panel to provide more room for task titles
- expand the overall workspace width and increase result panel height for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df63822d248331a537c936baee9c1c