### PR TITLE
Add mouse wheel zoom handling to image editor dialog

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
@@ -9,7 +9,7 @@
       <h3>Масштаб</h3>
       <mat-button-toggle-group [value]="zoom()" (change)="onZoomChange($event)" name="zoom" [multiple]="false">
         <mat-button-toggle *ngFor="let option of zoomOptions" [value]="option">
-          {{ option === 1 ? '1:1' : option === 0.5 ? '1:2' : '1:4' }}
+          {{ option === 1 ? '1:1' : option === 2 ? '1:2' : '1:4' }}
         </mat-button-toggle>
       </mat-button-toggle-group>
     </section>

--- a/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.html
@@ -73,7 +73,6 @@
     <mat-divider vertical></mat-divider>
 
     <div class="preview">
-      <h2>{{ hasEdits() ? 'После редактирования' : 'Текущее изображение' }}</h2>
       <div class="image-frame">
         <div class="checkerboard"></div>
         <img *ngIf="workingPreviewUrl() as currentUrl" [src]="currentUrl" alt="Текущее изображение">


### PR DESCRIPTION
## Summary
- add mouse wheel zoom support to the image editor dialog and listen to wheel events
- adjust zoom presets so 1:2 and 1:4 enlarge the image and update button labels
- remove the redundant heading from the intermediate PNG to WebP preview column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e13cd38a6883319a333a52fd18fdeb