### PR TITLE
Ensure HTTPS redirection is always enabled

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -239,6 +239,13 @@ await MarkIncompleteOpenAiTasksAsErroredAsync(app.Services);
 
 // (пропущена инициализация ролей и IndexNow для краткости)
 
+app.UseHttpsRedirection();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+}
+
 app.UseRouting();
 app.UseCors("AllowAngularApp");
 app.UseAuthentication();
@@ -248,7 +255,6 @@ app.UseEndpoints(endpoints => endpoints.MapControllers());
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseHttpsRedirection();
     app.UseSpa(spa =>
     {
         spa.Options.SourcePath = "ClientApp";


### PR DESCRIPTION
## Summary
- always enable ASP.NET Core HTTPS redirection so Telegram webhooks are reachable over TLS
- enable HSTS in non-development environments to advertise strict HTTPS usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49a991f248331839074b305d6e830