### PR TITLE
Improve completed transcription result alignment

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -423,6 +423,21 @@ section {
   border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
+.details-panel.has-result {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+.details-panel.has-result .result-block:not(.fullscreen) {
+  margin: 0;
+  padding: 24px 32px;
+  background: rgba(226, 240, 255, 0.95);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  border-radius: 28px;
+}
+
 .result-block.fullscreen {
   position: fixed;
   inset: 32px;
@@ -437,6 +452,8 @@ section {
   gap: 24px;
   padding: 32px;
   border-radius: 28px;
+  background: rgba(248, 250, 255, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
   overflow: hidden;
 }
@@ -458,6 +475,12 @@ section {
     inset: 16px;
     padding: 24px;
     max-height: calc(100vh - 32px);
+    background: rgba(248, 250, 255, 0.96);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+  }
+
+  .details-panel.has-result .result-block:not(.fullscreen) {
+    padding: 24px;
   }
 }
 

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -81,7 +81,7 @@
         </div>
 
         <ng-container *ngIf="selectedTaskId; else selectPrompt">
-          <div class="panel details-panel">
+          <div class="panel details-panel" [class.has-result]="selectedTask && isTaskCompleted(selectedTask)">
             <ng-container *ngIf="detailsLoading; else taskDetails">
               <div class="loading-state">
                 <mat-progress-spinner mode="indeterminate" diameter="40"></mat-progress-spinner>


### PR DESCRIPTION
## Summary
- restore the completed result container's blue background and border while removing the extra outer frame
- align the completed transcript content with the task list by tuning padding and border radius, including a mobile-friendly variant

## Testing
- CI=true npm start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68df759301288331a3d0ad252c877edb