### PR TITLE
Add frontend PNG to WebP converter tool

### DIFF
--- a/Angular/youtube-downloader/src/app/app-routing.module.ts
+++ b/Angular/youtube-downloader/src/app/app-routing.module.ts
@@ -11,12 +11,14 @@ import { AboutBusinessComponent } from './about-business/about-business.componen
 import { About1Component } from './about1/about1.component';
 import { About2Component } from './about2/about2.component';
 import { About3Component } from './about3/about3.component';
+import { PngToWebpComponent } from './png-to-webp/png-to-webp.component';
 
 const routes: Routes = [
   { path: '', component: YoutubeDownloaderComponent },
   { path: 'youtube-downloader', component: YoutubeDownloaderComponent },
   { path: 'recognition-tasks', component: RecognitionTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
+  { path: 'png-to-webp', component: PngToWebpComponent },
   { path: 'billing', component: BillingComponent, canActivate: [AuthGuard] },
   {
     path: 'admin/users',

--- a/Angular/youtube-downloader/src/app/app.routes.ts
+++ b/Angular/youtube-downloader/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { YoutubeDownloaderComponent } from './youtube-downloader/youtube-downloa
 import { RecognitionTasksComponent } from './recognition-tasks/recognition-tasks.component';
 import { SubtitlesTasksComponent } from './subtitles-task/subtitles-tasks.component';
 import { MarkdownConverterComponent } from './Markdown-converter/markdown-converter.component';
+import { PngToWebpComponent } from './png-to-webp/png-to-webp.component';
 import { OpenAiTranscriptionComponent } from './openai-transcription/openai-transcription.component';
 import { BillingComponent } from './billing/billing.component';
 import { AuthGuard } from './services/auth.guard';
@@ -19,6 +20,7 @@ export const appRoutes: Routes = [
   { path: 'recognition-tasks', component: SubtitlesTasksComponent },
   { path: 'transcriptions', component: OpenAiTranscriptionComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
+  { path: 'png-to-webp', component: PngToWebpComponent },
   { path: 'billing', component: BillingComponent, canActivate: [AuthGuard] },
   {
     path: 'admin/users',

--- a/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.css
+++ b/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.css
@@ -1,0 +1,169 @@
+:host {
+  display: block;
+  padding: 24px;
+}
+
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.description {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.upload-area {
+  border: 2px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 16px;
+  padding: 32px;
+  text-align: center;
+  transition: border-color 0.2s ease;
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.02) 25%, transparent 25%) -10px 0/20px 20px,
+              linear-gradient(225deg, rgba(0, 0, 0, 0.02) 25%, transparent 25%) -10px 0/20px 20px,
+              linear-gradient(315deg, rgba(0, 0, 0, 0.02) 25%, transparent 25%) 0px 0/20px 20px,
+              linear-gradient(45deg, rgba(0, 0, 0, 0.02) 25%, transparent 25%) 0px 0/20px 20px;
+}
+
+.upload-area:hover {
+  border-color: rgba(63, 81, 181, 0.6);
+}
+
+.upload-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.hint {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.slider {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.previews {
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  padding: 24px;
+}
+
+.preview {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.image-frame {
+  position: relative;
+  width: 100%;
+  min-height: 240px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.checkerboard {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 32px 32px;
+  background-position: 0 0, 0 16px, 16px -16px, -16px 0px;
+  background-color: #f5f5f5;
+}
+
+.image-frame img {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 1;
+}
+
+.spinner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 2;
+}
+
+dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 16px;
+}
+
+dl div {
+  display: contents;
+}
+
+dt {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+dd {
+  margin: 0;
+}
+
+.note {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.error {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: rgba(244, 67, 54, 0.1);
+  color: #c62828;
+}
+
+@media (max-width: 900px) {
+  .previews {
+    flex-direction: column;
+  }
+
+  .image-frame {
+    min-height: 200px;
+  }
+}

--- a/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.html
@@ -1,0 +1,100 @@
+<div class="page">
+  <h1>PNG → WebP конвертер</h1>
+  <p class="description">
+    Преобразуйте PNG изображение в WebP прямо в браузере. Загрузите файл, вставьте из буфера обмена или перетащите его в область ниже.
+    Прозрачность сохраняется, а вы сразу увидите результат и размер полученного файла.
+  </p>
+
+  <div class="upload-area"
+       (drop)="onDrop($event)"
+       (dragover)="onDragOver($event)">
+    <div class="upload-content">
+      <button mat-stroked-button color="primary" (click)="fileInput.click()">
+        <mat-icon>upload_file</mat-icon>
+        Выбрать PNG
+      </button>
+      <p class="hint">или перетащите изображение сюда, или нажмите <strong>Ctrl/⌘ + V</strong> для вставки</p>
+      <input #fileInput type="file" accept="image/png" (change)="onFileInput($event)" hidden>
+    </div>
+  </div>
+
+  <div class="controls" *ngIf="originalFile()">
+    <div class="slider">
+      <label for="quality">Качество WebP: {{ quality() | number:'1.0-2' }}</label>
+      <mat-slider
+        id="quality"
+        min="0.1"
+        max="1"
+        step="0.01"
+        [discrete]="true">
+        <input matSliderThumb [value]="quality()" (input)="onSliderInput($event)">
+      </mat-slider>
+    </div>
+
+    <div class="actions">
+      <button mat-flat-button color="primary" (click)="downloadResult()" [disabled]="!result()">
+        <mat-icon>download</mat-icon>
+        Скачать WebP
+      </button>
+      <button mat-button color="warn" (click)="clear()">
+        <mat-icon>delete</mat-icon>
+        Очистить
+      </button>
+    </div>
+  </div>
+
+  <mat-card class="previews" *ngIf="originalFile()">
+    <div class="preview">
+      <h2>Оригинал</h2>
+      <div class="image-frame">
+        <div class="checkerboard"></div>
+        <img *ngIf="originalUrl()" [src]="originalUrl()" alt="Оригинал">
+      </div>
+      <dl>
+        <div>
+          <dt>Размер</dt>
+          <dd>{{ originalSizeLabel() }}</dd>
+        </div>
+        <div *ngIf="originalDimensions() as dims">
+          <dt>Разрешение</dt>
+          <dd>{{ dims.width }} × {{ dims.height }} px</dd>
+        </div>
+      </dl>
+    </div>
+
+    <mat-divider vertical></mat-divider>
+
+    <div class="preview">
+      <h2>WebP</h2>
+      <div class="image-frame">
+        <div class="checkerboard"></div>
+        <img *ngIf="result() as res" [src]="res.previewUrl" alt="WebP результат">
+        <div class="spinner" *ngIf="processing()">
+          <mat-progress-spinner mode="indeterminate" diameter="48"></mat-progress-spinner>
+        </div>
+      </div>
+      <dl>
+        <div>
+          <dt>Размер</dt>
+          <dd>{{ resultSizeLabel() }}</dd>
+        </div>
+        <div>
+          <dt>Сжатие</dt>
+          <dd>{{ compressionRatio() }}</dd>
+        </div>
+        <div *ngIf="result() as res">
+          <dt>Время конверсии</dt>
+          <dd>{{ res.durationMs | number:'1.0-0' }} мс</dd>
+        </div>
+      </dl>
+      <p class="note" *ngIf="!result() && !processing()">
+        Выберите качество, чтобы получить WebP файл.
+      </p>
+    </div>
+  </mat-card>
+
+  <div class="error" *ngIf="error()">
+    <mat-icon>error_outline</mat-icon>
+    {{ error() }}
+  </div>
+</div>

--- a/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.ts
+++ b/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.ts
@@ -1,0 +1,303 @@
+import { CommonModule } from '@angular/common';
+import { Component, HostListener, OnDestroy, Signal, computed, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+interface ConversionResult {
+  previewUrl: string;
+  blob: Blob;
+  size: number;
+  durationMs: number;
+}
+
+@Component({
+  selector: 'app-png-to-webp',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatSliderModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './png-to-webp.component.html',
+  styleUrls: ['./png-to-webp.component.css']
+})
+export class PngToWebpComponent implements OnDestroy {
+  readonly quality = signal(0.92);
+  readonly processing = signal(false);
+  readonly originalFile = signal<File | null>(null);
+  readonly originalUrl = signal<string | null>(null);
+  readonly originalSize = signal<number>(0);
+  readonly originalDimensions = signal<{ width: number; height: number } | null>(null);
+  readonly result = signal<ConversionResult | null>(null);
+  readonly error = signal<string | null>(null);
+
+  private sourceImage: ImageBitmap | HTMLImageElement | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private lastObjectUrls: string[] = [];
+  private pendingQuality: number | null = null;
+
+  readonly originalSizeLabel: Signal<string> = computed(() => this.formatBytes(this.originalSize()));
+  readonly resultSizeLabel: Signal<string> = computed(() => {
+    const res = this.result();
+    return res ? this.formatBytes(res.size) : '—';
+  });
+
+  readonly compressionRatio: Signal<string> = computed(() => {
+    const original = this.originalSize();
+    const res = this.result();
+    if (!original || !res) return '—';
+    const ratio = original / res.size;
+    return ratio ? ratio.toFixed(2) + '×' : '—';
+  });
+
+  constructor(private snackBar: MatSnackBar) {}
+
+  @HostListener('window:paste', ['$event'])
+  async onPaste(event: ClipboardEvent): Promise<void> {
+    if (!event.clipboardData) return;
+    const file = Array.from(event.clipboardData.files).find(f => f.type === 'image/png' || f.type === 'image/x-png' || f.name.toLowerCase().endsWith('.png'));
+    if (file) {
+      event.preventDefault();
+      await this.handleFile(file);
+      this.snackBar.open('PNG получен из буфера обмена', '', { duration: 2000 });
+    }
+  }
+
+  async onFileInput(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length) {
+      await this.handleFile(input.files[0]);
+      input.value = '';
+    }
+  }
+
+  async onDrop(event: DragEvent): Promise<void> {
+    event.preventDefault();
+    if (event.dataTransfer?.files?.length) {
+      const file = Array.from(event.dataTransfer.files).find(f => this.isPngFile(f));
+      if (file) {
+        await this.handleFile(file);
+      } else {
+        this.snackBar.open('Перетащите PNG изображение', 'OK', { duration: 2500 });
+      }
+    }
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+  }
+
+  async handleFile(file: File): Promise<void> {
+    if (!this.isPngFile(file)) {
+      this.snackBar.open('Поддерживаются только PNG изображения', 'OK', { duration: 2500 });
+      return;
+    }
+
+    this.resetState();
+    this.processing.set(true);
+    this.error.set(null);
+
+    try {
+      this.originalFile.set(file);
+      this.originalSize.set(file.size);
+      const originalUrl = URL.createObjectURL(file);
+      this.registerObjectUrl(originalUrl);
+      this.originalUrl.set(originalUrl);
+
+      this.sourceImage = await this.loadImage(file);
+      const dimensions = this.getImageDimensions(this.sourceImage);
+      this.originalDimensions.set(dimensions);
+
+      await this.convertToWebp();
+    } catch (err) {
+      console.error(err);
+      this.error.set('Не удалось преобразовать изображение. Проверьте поддержку WebP в браузере.');
+    } finally {
+      this.processing.set(false);
+    }
+  }
+
+  async onQualityChange(value: number): Promise<void> {
+    this.quality.set(value);
+    if (!this.originalFile()) {
+      return;
+    }
+    if (this.processing()) {
+      this.pendingQuality = value;
+      return;
+    }
+    this.processing.set(true);
+    try {
+      await this.convertToWebp();
+    } catch (err) {
+      console.error(err);
+      this.error.set('Не удалось обновить WebP. Попробуйте другое качество.');
+    } finally {
+      this.processing.set(false);
+      const nextQuality = this.pendingQuality;
+      this.pendingQuality = null;
+      if (nextQuality !== null && nextQuality !== value) {
+        await this.onQualityChange(nextQuality);
+      }
+    }
+  }
+
+  async onSliderInput(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const value = input.valueAsNumber;
+    if (Number.isNaN(value)) {
+      return;
+    }
+    await this.onQualityChange(value);
+  }
+
+  downloadResult(): void {
+    const res = this.result();
+    const original = this.originalFile();
+    if (!res || !original) return;
+
+    const link = document.createElement('a');
+    const suggestedName = original.name.replace(/\.png$/i, '') + `.webp`;
+    link.href = res.previewUrl;
+    link.download = suggestedName;
+    link.click();
+  }
+
+  clear(): void {
+    this.resetState();
+  }
+
+  ngOnDestroy(): void {
+    this.cleanupObjectUrls();
+    if (this.sourceImage && 'close' in this.sourceImage) {
+      try {
+        (this.sourceImage as ImageBitmap).close();
+      } catch { /* noop */ }
+    }
+  }
+
+  private async convertToWebp(): Promise<void> {
+    if (!this.sourceImage) return;
+
+    const quality = this.quality();
+    const canvas = this.canvas ?? document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+      throw new Error('Canvas недоступен');
+    }
+
+    const { width, height } = this.getImageDimensions(this.sourceImage);
+    if (!width || !height) {
+      throw new Error('Невозможно определить размеры изображения');
+    }
+
+    canvas.width = width;
+    canvas.height = height;
+    ctx.clearRect(0, 0, width, height);
+    ctx.drawImage(this.sourceImage, 0, 0, width, height);
+    this.canvas = canvas;
+
+    const start = performance.now();
+    const blob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/webp', quality));
+    const durationMs = performance.now() - start;
+
+    if (!blob) {
+      throw new Error('WebP не поддерживается');
+    }
+
+    this.cleanupResultUrl();
+    const previewUrl = URL.createObjectURL(blob);
+    this.registerObjectUrl(previewUrl);
+    this.result.set({
+      blob,
+      previewUrl,
+      size: blob.size,
+      durationMs,
+    });
+    this.error.set(null);
+  }
+
+  private async loadImage(file: File): Promise<ImageBitmap | HTMLImageElement> {
+    if (typeof window !== 'undefined' && 'createImageBitmap' in window) {
+      try {
+        return await createImageBitmap(file);
+      } catch (error) {
+        console.warn('createImageBitmap error, falling back to HTMLImageElement', error);
+      }
+    }
+
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject('Не удалось загрузить изображение');
+      img.src = URL.createObjectURL(file);
+      this.registerObjectUrl(img.src);
+    });
+  }
+
+  private getImageDimensions(source: ImageBitmap | HTMLImageElement): { width: number; height: number } {
+    return { width: source.width, height: source.height };
+  }
+
+  private isPngFile(file: File): boolean {
+    return file.type === 'image/png' || file.type === 'image/x-png' || file.name.toLowerCase().endsWith('.png');
+  }
+
+  private formatBytes(bytes: number): string {
+    if (!bytes) return '0 Б';
+    const units = ['Б', 'КБ', 'МБ', 'ГБ'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const size = bytes / Math.pow(1024, exponent);
+    return `${size.toFixed(size >= 100 ? 0 : size >= 10 ? 1 : 2)} ${units[exponent]}`;
+  }
+
+  private resetState(): void {
+    this.cleanupResultUrl();
+    this.cleanupObjectUrls();
+    this.error.set(null);
+    this.result.set(null);
+    this.originalFile.set(null);
+    this.originalUrl.set(null);
+    this.originalDimensions.set(null);
+    this.originalSize.set(0);
+    this.canvas = null;
+    this.pendingQuality = null;
+    if (this.sourceImage && 'close' in this.sourceImage) {
+      try {
+        (this.sourceImage as ImageBitmap).close();
+      } catch { /* noop */ }
+    }
+    this.sourceImage = null;
+  }
+
+  private registerObjectUrl(url: string | null): void {
+    if (!url) return;
+    this.lastObjectUrls.push(url);
+  }
+
+  private cleanupResultUrl(): void {
+    const res = this.result();
+    if (res) {
+      URL.revokeObjectURL(res.previewUrl);
+      this.lastObjectUrls = this.lastObjectUrls.filter(url => url !== res.previewUrl);
+    }
+  }
+
+  private cleanupObjectUrls(): void {
+    this.lastObjectUrls.forEach(url => URL.revokeObjectURL(url));
+    this.lastObjectUrls = [];
+  }
+}

--- a/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
+++ b/Angular/youtube-downloader/src/app/side-menu/side-menu.component.html
@@ -21,6 +21,10 @@
       <mat-icon matListItemIcon>sync_alt</mat-icon>
       <span matListItemTitle>Конвертер Markdown </span>
     </a>
+    <a mat-list-item (click)="navigate('/png-to-webp')">
+      <mat-icon matListItemIcon>image</mat-icon>
+      <span matListItemTitle>PNG → WebP</span>
+    </a>
     
     <a mat-list-item (click)="navigate('/')">
       <mat-icon matListItemIcon>info</mat-icon>
@@ -68,7 +72,11 @@
     <a mat-list-item (click)="navigate('/markdown-converter')">
       <mat-icon matListItemIcon>sync_alt</mat-icon>
       <span matListItemTitle>Конвертер Markdown</span>
-    </a>  
+    </a>
+    <a mat-list-item (click)="navigate('/png-to-webp')">
+      <mat-icon matListItemIcon>image</mat-icon>
+      <span matListItemTitle>PNG → WebP</span>
+    </a>
     <a mat-list-item (click)="navigate('/blog')">
       <mat-icon matListItemIcon>article</mat-icon>
       <span matListItemTitle>Блоги</span>

--- a/Angular/youtube-downloader/src/main.ts
+++ b/Angular/youtube-downloader/src/main.ts
@@ -38,6 +38,7 @@ import { About1Component } from './app/about1/about1.component';
 import { About2Component } from './app/about2/about2.component';
 import { About3Component } from './app/about3/about3.component';
 import { AdminUsersComponent } from './app/admin-users/admin-users.component';
+import { PngToWebpComponent } from './app/png-to-webp/png-to-webp.component';
 
 
 
@@ -120,6 +121,7 @@ const routes: Routes = [
   },
   { path: 'markdown-converter/:id', component: MarkdownConverterComponent },
   { path: 'markdown-converter', component: MarkdownConverterComponent },
+  { path: 'png-to-webp', component: PngToWebpComponent },
   {
     path: 'edit/:id',
     component: EditorPageComponent,


### PR DESCRIPTION
## Summary
- add a standalone PNG→WebP converter component that works fully in the browser, including drag-and-drop, clipboard paste, quality control, previews, and downloads
- register the new converter route and expose it from the application side menu for quick access
- style the converter with a checkerboard preview background to highlight alpha transparency and conversion details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0c381e2e08331997b7c3d1a5c3ca4