### PR TITLE
Handle Telegram webhook updates without blocking requests

### DIFF
--- a/Controllers/TelegramWebhookController.cs
+++ b/Controllers/TelegramWebhookController.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -31,7 +29,7 @@ namespace YandexSpeech.Controllers
         }
 
         [HttpPost("webhook")]
-        public async Task<IActionResult> HandleUpdate([FromBody] Update? update, CancellationToken cancellationToken)
+        public IActionResult HandleUpdate([FromBody] Update? update)
         {
             var options = _optionsMonitor.CurrentValue;
             if (!options.Enabled)
@@ -57,7 +55,7 @@ namespace YandexSpeech.Controllers
                 return Ok();
             }
 
-            await _bot.ProcessUpdateAsync(update, cancellationToken).ConfigureAwait(false);
+            _bot.EnqueueWebhookUpdate(update);
             return Ok();
         }
     }


### PR DESCRIPTION
## Summary
- capture the background service stopping token for reuse when processing webhook updates
- enqueue webhook updates for asynchronous processing instead of awaiting them inside the HTTP handler
- adjust the webhook controller to return immediately once the update is queued

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e25ba35afc83319be69bedc1222cba