### PR TITLE
Refine completed transcription result panel styling

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -423,6 +423,13 @@ section {
   border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
+.details-panel.has-result {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
 .result-block.fullscreen {
   position: fixed;
   inset: 32px;
@@ -437,6 +444,8 @@ section {
   gap: 24px;
   padding: 32px;
   border-radius: 28px;
+  background: rgba(248, 250, 255, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
   overflow: hidden;
 }
@@ -458,6 +467,8 @@ section {
     inset: 16px;
     padding: 24px;
     max-height: calc(100vh - 32px);
+    background: rgba(248, 250, 255, 0.96);
+    border: 1px solid rgba(148, 163, 184, 0.35);
   }
 }
 

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -81,7 +81,7 @@
         </div>
 
         <ng-container *ngIf="selectedTaskId; else selectPrompt">
-          <div class="panel details-panel">
+          <div class="panel details-panel" [class.has-result]="selectedTask && isTaskCompleted(selectedTask)">
             <ng-container *ngIf="detailsLoading; else taskDetails">
               <div class="loading-state">
                 <mat-progress-spinner mode="indeterminate" diameter="40"></mat-progress-spinner>


### PR DESCRIPTION
## Summary
- restore the completed result block's tinted background and border so it matches the previous appearance
- remove the surrounding panel border, padding, and shadow when a completed result is shown to eliminate the double frame
- add a template class binding to toggle the panel styling only for completed results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df759301288331a3d0ad252c877edb