### PR TITLE
Adapt Telegram bot and RabbitMQ integration to latest SDK APIs

### DIFF
--- a/services/Telegram/TelegramTranscriptionBot.cs
+++ b/services/Telegram/TelegramTranscriptionBot.cs
@@ -88,7 +88,7 @@ namespace YandexSpeech.services.Telegram
 
         private CancellationToken _stoppingToken = CancellationToken.None;
 
-        private ITelegramBotClient? _botClient;
+        private TelegramBotClient? _botClient;
 
         private readonly record struct OpenAiPostProcessingResult(
             string Text,

--- a/services/Whisper/FasterWhisperQueueClient.cs
+++ b/services/Whisper/FasterWhisperQueueClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -20,7 +21,7 @@ namespace YandexSpeech.services.Whisper
         private readonly EventBusOptions _options;
         private readonly ConcurrentDictionary<string, TaskCompletionSource<FasterWhisperQueueResponse>> _pending = new();
         private readonly IConnection _connection;
-        private readonly IModel _channel;
+        private readonly IChannel _channel;
         private readonly object _channelLock = new();
 
         public FasterWhisperQueueClient(IOptions<EventBusOptions> options, ILogger<FasterWhisperQueueClient> logger)
@@ -36,21 +37,21 @@ namespace YandexSpeech.services.Whisper
                 HostName = access.Host,
                 UserName = access.UserName,
                 Password = access.Password,
-                DispatchConsumersAsync = true,
                 AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(5)
             };
 
             var clientName = string.IsNullOrWhiteSpace(_options.Broker) ? "faster-whisper" : _options.Broker;
