### PR TITLE
Handle AMR audio documents

### DIFF
--- a/services/Telegram/TelegramTranscriptionBot.cs
+++ b/services/Telegram/TelegramTranscriptionBot.cs
@@ -61,6 +61,7 @@ namespace YandexSpeech.services.Telegram
         private static readonly HashSet<string> AudioFileExtensions = new(StringComparer.OrdinalIgnoreCase)
         {
             ".aac",
+            ".amr",
             ".flac",
             ".m4a",
             ".mp3",
@@ -1186,6 +1187,11 @@ namespace YandexSpeech.services.Telegram
                 if (normalized.Contains("aac"))
                 {
                     return ".aac";
+                }
+
+                if (normalized.Contains("amr"))
+                {
+                    return ".amr";
                 }
 
                 if (normalized.Contains("flac"))


### PR DESCRIPTION
## Summary
- add the AMR extension to the audio document whitelist so Telegram forwards using application/octet-stream are picked up
- map AMR mime types to the .amr default extension when building filenames

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e49a3f8c948331bf24b6b5dad23931