### PR TITLE
Embed landing search on About page

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -203,6 +203,145 @@ section {
   box-shadow: 0 12px 24px rgba(10, 31, 68, 0.12);
 }
 
+.landing-search {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 116, 144, 0.12));
+  border-radius: 40px;
+  padding: 56px 64px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+}
+
+.landing-search-inner {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: start;
+}
+
+.landing-search-text h2 {
+  font-size: 2.4rem;
+  margin-bottom: 20px;
+  color: #0f172a;
+}
+
+.landing-search-text p {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: #1f2937;
+  margin-bottom: 24px;
+}
+
+.landing-search-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 16px;
+}
+
+.landing-search-list li {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 500;
+  color: #0f172a;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.landing-search-panel {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 28px;
+  padding: 32px;
+  display: grid;
+  gap: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+}
+
+.landing-search-form {
+  display: grid;
+  gap: 12px;
+}
+
+.landing-search-label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.landing-search-field {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  padding: 10px 12px 10px 20px;
+}
+
+.landing-search-field input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  color: #0f172a;
+  outline: none;
+}
+
+.landing-search-field input::placeholder {
+  color: #94a3b8;
+}
+
+.landing-search-field:focus-within {
+  border-color: rgba(59, 130, 246, 0.65);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
+}
+
+.landing-search-field .btn {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.landing-search-hint {
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.landing-search-hint a {
+  color: #1d4ed8;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.landing-search-hint a:hover {
+  text-decoration: underline;
+}
+
+.landing-search-error {
+  color: #dc2626;
+  font-weight: 500;
+}
+
+@media (max-width: 1024px) {
+  .landing-search-inner {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-search {
+    padding: 40px 28px;
+  }
+}
+
+@media (max-width: 640px) {
+  .landing-search-field {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 16px;
+  }
+
+  .landing-search-field .btn {
+    width: 100%;
+  }
+}
+
 .logo-card img {
   max-width: 120px;
   max-height: 48px;

--- a/Angular/youtube-downloader/src/app/about3/about3.component.html
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.html
@@ -31,6 +31,49 @@
       </div>
     </section>
 
+    <section class="landing-search">
+      <div class="landing-search-inner">
+        <div class="landing-search-text">
+          <h2>Расшифровывайте YouTube за пару минут</h2>
+          <p>
+            Запустите задачу прямо со страницы «О сервисе»: укажите ссылку или идентификатор ролика, а мы подготовим
+            аккуратно оформленный документ с тайм-кодами, списками и цитатами.
+          </p>
+          <ul class="landing-search-list">
+            <li *ngFor="let item of recognitionGuide">{{ item }}</li>
+          </ul>
+        </div>
+
+        <div class="landing-search-panel">
+          <form class="landing-search-form" (ngSubmit)="startRecognition()">
+            <label class="landing-search-label" for="landing-search-input">Ссылка или идентификатор YouTube</label>
+            <div class="landing-search-field">
+              <input
+                id="landing-search-input"
+                name="youtubeQuery"
+                type="text"
+                [(ngModel)]="searchValue"
+                placeholder="https://youtube.com/..."
+                autocomplete="off"
+                [disabled]="isStarting"
+              />
+              <button class="btn btn-primary" type="submit" [disabled]="isStarting || !searchValue.trim()">
+                <span *ngIf="!isStarting">Начать транскрибацию</span>
+                <span *ngIf="isStarting">Запускаем…</span>
+              </button>
+            </div>
+          </form>
+
+          <p class="landing-search-hint">
+            Результат появится в разделе <a [routerLink]="['/recognition-tasks']">Scriptorium</a>, а прогресс можно будет
+            отслеживать позднее.
+          </p>
+
+          <p class="landing-search-error" *ngIf="startError">{{ startError }}</p>
+        </div>
+      </div>
+    </section>
+
     <section class="trusted">
       <h2>Нам доверяют команды из топовых компаний</h2>
       <div class="logo-grid">


### PR DESCRIPTION
## Summary
- embed a YouTube transcription search block within /about3 and reuse the existing service flow
- wire the About page component to SubtitleService so the search form launches recognition tasks with error handling
- style the new section to match the page layout and ensure responsive behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df8b31f5bc83318e4dc8c649b21f37