-            _connection = factory.CreateConnection(clientName);
-            _channel = _connection.CreateModel();
+            TrySetClientProvidedName(factory, clientName);
+            _connection = CreateConnection(factory);
+            _channel = CreateChannel(_connection);
 
             _channel.QueueDeclare(queue: _options.CommandQueueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
             _channel.QueueDeclare(queue: _options.QueueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
             _channel.BasicQos(0, 1, false);
 
-            var consumer = new AsyncEventingBasicConsumer(_channel);
-            consumer.Received += HandleResponseAsync;
+            var consumer = new EventingBasicConsumer(_channel);
+            consumer.Received += HandleResponse;
             _channel.BasicConsume(queue: _options.QueueName, autoAck: false, consumer: consumer);
 
             _logger.LogInformation("Initialized FasterWhisper RabbitMQ client. CommandQueue={CommandQueue}, ResponseQueue={ResponseQueue}",
@@ -64,6 +65,7 @@ namespace YandexSpeech.services.Whisper
 
             var correlationId = Guid.NewGuid().ToString("N");
             var body = JsonSerializer.SerializeToUtf8Bytes(request, JsonOptions);
+            var bodyMemory = new ReadOnlyMemory<byte>(body);
             var props = _channel.CreateBasicProperties();
             props.Persistent = true;
             props.CorrelationId = correlationId;
@@ -77,7 +79,7 @@ namespace YandexSpeech.services.Whisper
             {
                 lock (_channelLock)
                 {
-                    _channel.BasicPublish(exchange: string.Empty, routingKey: _options.CommandQueueName, mandatory: false, basicProperties: props, body: body);
+                    _channel.BasicPublish(exchange: string.Empty, routingKey: _options.CommandQueueName, mandatory: false, basicProperties: props, body: bodyMemory);
                 }
             }
             catch
@@ -95,7 +97,7 @@ namespace YandexSpeech.services.Whisper
             return await tcs.Task.ConfigureAwait(false);
         }
 
-        private Task HandleResponseAsync(object sender, BasicDeliverEventArgs args)
+        private void HandleResponse(object? sender, BasicDeliverEventArgs args)
         {
             TaskCompletionSource<FasterWhisperQueueResponse>? pending = null;
             string? correlationId = null;
@@ -125,17 +127,123 @@ namespace YandexSpeech.services.Whisper
                     _channel.BasicAck(args.DeliveryTag, false);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            try { _channel?.Close(); } catch { /* ignore */ }
-            try { _channel?.Dispose(); } catch { /* ignore */ }
-            try { _connection?.Close(); } catch { /* ignore */ }
-            try { _connection?.Dispose(); } catch { /* ignore */ }
-            return ValueTask.CompletedTask;
+            await DisposeSafelyAsync(_channel).ConfigureAwait(false);
+            await DisposeSafelyAsync(_connection).ConfigureAwait(false);
+        }
+
+        private static void TrySetClientProvidedName(ConnectionFactory factory, string clientName)
+        {
+            var property = typeof(ConnectionFactory).GetProperty("ClientProvidedName");
+            if (property is not null && property.CanWrite)
+            {
+                property.SetValue(factory, clientName);
+            }
+        }
+
+        private static IConnection CreateConnection(ConnectionFactory factory)
+        {
+            var nameProperty = typeof(ConnectionFactory).GetProperty("ClientProvidedName");
+            var clientName = nameProperty?.GetValue(factory) as string ?? string.Empty;
+
+            foreach (var method in typeof(ConnectionFactory).GetMethods().Where(m => m.Name is "CreateConnection" or "CreateConnectionAsync"))
+            {
+                var parameters = method.GetParameters();
+                var arguments = new object?[parameters.Length];
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var parameter = parameters[i];
+                    if (parameter.ParameterType == typeof(string))
+                    {
+                        arguments[i] = clientName;
+                    }
+                    else if (parameter.ParameterType == typeof(CancellationToken))
+                    {
+                        arguments[i] = CancellationToken.None;
+                    }
+                    else if (parameter.ParameterType == typeof(bool))
+                    {
+                        arguments[i] = true;
+                    }
+                    else if (parameter.HasDefaultValue)
+                    {
+                        arguments[i] = parameter.DefaultValue;
+                    }
+                    else
+                    {
+                        arguments[i] = null;
+                    }
+                }
+
+                var result = method.Invoke(factory, arguments);
+                switch (result)
+                {
+                    case IConnection connection:
+                        return connection;
+                    case Task<IConnection> task:
+                        return task.GetAwaiter().GetResult();
+                    case ValueTask<IConnection> valueTask:
+                        return valueTask.GetAwaiter().GetResult();
+                }
+            }
+
+            throw new NotSupportedException("RabbitMQ ConnectionFactory does not expose a supported CreateConnection method.");
+        }
+
+        private static IChannel CreateChannel(IConnection connection)
+        {
+            foreach (var method in connection.GetType().GetMethods().Where(m => m.Name is "CreateChannel" or "CreateModel"))
+            {
+                if (method.GetParameters().Length != 0)
+                {
+                    continue;
+                }
+
+                var result = method.Invoke(connection, Array.Empty<object?>());
+                switch (result)
+                {
+                    case IChannel channel:
+                        return channel;
+                    case Task<IChannel> task:
+                        return task.GetAwaiter().GetResult();
+                    case ValueTask<IChannel> valueTask:
+                        return valueTask.GetAwaiter().GetResult();
+                }
+            }
+
+            throw new NotSupportedException("RabbitMQ connection does not expose a supported channel creation method.");
+        }
+
+        private static async ValueTask DisposeSafelyAsync(object? disposable)
+        {
+            switch (disposable)
+            {
+                case null:
+                    return;
+                case IAsyncDisposable asyncDisposable:
+                    try
+                    {
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // ignore dispose exceptions
+                    }
+                    break;
+                case IDisposable syncDisposable:
+                    try
+                    {
+                        syncDisposable.Dispose();
+                    }
+                    catch
+                    {
+                        // ignore dispose exceptions
+                    }
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- restore Telegram.Bot 20.0.0 and RabbitMQ.Client 6.8.1 package references
- update the Telegram bot service to work directly with TelegramBotClient so modern client APIs are available
- refactor the FasterWhisper queue client to the new RabbitMQ channel APIs with reflective fallbacks for connection and disposal

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e49f01c5a4833197e36b7f2112208e