### PR TITLE
Hide video dialog controls for guests

### DIFF
--- a/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.html
+++ b/Angular/youtube-downloader/src/app/subtitles-task/subtitles-tasks.component.html
@@ -99,7 +99,7 @@
                   </td>
                 </ng-container>
 
-                <ng-container matColumnDef="youtube">
+                <ng-container *ngIf="isAuthenticated" matColumnDef="youtube">
                   <th mat-header-cell *matHeaderCellDef>Видео</th>
                   <td mat-cell *matCellDef="let task">
                     <button class="youtube-logo-button" matRipple (click)="openVideoDialog(task)">
@@ -191,7 +191,12 @@
                     <p>Канал: {{ task.channelName }}</p>
                     <p>{{ task.createdAt | localTime:'yyyy-MM-dd HH:mm' }}</p>
                   </div>
-                  <button class="youtube-logo-button" matRipple (click)="openVideoDialog(task)">
+                  <button
+                    *ngIf="isAuthenticated"
+                    class="youtube-logo-button"
+                    matRipple
+                    (click)="openVideoDialog(task)"
+                  >
                     <img src="assets/yt.webp" alt="YouTube" class="youtube-logo">
                   </button>
                 </div>

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -2,6 +2,7 @@
   <div class="video-summary">
     <div class="video-summary-left">
       <button
+        *ngIf="isAuthenticated"
         class="yt-logo-button"
         type="button"
         (click)="openVideoDialog(task)"
@@ -21,17 +22,6 @@
           <span *ngIf="task.createdAt">· Обновлено {{ task.createdAt | localTime: 'yyyy-MM-dd HH:mm' }}</span>
         </div>
       </div>
-    </div>
-    <div class="video-summary-actions">
-      <button
-        class="btn btn-outline"
-        type="button"
-        (click)="openVideoDialog(task)"
-        aria-label="Смотреть видео"
-      >
-        <mat-icon>play_circle</mat-icon>
-        <span>Смотреть видео</span>
-      </button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- hide the YouTube preview column and mobile button for unauthenticated visitors in the subtitles task list
- wire subtitles queue and task result components to the auth service so login state controls access to the video dialog
- remove the "Смотреть видео" call-to-action from the recognized task header and only show the YouTube icon button when logged in

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e0a038df588331abf89afc20158684