### PR TITLE
Add OpenAI post-processing to Telegram bot

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -39,7 +39,11 @@
     "UseLongPolling": false,
     "MessageChunkLimit": 3900,
     "LogFilePath": "c:/log/telegram_messages.log",
-    "FfmpegExecutable": "ffmpeg"
+    "FfmpegExecutable": "ffmpeg",
+    "EnableOpenAiPostProcessing": false,
+    "OpenAiModel": "gpt-4.1",
+    "OpenAiApiKey": "",
+    "OpenAiSummaryWordThreshold": 70
   },
 
   "EventBus": {

--- a/services/Options/TelegramBotOptions.cs
+++ b/services/Options/TelegramBotOptions.cs
@@ -22,6 +22,14 @@ namespace YandexSpeech.services.Options
 
         public string? FfmpegExecutable { get; set; }
 
+        public bool EnableOpenAiPostProcessing { get; set; }
+
+        public string? OpenAiModel { get; set; }
+
+        public string? OpenAiApiKey { get; set; }
+
+        public int OpenAiSummaryWordThreshold { get; set; } = 70;
+
         public void Validate()
         {
             if (!Enabled)


### PR DESCRIPTION
## Summary
- add optional OpenAI post-processing for Telegram transcripts with polished text, summaries, and error handling
- extend Telegram bot options and configuration to manage OpenAI model, API key, and summary threshold values

## Testing
- dotnet build *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e25df45bfc8331bafe4a4170f091bd