### PR TITLE
Restyle Scriptorium filter input to match recognition page

### DIFF
--- a/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.css
+++ b/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.css
@@ -142,14 +142,66 @@ section {
 }
 
 .filter-toolbar {
-  display: flex;
-  justify-content: flex-start;
+  display: grid;
+  gap: 12px;
+  justify-items: flex-start;
+}
+
+.filter-label {
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .filter-field {
-  width: min(100%, 420px);
-  background: rgba(59, 130, 246, 0.08);
-  border-radius: 16px;
+  width: min(100%, 540px);
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  padding: 10px 12px 10px 20px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-field:focus-within {
+  border-color: rgba(59, 130, 246, 0.65);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.18);
+}
+
+.filter-field input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  color: #0f172a;
+  outline: none;
+}
+
+.filter-field input::placeholder {
+  color: #94a3b8;
+}
+
+.filter-reset-btn {
+  border: none;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 165, 233, 0.18));
+  color: #1d4ed8;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.filter-reset-btn:hover {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(14, 165, 233, 0.26));
+  color: #1e3a8a;
+}
+
+.filter-reset-btn:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.55);
+  outline-offset: 2px;
 }
 
 .custom-table {

--- a/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.html
+++ b/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.html
@@ -53,10 +53,26 @@
             (scrolled)="onScrollDown()"
           >
             <div class="filter-toolbar">
-              <mat-form-field appearance="outline" class="filter-field">
-                <mat-label>Фильтр по названию или каналу</mat-label>
-                <input matInput placeholder="Начните печатать..." (keyup)="applyFilter($event)">
-              </mat-form-field>
+              <label class="filter-label" for="tasks-filter-input">Фильтр по названию или каналу</label>
+              <div class="filter-field">
+                <input
+                  #filterInput
+                  id="tasks-filter-input"
+                  type="text"
+                  [value]="filterValue"
+                  (input)="applyFilter($event)"
+                  placeholder="Начните печатать..."
+                  autocomplete="off"
+                />
+                <button
+                  *ngIf="filterValue"
+                  type="button"
+                  class="filter-reset-btn"
+                  (click)="clearFilter(filterInput)"
+                >
+                  Очистить
+                </button>
+              </div>
             </div>
 
             <app-yandex-ad></app-yandex-ad>

--- a/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.ts
+++ b/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.ts
@@ -6,8 +6,6 @@ import { Title } from '@angular/platform-browser';
 
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCardModule } from '@angular/material/card';
@@ -36,8 +34,6 @@ import { YandexAdComponent } from '../ydx-ad/yandex-ad.component';
     /* Material & CDK */
     MatTableModule,
     MatSortModule,
-    MatFormFieldModule,
-    MatInputModule,
     MatButtonModule,
     MatIconModule,
     MatCardModule,
@@ -105,13 +101,14 @@ export class SubtitlesTasksComponent implements OnInit {
   private loadTasks(append = false): void {
     this.loading = true;
     const page = this.pageIndex + 1;
+    const filter = this.filterValue.trim().toLowerCase();
     this.subtitleService
       .getTasks(
         page,
         this.pageSize,
         this.sortField,
         this.sortOrder,
-        this.filterValue,
+        filter,
         this.userIdFilter
       )
       .subscribe({
@@ -133,9 +130,16 @@ export class SubtitlesTasksComponent implements OnInit {
   }
 
   applyFilter(evt: Event): void {
-    this.filterValue = (evt.target as HTMLInputElement).value.trim().toLowerCase();
+    this.filterValue = (evt.target as HTMLInputElement).value;
     this.pageIndex = 0;
     this.loadTasks();
+  }
+
+  clearFilter(input: HTMLInputElement): void {
+    this.filterValue = '';
+    this.pageIndex = 0;
+    this.loadTasks();
+    input.focus();
   }
 
   onSortChange(sort: Sort): void {


### PR DESCRIPTION
## Summary
- restyle the Scriptorium queue filter field to mirror the recognition landing search styling and add a clear action
- adjust filter handling to preserve user casing while normalizing requests and clean up unused Angular Material form modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff1b166fc8331a7ebd746262e02ce