### PR TITLE
Limit image editor zoom range

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
@@ -8,8 +8,11 @@
     <section>
       <h3>Масштаб</h3>
       <mat-button-toggle-group [value]="zoom()" (change)="onZoomChange($event)" name="zoom" [multiple]="false">
-        <mat-button-toggle *ngFor="let option of zoomOptions" [value]="option">
-          {{ option === 1 ? '1:1' : option === 2 ? '1:2' : '1:4' }}
+        <mat-button-toggle
+          *ngFor="let option of zoomOptions(); trackBy: trackZoomOption"
+          [value]="option"
+        >
+          {{ formatZoomLabel(option) }}
         </mat-button-toggle>
       </mat-button-toggle-group>
     </section>


### PR DESCRIPTION
## Summary
- clamp image editor zoom to stay between the fit-to-screen scale and 8× magnification
- allow the zoom wheel to use smooth scaling while dynamically surfacing custom zoom values in the toggle list
- adjust zoom label rendering and pan resets to match the new behaviour

## Testing
- CI=1 npm run build -- --configuration development

------
https://chatgpt.com/codex/tasks/task_e_68e13fac1a288331b2a2ddd9062649fb