### PR TITLE
Remove extra border from transcription result view

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -417,10 +417,10 @@ section {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  background: rgba(248, 250, 255, 0.9);
+  background: transparent;
   border-radius: 24px;
   padding: 24px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  border: none;
 }
 
 .result-block.fullscreen {
@@ -437,6 +437,8 @@ section {
   gap: 24px;
   padding: 32px;
   border-radius: 28px;
+  background: rgba(248, 250, 255, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
   overflow: hidden;
 }
@@ -458,6 +460,8 @@ section {
     inset: 16px;
     padding: 24px;
     max-height: calc(100vh - 32px);
+    background: rgba(248, 250, 255, 0.96);
+    border: 1px solid rgba(148, 163, 184, 0.35);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the extra border styling from the completed transcription result block while preserving spacing
- keep the fullscreen reader styling intact by explicitly applying its background and border in overlay mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df759301288331a3d0ad252c877edb