### PR TITLE
Refine OpenAI transcription result styling

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -417,10 +417,10 @@ section {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  background: transparent;
+  background: rgba(248, 250, 255, 0.9);
   border-radius: 24px;
   padding: 24px;
-  border: none;
+  border: 1px solid rgba(148, 163, 184, 0.3);
 }
 
 .details-panel.has-result {
@@ -428,6 +428,14 @@ section {
   border: none;
   box-shadow: none;
   padding: 0;
+}
+
+.details-panel.has-result .result-block:not(.fullscreen) {
+  margin: 0;
+  padding: 24px 32px;
+  background: rgba(226, 240, 255, 0.95);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  border-radius: 28px;
 }
 
 .result-block.fullscreen {
@@ -469,6 +477,10 @@ section {
     max-height: calc(100vh - 32px);
     background: rgba(248, 250, 255, 0.96);
     border: 1px solid rgba(148, 163, 184, 0.35);
+  }
+
+  .details-panel.has-result .result-block:not(.fullscreen) {
+    padding: 24px;
   }
 }
 

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -102,58 +102,56 @@
 
 
                   <section class="result-block" [class.fullscreen]="isResultFullscreen">
-
-                    <div class="details-header">
-                  <div class="details-title">
-                    <h3>{{ selectedTask.displayName }}    </h3>
-                    <div class="clarification-display" *ngIf="selectedTask.clarification">
-                      <strong>Уточнение:</strong>
-                      <span>{{ selectedTask.clarification }}</span>
-                    </div>
-                  </div>
-                  <span class="status-chip" [ngClass]="getStatusClass(selectedTask.status)">
-                    {{ getStatusText(selectedTask.status) }}
-                  </span>
-                </div>
-
-                    
-                      <div class="result-actions">
-                        <button
-                          class="btn btn-outline"
-                          type="button"
-                          [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
-                        >
-                          <mat-icon>edit</mat-icon>
-                          <span>Редактировать</span>
-                        </button>
-                        <button
-                          class="btn btn-outline"
-                          type="button"
-                          [matMenuTriggerFor]="downloadMenu"
-                          [disabled]="downloadInProgress || !hasAnyDownloadOption()"
-                        >
-                          <mat-icon>download</mat-icon>
-                          <span>Скачать</span>
-                        </button>
-                        <button
-                          class="btn btn-outline"
-                          type="button"
-                          [matMenuTriggerFor]="copyMenu"
-                          [disabled]="copying || !hasAnyCopyOption()"
-                        >
-                          <mat-icon>content_copy</mat-icon>
-                          <span>Копировать</span>
-                        </button>
-                        <button
-                          class="btn btn-outline"
-                          type="button"
-                          (click)="toggleResultFullscreen()"
-                          [attr.aria-pressed]="isResultFullscreen"
-                        >
-                          <mat-icon>{{ isResultFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
-                          <span>{{ isResultFullscreen ? 'Свернуть' : 'На весь экран' }}</span>
-                        </button>
+                    <div class="result-header">
+                      <div class="details-title">
+                        <h4>{{ selectedTask.displayName }}</h4>
+                        <div class="clarification-display" *ngIf="selectedTask.clarification">
+                          <strong>Уточнение:</strong>
+                          <span>{{ selectedTask.clarification }}</span>
+                        </div>
                       </div>
+                      <span class="status-chip" [ngClass]="getStatusClass(selectedTask.status)">
+                        {{ getStatusText(selectedTask.status) }}
+                      </span>
+                    </div>
+
+                    <div class="result-actions">
+                      <button
+                        class="btn btn-outline"
+                        type="button"
+                        [routerLink]="['/transcriptions', selectedTask.id, 'edit']"
+                      >
+                        <mat-icon>edit</mat-icon>
+                        <span>Редактировать</span>
+                      </button>
+                      <button
+                        class="btn btn-outline"
+                        type="button"
+                        [matMenuTriggerFor]="downloadMenu"
+                        [disabled]="downloadInProgress || !hasAnyDownloadOption()"
+                      >
+                        <mat-icon>download</mat-icon>
+                        <span>Скачать</span>
+                      </button>
+                      <button
+                        class="btn btn-outline"
+                        type="button"
+                        [matMenuTriggerFor]="copyMenu"
+                        [disabled]="copying || !hasAnyCopyOption()"
+                      >
+                        <mat-icon>content_copy</mat-icon>
+                        <span>Копировать</span>
+                      </button>
+                      <button
+                        class="btn btn-outline"
+                        type="button"
+                        (click)="toggleResultFullscreen()"
+                        [attr.aria-pressed]="isResultFullscreen"
+                      >
+                        <mat-icon>{{ isResultFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
+                        <span>{{ isResultFullscreen ? 'Свернуть' : 'На весь экран' }}</span>
+                      </button>
+                    </div>
                  
                     <mat-menu #downloadMenu="matMenu">
                       <button


### PR DESCRIPTION
## Summary
- restore the result panel styling with contextual highlight for completed tasks
- align the result header markup with shared styles for action buttons and status chip

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df7e6bde888331a1abb9ae17679668