### PR TITLE
Adjust OpenAI transcription task list padding

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -288,6 +288,7 @@ section {
   background: rgba(248, 250, 255, 0.9);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease;
   padding-inline: 18px;
+  padding-inline-start: 3px;
 }
 
 .tasks-list .mat-mdc-list-item:hover {


### PR DESCRIPTION
## Summary
- shift the transcription task list entries 15px to the left by reducing their leading padding

## Testing
- CI=true npm run build *(fails: existing CSS budget limits in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68df6b94b6788331b02ade5055e2206e