### PR TITLE
Replace about page recognition block

### DIFF
--- a/Angular/youtube-downloader/src/app/about3/about3.component.css
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.css
@@ -203,71 +203,100 @@ section {
   box-shadow: 0 12px 24px rgba(10, 31, 68, 0.12);
 }
 
-.landing-search {
+.recognition-block {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 116, 144, 0.12));
   border-radius: 40px;
   padding: 56px 64px;
   box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
 }
 
-.landing-search-inner {
+.recognition-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 48px;
-  align-items: start;
+  align-items: center;
 }
 
-.landing-search-text h2 {
-  font-size: 2.4rem;
-  margin-bottom: 20px;
-  color: #0f172a;
+.recognition-text {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
-.landing-search-text p {
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: #1f2937;
-  margin-bottom: 24px;
-}
-
-.landing-search-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
+.recognition-brand {
+  display: flex;
+  align-items: center;
   gap: 16px;
 }
 
-.landing-search-list li {
-  background: rgba(255, 255, 255, 0.82);
-  border-radius: 16px;
-  padding: 14px 18px;
-  font-weight: 500;
-  color: #0f172a;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+.recognition-logo {
+  max-width: 120px;
+  width: 100%;
+  filter: drop-shadow(0 12px 24px rgba(238, 242, 255, 0.58));
 }
 
-.landing-search-panel {
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 28px;
-  padding: 32px;
-  display: grid;
-  gap: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
+.recognition-title {
+  font-size: 4rem;
+  line-height: 1.15;
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.recognition-tagline {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  color: #1f2937;
+  margin: 0;
+}
+
+.recognition-lead {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: #334155;
+  margin: 0;
+}
+
+.recognition-ad {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 24px;
+  padding: 20px;
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
 }
 
-.landing-search-form {
+.recognition-card {
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 32px;
+  padding: 36px;
+  display: grid;
+  gap: 20px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+}
+
+.recognition-card h2 {
+  font-size: 2rem;
+  color: #0b1f33;
+  margin: 0;
+}
+
+.recognition-card-lead {
+  font-size: 1rem;
+  color: #475569;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.recognition-form {
   display: grid;
   gap: 12px;
 }
 
-.landing-search-label {
+.recognition-label {
   font-weight: 600;
   color: #0f172a;
 }
 
-.landing-search-field {
+.recognition-field {
   display: flex;
   gap: 12px;
   align-items: center;
@@ -275,9 +304,10 @@ section {
   border-radius: 20px;
   border: 1px solid rgba(148, 163, 184, 0.32);
   padding: 10px 12px 10px 20px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
-.landing-search-field input {
+.recognition-field input {
   flex: 1;
   border: none;
   background: transparent;
@@ -286,59 +316,112 @@ section {
   outline: none;
 }
 
-.landing-search-field input::placeholder {
+.recognition-field input::placeholder {
   color: #94a3b8;
 }
 
-.landing-search-field:focus-within {
+.recognition-field:focus-within {
   border-color: rgba(59, 130, 246, 0.65);
   box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
 }
 
-.landing-search-field .btn {
+.recognition-field .btn {
   flex-shrink: 0;
   white-space: nowrap;
 }
 
-.landing-search-hint {
+.recognition-hint {
   font-size: 0.95rem;
   color: #334155;
+  line-height: 1.6;
 }
 
-.landing-search-hint a {
+.recognition-hint a {
   color: #1d4ed8;
   text-decoration: none;
   font-weight: 600;
 }
 
-.landing-search-hint a:hover {
+.recognition-hint a:hover {
   text-decoration: underline;
 }
 
-.landing-search-error {
+.recognition-error {
   color: #dc2626;
   font-weight: 500;
 }
 
+.recognition-instructions {
+  display: grid;
+}
+
+.recognition-instructions .instruction-card {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 116, 144, 0.12));
+  border-radius: 40px;
+  padding: 56px 64px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+  display: grid;
+  gap: 32px;
+}
+
+.instruction-intro {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: #1f2937;
+  margin: 0;
+}
+
+.instruction-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 18px;
+}
+
+.instruction-list li {
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 20px;
+  padding: 18px 22px;
+  font-weight: 500;
+  color: #0f172a;
+  line-height: 1.6;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+}
+
+.instruction-list a {
+  color: #1d4ed8;
+  text-decoration: none;
+}
+
+.instruction-list a:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 1024px) {
-  .landing-search-inner {
+  .recognition-grid {
     grid-template-columns: 1fr;
   }
 
-  .landing-search {
+  .recognition-block,
+  .recognition-instructions .instruction-card {
     padding: 40px 28px;
   }
 }
 
 @media (max-width: 640px) {
-  .landing-search-field {
+  .recognition-field {
     flex-direction: column;
     align-items: stretch;
     padding: 16px;
   }
 
-  .landing-search-field .btn {
+  .recognition-field .btn {
     width: 100%;
+  }
+
+  .recognition-title {
+    font-size: 2.8rem;
   }
 }
 

--- a/Angular/youtube-downloader/src/app/about3/about3.component.html
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.html
@@ -31,25 +31,34 @@
       </div>
     </section>
 
-    <section class="landing-search">
-      <div class="landing-search-inner">
-        <div class="landing-search-text">
-          <h2>Расшифровывайте YouTube за пару минут</h2>
-          <p>
-            Запустите задачу прямо со страницы «О сервисе»: укажите ссылку или идентификатор ролика, а мы подготовим
-            аккуратно оформленный документ с тайм-кодами, списками и цитатами.
+    <section class="recognition-block">
+      <div class="recognition-grid">
+        <div class="recognition-text">
+          <div class="recognition-brand">
+            <img class="recognition-logo" src="assets/logo.webp" alt="Логотип YouScriptor" />
+            <span class="recognition-title">YouScriptor</span>
+          </div>
+          <p class="recognition-tagline">Конспектируем за вас — как личный учёный писарь.</p>
+          <p class="recognition-lead">
+            Автоматически создавайте профессиональные конспекты и отчёты из YouTube-видео: с расшифровкой,
+            форматированием, разметкой, формулами и подсветкой кода.
           </p>
-          <ul class="landing-search-list">
-            <li *ngFor="let item of recognitionGuide">{{ item }}</li>
-          </ul>
+
+          <div class="recognition-ad">
+            <app-yandex-ad></app-yandex-ad>
+          </div>
         </div>
 
-        <div class="landing-search-panel">
-          <form class="landing-search-form" (ngSubmit)="startRecognition()">
-            <label class="landing-search-label" for="landing-search-input">Ссылка или идентификатор YouTube</label>
-            <div class="landing-search-field">
+        <div class="recognition-card">
+          <h2>Запустите новую расшифровку</h2>
+          <p class="recognition-card-lead">
+            Введите идентификатор или ссылку на YouTube, чтобы получить готовый документ.
+          </p>
+          <form class="recognition-form" (ngSubmit)="startRecognition()">
+            <label class="recognition-label" for="recognition-input">Введите идентификатор или ссылку YouTube</label>
+            <div class="recognition-field">
               <input
-                id="landing-search-input"
+                id="recognition-input"
                 name="youtubeQuery"
                 type="text"
                 [(ngModel)]="searchValue"
@@ -58,19 +67,41 @@
                 [disabled]="isStarting"
               />
               <button class="btn btn-primary" type="submit" [disabled]="isStarting || !searchValue.trim()">
-                <span *ngIf="!isStarting">Начать транскрибацию</span>
+                <span *ngIf="!isStarting">Запустить</span>
                 <span *ngIf="isStarting">Запускаем…</span>
               </button>
             </div>
           </form>
-
-          <p class="landing-search-hint">
-            Результат появится в разделе <a [routerLink]="['/Scriptorium']">Scriptorium</a>, а прогресс можно будет
-            отслеживать позднее.
+          <p class="recognition-hint">
+            Готовый результат ищите в <b><a [routerLink]="['/Scriptorium']">Scriptorium</a></b>, либо повторите тот же
+            запрос — результат сохраняется.
           </p>
-
-          <p class="landing-search-error" *ngIf="startError">{{ startError }}</p>
+          <p class="recognition-error" *ngIf="startError">{{ startError }}</p>
         </div>
+      </div>
+    </section>
+
+    <section class="recognition-instructions">
+      <div class="instruction-card">
+        <h2>Как это работает</h2>
+        <p class="instruction-intro">Создавайте профессиональные конспекты и отчёты из видео автоматически.</p>
+        <ol class="instruction-list">
+          <li>Укажите ссылку на YouTube-видео с субтитрами.</li>
+          <li>
+            Готовый результат ищите в <b><a [routerLink]="['/Scriptorium']">Scriptorium</a></b>, либо повторите тот же
+            запрос — результат сохраняется.
+          </li>
+          <li>
+            Получите транскрипцию в виде аккуратно отформатированного документа. Готовое решение для учёбы, работы и
+            технической документации.
+          </li>
+          <li>Сохраняется структура: заголовки, списки, цитаты, формулы (LaTeX), программный код с подсветкой.</li>
+          <li>Экспортируйте в PDF, Word, HTML или Markdown; при необходимости сохраните субтитры в формате <strong>.srt</strong>.</li>
+          <li>
+            Можно также <b><a [routerLink]="['/down']">скачать YouTube-видео</a></b> с нужными дорожками (качество/контейнер/кодек/аудио и
+            субтитры).
+          </li>
+        </ol>
       </div>
     </section>
 

--- a/Angular/youtube-downloader/src/app/about3/about3.component.ts
+++ b/Angular/youtube-downloader/src/app/about3/about3.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { SubtitleService } from '../services/subtitle.service';
+import { YandexAdComponent } from '../ydx-ad/yandex-ad.component';
 
 interface WorkflowStep {
   readonly title: string;
@@ -53,7 +54,7 @@ interface FaqItem {
 @Component({
   selector: 'app-about3',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterModule, MatExpansionModule],
+  imports: [CommonModule, FormsModule, RouterModule, MatExpansionModule, YandexAdComponent],
   templateUrl: './about3.component.html',
   styleUrls: ['./about3.component.css'],
 })
@@ -69,13 +70,6 @@ export class About3Component {
   searchValue = '';
   isStarting = false;
   startError: string | null = null;
-
-  readonly recognitionGuide: readonly string[] = [
-    'Укажите ссылку или идентификатор YouTube-видео с доступными субтитрами.',
-    'Мы создадим задачу и автоматически сохраним прогресс — вы сможете вернуться к ней позже.',
-    'Готовую расшифровку найдёте в разделе «Scriptorium» или повторите тот же запрос.',
-    'Экспортируйте результат в DOCX, PDF, HTML или Markdown и загрузите субтитры в формате .srt.',
-  ];
 
   readonly trustedCompanies: readonly TrustedCompany[] = [
     {

--- a/Angular/youtube-downloader/src/app/ydx-ad/yandex-ad.component.ts
+++ b/Angular/youtube-downloader/src/app/ydx-ad/yandex-ad.component.ts
@@ -5,6 +5,7 @@ declare var Ya: any;
 
 @Component({
   selector: 'app-yandex-ad',
+  standalone: true,
   template: `
     <!-- Yandex.RTB R-A-14227572-1 -->
     <div id="yandex_rtb_R-A-14227572-1"></div>


### PR DESCRIPTION
## Summary
- replace the "Расшифровывайте YouTube за пару минут" section on the about page with the updated recognition hero and instructions from /recognition
- add corresponding styling updates and remove the unused recognition guide data
- mark the Yandex ad component as standalone so it can be reused in the new block

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0d582c4cc833183e43e2ae5d6790b