### PR TITLE
Adjust recognized task page height to remove stray scrollbar

### DIFF
--- a/Angular/youtube-downloader/src/app/task-page/task-page.component.css
+++ b/Angular/youtube-downloader/src/app/task-page/task-page.component.css
@@ -3,11 +3,11 @@
   color: #102a43;
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
   background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
-  min-height: 100vh;
+  min-height: calc(100vh - var(--app-header-height));
 }
 
 .transcription-page {
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 .page-content {

--- a/Angular/youtube-downloader/src/styles.css
+++ b/Angular/youtube-downloader/src/styles.css
@@ -1,3 +1,7 @@
+:root {
+  --app-header-height: 64px;
+}
+
 html, body {
   height: 100%;
 }
@@ -7,6 +11,12 @@ body {
   font-family: Roboto, "Helvetica Neue", sans-serif;
   min-height: 100vh;
   background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+}
+
+@media (max-width: 600px) {
+  :root {
+    --app-header-height: 56px;
+  }
 }
 
 /* Если нужно, можно убрать или откорректировать стили для контейнеров Angular Material */


### PR DESCRIPTION
## Summary
- add a reusable CSS custom property for the application header height with a mobile-friendly override
- update the recognized task page container to subtract the header height so the page no longer exceeds the viewport

## Testing
- CI=1 npm run start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68e09b3b133483318cf30cbe87cf5488