### PR TITLE
Normalize Telegram command parsing

### DIFF
--- a/services/Telegram/TelegramTranscriptionBot.cs
+++ b/services/Telegram/TelegramTranscriptionBot.cs
@@ -206,7 +206,9 @@ namespace YandexSpeech.services.Telegram
                 return;
             }
 
-            var command = text.Split(' ', '\t', '\n')[0];
+            var rawCommand = text.Split(new[] { ' ', '\t', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()
+                              ?? text;
+            var command = rawCommand.Split('@')[0];
             switch (command)
             {
                 case "/start":


### PR DESCRIPTION
## Summary
- normalize incoming Telegram commands by stripping bot usernames before handling
- ensure commands like /start@YourBot are routed to their base handler

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e247a64e2083318b828143ffa0306c