### PR TITLE
Remove Angular production build budget limits

### DIFF
--- a/Angular/youtube-downloader/angular.json
+++ b/Angular/youtube-downloader/angular.json
@@ -64,18 +64,6 @@
           },
           "configurations": {
             "production": {
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "2MB",
-                  "maximumError": "20MB"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
-                }
-              ],
               "outputHashing": "all",
               "optimization": {
                 "fonts": {


### PR DESCRIPTION
## Summary
- remove production build style and bundle budget limits from the Angular workspace configuration to prevent budget overflow failures

## Testing
- npm run build -- --configuration production --progress false *(fails: Workspace extension with invalid name (defaultProject) found.)*

------
https://chatgpt.com/codex/tasks/task_e_68df871a4ed0833197774b68e81d4bf9