### PR TITLE
Restyle toolbar to match landing page branding

### DIFF
--- a/Angular/youtube-downloader/src/app/app.component.css
+++ b/Angular/youtube-downloader/src/app/app.component.css
@@ -20,15 +20,97 @@ html, body {
   background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
 }
 
+
 .app-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  transition: transform .3s ease;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding-inline: clamp(1rem, 4vw, 2.5rem);
+  height: var(--app-header-height, 64px);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(243, 248, 255, 0.9));
+  color: #0b172a;
+  box-shadow: 0 24px 50px -32px rgba(16, 31, 68, 0.65);
+  border-bottom: 1px solid rgba(34, 76, 255, 0.12);
+  backdrop-filter: blur(14px);
+  transition: transform .3s ease, background .3s ease;
 }
 
 .app-header.hidden {
   transform: translateY(-100%);
+}
+
+.app-header .mat-mdc-icon-button {
+  color: #1a2c52;
+  transition: background-color .2s ease, color .2s ease;
+}
+
+.app-header .mat-mdc-icon-button:hover,
+.app-header .mat-mdc-icon-button:focus-visible {
+  background-color: rgba(34, 76, 255, 0.08);
+  color: #0f8dff;
+}
+
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.app-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: radial-gradient(circle at 50% 45%, rgba(34, 76, 255, 0.12), transparent 60%);
+  padding: 6px;
+  box-shadow: 0 18px 35px -25px rgba(11, 23, 42, 0.8);
+  object-fit: contain;
+}
+
+.app-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+}
+
+#hAI {
+  color: #1b52ff;
+}
+
+#hDot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  display: inline-block;
+  background: linear-gradient(135deg, #224cff, #0f8dff);
+  box-shadow: 0 8px 18px -8px rgba(34, 76, 255, 0.6);
+}
+
+#hPodcaster {
+  color: #0b172a;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    gap: 1rem;
+    padding-inline: 1rem;
+  }
+
+  .app-logo {
+    width: 32px;
+    height: 32px;
+    padding: 4px;
+  }
+
+  .app-title {
+    font-size: 1rem;
+    gap: 0.4rem;
+  }
 }
 
 /* убраны все локальные overflow-y из старых .scroll-host и внутренних контейнеров */

--- a/Angular/youtube-downloader/src/app/app.component.html
+++ b/Angular/youtube-downloader/src/app/app.component.html
@@ -12,14 +12,22 @@
     <mat-toolbar
       class="app-header"
       [class.hidden]="hideToolbar"
-      color="primary"
     >
       <button mat-icon-button (click)="drawer.toggle()">
         <mat-icon>menu</mat-icon>
       </button>
-      <span class="app-title">
-        <span id="hAI">You</span><span id="hDot"></span><span id="hPodcaster">Scriptor</span>
-      </span>
+      <div class="app-brand">
+        <img
+          class="app-logo"
+          src="assets/logo.webp"
+          width="40"
+          height="40"
+          alt="YouScriptor логотип"
+        />
+        <span class="app-title">
+          <span id="hAI">You</span><span id="hDot"></span><span id="hPodcaster">Scriptor</span>
+        </span>
+      </div>
     </mat-toolbar>
 
     <router-outlet></router-outlet>


### PR DESCRIPTION
## Summary
- align the application header with landing page colors, shadows, and typography
- add the YouScriptor logo ahead of the brand name inside the toolbar
- improve button hover states and responsive spacing for the updated menu layout

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e364e6a6d0833197970497e6a275d4