### PR TITLE
Align recognition hero title beside logo

### DIFF
--- a/Angular/youtube-downloader/src/app/app-recognition-control/recognition-control.component.css
+++ b/Angular/youtube-downloader/src/app/app-recognition-control/recognition-control.component.css
@@ -34,16 +34,29 @@ section {
   gap: 24px;
 }
 
+.hero-brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .hero-logo {
   max-width: 120px;
   width: 100%;
   filter: drop-shadow(0 12px 24px #eef2ff93);
 }
 
-.hero-text h1 {
+.hero-title {
   font-size: 3rem;
   line-height: 1.15;
   color: #0f172a;
+  font-weight: 700;
+}
+
+.hero-tagline {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  color: #1f2937;
   margin: 0;
 }
 

--- a/Angular/youtube-downloader/src/app/app-recognition-control/recognition-control.component.html
+++ b/Angular/youtube-downloader/src/app/app-recognition-control/recognition-control.component.html
@@ -2,10 +2,13 @@
   <main class="page-content">
     <section class="hero">
       <div class="hero-text">
-        <img class="hero-logo" src="assets/logo.webp" alt="Логотип YouScriptor" />
-        <h1>YouScriptor - Ваш личный учёный писарь</h1>
+        <div class="hero-brand">
+          <img class="hero-logo" src="assets/logo.webp" alt="Логотип YouScriptor" />
+          <span class="hero-title">YouScriptor</span>
+        </div>
+        <p class="hero-tagline">Ваш личный учёный писарь</p>
         <p class="hero-lead">Создавайте профессиональные конспекты и отчёты из видео автоматически</p>
-        
+
         <div >
           <app-yandex-ad></app-yandex-ad>
         </div>


### PR DESCRIPTION
## Summary
- align the YouScriptor brand name next to the hero logo on the recognition page
- move the "Ваш личный учёный писарь" tagline onto its own line with dedicated styling

## Testing
- CI=true npm start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68e0cac958348331ab8c13bc83e4cccd