### PR TITLE
Enhance image editor cropping workflow

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
@@ -53,6 +53,16 @@
           <mat-icon>crop</mat-icon>
           {{ isCropping() ? 'Выделите область' : 'Выбрать область' }}
         </button>
+        <button
+          *ngIf="isCropping()"
+          mat-stroked-button
+          color="primary"
+          type="button"
+          (click)="applyCropSelection()"
+        >
+          <mat-icon>done</mat-icon>
+          Завершить обрезку
+        </button>
         <div class="crop-info">{{ cropInfo() }}</div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add state management so crop mode no longer resets pan and provides an explicit apply action
- render visual crop handles and allow moving or resizing selections via pointer hit-testing

## Testing
- CI=1 npm start -- --host 0.0.0.0 --port 4200

------
https://chatgpt.com/codex/tasks/task_e_68e0fc2f8f0483318bb0223d5b3e1f8d