### PR TITLE
Adapt RabbitMQ and Telegram integrations to new client APIs

### DIFF
--- a/services/Telegram/TelegramBotClientExtensions.cs
+++ b/services/Telegram/TelegramBotClientExtensions.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Requests;
+
+namespace YandexSpeech.services.Telegram
+{
+    internal static class TelegramBotClientExtensions
+    {
+        private static readonly string[] CandidateMethodNames =
+        {
+            "MakeRequestAsync",
+            "MakeRequest",
+            "Send",
+            "SendAsync",
+            "Execute",
+            "ExecuteAsync",
+            "Call",
+            "CallAsync"
+        };
+
+        public static Task<TResponse> MakeRequestAsync<TResponse>(this ITelegramBotClient client, IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            if (client is null)
+                throw new ArgumentNullException(nameof(client));
+            if (request is null)
+                throw new ArgumentNullException(nameof(request));
+
+            var clientType = client.GetType();
+            foreach (var methodName in CandidateMethodNames)
+            {
+                foreach (var method in clientType.GetMethods().Where(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var targetMethod = method;
+                    if (method.IsGenericMethodDefinition)
+                    {
+                        try
+                        {
+                            targetMethod = method.MakeGenericMethod(typeof(TResponse));
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+                    }
+
+                    var parameters = targetMethod.GetParameters();
+                    object?[] arguments;
+                    if (parameters.Length == 1 && parameters[0].ParameterType.IsInstanceOfType(request))
+                    {
+                        arguments = new object?[] { request };
+                    }
+                    else if (parameters.Length == 2 && parameters[0].ParameterType.IsInstanceOfType(request) && parameters[1].ParameterType == typeof(CancellationToken))
+                    {
+                        arguments = new object?[] { request, cancellationToken };
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    var result = targetMethod.Invoke(client, arguments);
+                    if (result is null)
+                    {
+                        continue;
+                    }
+
+                    if (result is Task<TResponse> typedTask)
+                    {
+                        return typedTask;
+                    }
+
+                    if (result is Task task)
+                    {
+                        return ConvertTask<TResponse>(task, cancellationToken);
+                    }
+
+                    var resultType = result.GetType();
+                    if (resultType.FullName?.StartsWith("System.Threading.Tasks.ValueTask`1", StringComparison.Ordinal) == true)
+                    {
+                        var asTask = resultType.GetMethod("AsTask", Type.EmptyTypes);
+                        if (asTask?.Invoke(result, Array.Empty<object?>()) is Task<TResponse> valueTask)
+                        {
+                            return valueTask;
+                        }
+                    }
+
+                    if (result is ValueTask<TResponse> typedValueTask)
+                    {
+                        return typedValueTask.AsTask();
+                    }
+
+                    if (result is ValueTask valueTaskNoResult)
+                    {
+                        return valueTaskNoResult.AsTask().ContinueWith(_ => default(TResponse)!, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                    }
+                }
+            }
+
+            throw new InvalidOperationException("Unable to locate a compatible request execution method on the Telegram bot client instance.");
+        }
+
+        private static Task<TResponse> ConvertTask<TResponse>(Task task, CancellationToken cancellationToken)
+        {
+            if (task is Task<TResponse> typed)
+            {
+                return typed;
+            }
+
+            if (task.GetType().IsGenericType)
+            {
+                return task.ContinueWith(t =>
+                {
+                    if (t.GetType().IsGenericType)
+                    {
+                        var resultProperty = t.GetType().GetProperty("Result");
+                        if (resultProperty?.GetValue(t) is TResponse value)
+                        {
+                            return value;
+                        }
+                    }
+
+                    throw new InvalidOperationException("Telegram bot client returned a task with an unexpected result type.");
+                }, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }
+
+            return task.ContinueWith(_ => default(TResponse)!, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+    }
+}

--- a/services/Telegram/TelegramTranscriptionBot.cs
+++ b/services/Telegram/TelegramTranscriptionBot.cs
@@ -828,8 +828,9 @@ namespace YandexSpeech.services.Telegram
 
         private async Task SetWebhookAsync(string url, IEnumerable<UpdateType>? allowedUpdates, string? secretToken, CancellationToken cancellationToken)
         {
-            var request = new SetWebhookRequest(url)
+            var request = new SetWebhookRequest
             {
+                Url = url,
                 AllowedUpdates = allowedUpdates,
                 SecretToken = secretToken
             };
@@ -851,8 +852,10 @@ namespace YandexSpeech.services.Telegram
 
         private Task<Message> SendTextMessageAsync(ChatId chatId, string text, ReplyParameters? replyParameters, CancellationToken cancellationToken)
         {
-            var request = new SendMessageRequest(chatId, text)
+            var request = new SendMessageRequest
             {
+                ChatId = chatId,
+                Text = text,
                 ReplyParameters = replyParameters
             };
 
@@ -861,14 +864,20 @@ namespace YandexSpeech.services.Telegram
 
         private async Task SendChatActionAsync(ChatId chatId, ChatAction chatAction, CancellationToken cancellationToken)
         {
-            var request = new SendChatActionRequest(chatId, chatAction);
+            var request = new SendChatActionRequest
+            {
+                ChatId = chatId,
+                Action = chatAction
+            };
             await RequireClient().MakeRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         private Task<Message> SendDocumentAsync(ChatId chatId, InputFile document, string? caption, CancellationToken cancellationToken)
         {
-            var request = new SendDocumentRequest(chatId, document)
+            var request = new SendDocumentRequest
             {
+                ChatId = chatId,
+                Document = document,
                 Caption = caption
             };
 
@@ -877,19 +886,33 @@ namespace YandexSpeech.services.Telegram
 
         private Task<Message> EditMessageTextAsync(ChatId chatId, int messageId, string text, CancellationToken cancellationToken)
         {
-            var request = new EditMessageTextRequest(chatId, messageId, text);
+            var request = new EditMessageTextRequest
+            {
+                ChatId = chatId,
+                MessageId = messageId,
+                Text = text
+            };
             return RequireClient().MakeRequestAsync(request, cancellationToken);
         }
 
         private async Task DeleteMessageAsync(ChatId chatId, int messageId, CancellationToken cancellationToken)
         {
-            var request = new DeleteMessageRequest(chatId, messageId);
+            var request = new DeleteMessageRequest
+            {
+                ChatId = chatId,
+                MessageId = messageId
+            };
             await RequireClient().MakeRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         private Task<Telegram.Bot.Types.File> GetFileAsync(string fileId, CancellationToken cancellationToken)
         {
-            return RequireClient().MakeRequestAsync(new GetFileRequest(fileId), cancellationToken);
+            var request = new GetFileRequest
+            {
+                FileId = fileId
+            };
+
+            return RequireClient().MakeRequestAsync(request, cancellationToken);
         }
 
         private async Task DownloadFileAsync(Telegram.Bot.Types.File file, Stream destination, CancellationToken cancellationToken)

--- a/services/Whisper/FasterWhisperQueueClient.cs
+++ b/services/Whisper/FasterWhisperQueueClient.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
 using YandexSpeech.services.Options;
+using System.Reflection;
 
 namespace YandexSpeech.services.Whisper
 {
@@ -19,9 +20,11 @@ namespace YandexSpeech.services.Whisper
         private readonly ILogger<FasterWhisperQueueClient> _logger;
         private readonly EventBusOptions _options;
         private readonly ConcurrentDictionary<string, TaskCompletionSource<FasterWhisperQueueResponse>> _pending = new();
-        private readonly IConnection _connection;
-        private readonly IModel _channel;
+        private readonly object _connection;
+        private readonly object _channel;
         private readonly object _channelLock = new();
+        private readonly CancellationTokenSource _receiverCts = new();
+        private readonly Task _receiverTask;
 
         public FasterWhisperQueueClient(IOptions<EventBusOptions> options, ILogger<FasterWhisperQueueClient> logger)
         {
@@ -31,30 +34,20 @@ namespace YandexSpeech.services.Whisper
 
             var access = _options.BusAccess ?? throw new InvalidOperationException("Event bus access options are not configured.");
 
-            var factory = new ConnectionFactory
-            {
-                HostName = access.Host,
-                UserName = access.UserName,
-                Password = access.Password,
-                AutomaticRecoveryEnabled = true,
-                NetworkRecoveryInterval = TimeSpan.FromSeconds(5)
-            };
+            var factory = RabbitMqCompat.CreateFactory(access, _options.Broker);
+            _connection = RabbitMqCompat.CreateConnection(factory);
+            _channel = RabbitMqCompat.CreateChannel(_connection);
 
-            var clientName = string.IsNullOrWhiteSpace(_options.Broker) ? "faster-whisper" : _options.Broker;
-            TrySetClientProvidedName(factory, clientName);
-            _connection = factory.CreateConnection();
-            _channel = _connection.CreateModel();
+            RabbitMqCompat.QueueDeclare(_channel, _options.CommandQueueName, durable: true);
+            RabbitMqCompat.QueueDeclare(_channel, _options.QueueName, durable: true);
+            RabbitMqCompat.BasicQos(_channel, prefetchCount: 1);
 
-            _channel.QueueDeclare(queue: _options.CommandQueueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
-            _channel.QueueDeclare(queue: _options.QueueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
-            _channel.BasicQos(0, 1, false);
+            _receiverTask = Task.Run(() => PollResponsesAsync(_receiverCts.Token));
 
-            var consumer = new EventingBasicConsumer(_channel);
-            consumer.Received += HandleResponse;
-            _channel.BasicConsume(queue: _options.QueueName, autoAck: false, consumer: consumer);
-
-            _logger.LogInformation("Initialized FasterWhisper RabbitMQ client. CommandQueue={CommandQueue}, ResponseQueue={ResponseQueue}",
-                _options.CommandQueueName, _options.QueueName);
+            _logger.LogInformation(
+                "Initialized FasterWhisper RabbitMQ client. CommandQueue={CommandQueue}, ResponseQueue={ResponseQueue}",
+                _options.CommandQueueName,
+                _options.QueueName);
         }
 
         public async Task<FasterWhisperQueueResponse> TranscribeAsync(FasterWhisperQueueRequest request, CancellationToken cancellationToken)
@@ -64,11 +57,10 @@ namespace YandexSpeech.services.Whisper
 
             var correlationId = Guid.NewGuid().ToString("N");
             var body = JsonSerializer.SerializeToUtf8Bytes(request, JsonOptions);
-            var bodyMemory = new ReadOnlyMemory<byte>(body);
-            var props = _channel.CreateBasicProperties();
-            props.Persistent = true;
-            props.CorrelationId = correlationId;
-            props.ReplyTo = _options.QueueName;
+            var props = RabbitMqCompat.CreateBasicProperties(_channel);
+            RabbitMqCompat.SetPersistent(props, true);
+            RabbitMqCompat.SetCorrelationId(props, correlationId);
+            RabbitMqCompat.SetReplyTo(props, _options.QueueName);
 
             var tcs = new TaskCompletionSource<FasterWhisperQueueResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             if (!_pending.TryAdd(correlationId, tcs))
@@ -78,7 +70,12 @@ namespace YandexSpeech.services.Whisper
             {
                 lock (_channelLock)
                 {
-                    _channel.BasicPublish(exchange: string.Empty, routingKey: _options.CommandQueueName, mandatory: false, basicProperties: props, body: bodyMemory);
+                    RabbitMqCompat.BasicPublish(
+                        _channel,
+                        exchange: string.Empty,
+                        routingKey: _options.CommandQueueName,
+                        basicProperties: props,
+                        body: body);
                 }
             }
             catch
@@ -96,20 +93,50 @@ namespace YandexSpeech.services.Whisper
             return await tcs.Task.ConfigureAwait(false);
         }
 
-        private void HandleResponse(object? sender, BasicDeliverEventArgs args)
+        private async Task PollResponsesAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                RabbitMqMessage? message = null;
+                try
+                {
+                    message = await RabbitMqCompat.BasicGetAsync(_channel, _options.QueueName, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to receive FasterWhisper response message from RabbitMQ.");
+                    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (message is null)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                HandleResponse(message);
+            }
+        }
+
+        private void HandleResponse(RabbitMqMessage delivery)
         {
             TaskCompletionSource<FasterWhisperQueueResponse>? pending = null;
             string? correlationId = null;
             try
             {
-                correlationId = args.BasicProperties?.CorrelationId;
+                correlationId = RabbitMqCompat.GetCorrelationId(delivery.Properties);
                 if (string.IsNullOrEmpty(correlationId) || !_pending.TryRemove(correlationId, out pending))
                 {
                     _logger.LogWarning("Received unexpected FasterWhisper response with correlation id {CorrelationId}", correlationId);
                     return;
                 }
 
-                var json = Encoding.UTF8.GetString(args.Body.Span);
+                var json = Encoding.UTF8.GetString(delivery.Body);
                 var response = JsonSerializer.Deserialize<FasterWhisperQueueResponse>(json, JsonOptions)
                                ?? throw new InvalidOperationException("Response payload was empty.");
                 pending.TrySetResult(response);
@@ -123,24 +150,32 @@ namespace YandexSpeech.services.Whisper
             {
                 lock (_channelLock)
                 {
-                    _channel.BasicAck(args.DeliveryTag, false);
+                    RabbitMqCompat.BasicAck(_channel, delivery.DeliveryTag);
                 }
             }
         }
 
         public async ValueTask DisposeAsync()
         {
+            try
+            {
+                _receiverCts.Cancel();
+                if (_receiverTask is not null)
+                {
+                    await _receiverTask.ConfigureAwait(false);
+                }
+            }
+            catch
+            {
+                // ignore cancellation exceptions during shutdown
+            }
+            finally
+            {
+                _receiverCts.Dispose();
+            }
+
             await DisposeSafelyAsync(_channel).ConfigureAwait(false);
             await DisposeSafelyAsync(_connection).ConfigureAwait(false);
-        }
-
-        private static void TrySetClientProvidedName(ConnectionFactory factory, string clientName)
-        {
-            var property = typeof(ConnectionFactory).GetProperty("ClientProvidedName");
-            if (property is not null && property.CanWrite)
-            {
-                property.SetValue(factory, clientName);
-            }
         }
 
         private static async ValueTask DisposeSafelyAsync(object? disposable)
@@ -169,6 +204,625 @@ namespace YandexSpeech.services.Whisper
                         // ignore dispose exceptions
                     }
                     break;
+            }
+        }
+    }
+
+    internal sealed record RabbitMqMessage(byte[] Body, object? Properties, ulong DeliveryTag);
+
+    internal static class RabbitMqCompat
+    {
+        private const string ClientAssemblyName = "RabbitMQ.Client";
+
+        public static object CreateFactory(EventBusAccessOptions access, string? brokerName)
+        {
+            if (access is null)
+                throw new ArgumentNullException(nameof(access));
+
+            var factoryType = GetRequiredType("RabbitMQ.Client.ConnectionFactory");
+            var factory = Activator.CreateInstance(factoryType)
+                          ?? throw new InvalidOperationException("Failed to create RabbitMQ connection factory instance.");
+
+            SetProperty(factoryType, factory, "HostName", access.Host);
+            SetProperty(factoryType, factory, "UserName", access.UserName);
+            SetProperty(factoryType, factory, "Password", access.Password);
+            SetProperty(factoryType, factory, "AutomaticRecoveryEnabled", true);
+            SetProperty(factoryType, factory, "NetworkRecoveryInterval", TimeSpan.FromSeconds(5));
+
+            var clientName = string.IsNullOrWhiteSpace(brokerName) ? "faster-whisper" : brokerName;
+            SetProperty(factoryType, factory, "ClientProvidedName", clientName, optional: true);
+
+            return factory;
+        }
+
+        public static object CreateConnection(object factory)
+        {
+            if (factory is null)
+                throw new ArgumentNullException(nameof(factory));
+
+            var factoryType = factory.GetType();
+
+            foreach (var methodName in new[] { "CreateConnectionAsync", "CreateAutorecoveringConnectionAsync" })
+            {
+                var asyncMethod = factoryType.GetMethod(methodName, Type.EmptyTypes);
+                if (asyncMethod is not null)
+                {
+                    var task = asyncMethod.Invoke(factory, Array.Empty<object?>())
+                               ?? throw new InvalidOperationException($"RabbitMQ factory method {methodName} returned null.");
+                    return Await(task);
+                }
+            }
+
+            foreach (var method in factoryType.GetMethods().Where(m => m.Name == "CreateConnection"))
+            {
+                var parameters = method.GetParameters();
+                object?[] args;
+                if (parameters.Length == 0)
+                {
+                    args = Array.Empty<object?>();
+                }
+                else if (parameters.Length == 1 && parameters[0].ParameterType == typeof(string))
+                {
+                    args = new object?[] { null };
+                }
+                else
+                {
+                    continue;
+                }
+
+                var result = method.Invoke(factory, args);
+                if (result is not null)
+                {
+                    return result;
+                }
+            }
+
+            throw new InvalidOperationException("RabbitMQ connection factory does not expose a supported CreateConnection method.");
+        }
+
+        public static object CreateChannel(object connection)
+        {
+            if (connection is null)
+                throw new ArgumentNullException(nameof(connection));
+
+            var connectionType = connection.GetType();
+
+            foreach (var methodName in new[] { "CreateChannelAsync", "CreateModelAsync" })
+            {
+                var asyncMethod = connectionType.GetMethod(methodName, Type.EmptyTypes);
+                if (asyncMethod is not null)
+                {
+                    var task = asyncMethod.Invoke(connection, Array.Empty<object?>())
+                               ?? throw new InvalidOperationException($"RabbitMQ connection method {methodName} returned null.");
+                    return Await(task);
+                }
+            }
+
+            foreach (var methodName in new[] { "CreateChannel", "CreateModel" })
+            {
+                var method = connectionType.GetMethod(methodName, Type.EmptyTypes);
+                if (method is not null)
+                {
+                    var result = method.Invoke(connection, Array.Empty<object?>());
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            throw new InvalidOperationException("RabbitMQ connection does not expose a supported channel creation method.");
+        }
+
+        public static void QueueDeclare(object channel, string queueName, bool durable)
+        {
+            if (channel is null)
+                throw new ArgumentNullException(nameof(channel));
+            if (string.IsNullOrEmpty(queueName))
+                throw new ArgumentException("Queue name is required.", nameof(queueName));
+
+            var channelType = channel.GetType();
+            var declareArgs = new object?[] { queueName, durable, false, false, null };
+
+            var method = channelType.GetMethod("QueueDeclare", new[] { typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(IDictionary) });
+            if (method is not null)
+            {
+                method.Invoke(channel, declareArgs);
+                return;
+            }
+
+            var asyncMethod = channelType.GetMethod("QueueDeclareAsync", new[] { typeof(string), typeof(bool), typeof(bool), typeof(bool), typeof(IDictionary), typeof(CancellationToken) });
+            if (asyncMethod is not null)
+            {
+                var args = declareArgs.Concat(new object?[] { CancellationToken.None }).ToArray();
+                var task = asyncMethod.Invoke(channel, args)
+                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from QueueDeclareAsync.");
+                Await(task);
+                return;
+            }
+
+            var argsType = Type.GetType("RabbitMQ.Client.QueueDeclareArgs, " + ClientAssemblyName);
+            if (argsType is not null)
+            {
+                var argsInstance = Activator.CreateInstance(argsType)
+                                   ?? throw new InvalidOperationException("Failed to create QueueDeclareArgs instance.");
+                SetProperty(argsType, argsInstance, "Queue", queueName, optional: true);
+                SetProperty(argsType, argsInstance, "Durable", durable, optional: true);
+                SetProperty(argsType, argsInstance, "Exclusive", false, optional: true);
+                SetProperty(argsType, argsInstance, "AutoDelete", false, optional: true);
+
+                var methodWithArgs = channelType.GetMethod("QueueDeclare", new[] { argsType });
+                if (methodWithArgs is not null)
+                {
+                    methodWithArgs.Invoke(channel, new[] { argsInstance });
+                    return;
+                }
+
+                var asyncMethodWithArgs = channelType.GetMethod("QueueDeclareAsync", new[] { argsType, typeof(CancellationToken) });
+                if (asyncMethodWithArgs is not null)
+                {
+                    var task = asyncMethodWithArgs.Invoke(channel, new object?[] { argsInstance, CancellationToken.None })
+                               ?? throw new InvalidOperationException("RabbitMQ channel returned null from QueueDeclareAsync.");
+                    Await(task);
+                    return;
+                }
+            }
+
+            throw new InvalidOperationException("RabbitMQ channel does not expose a supported QueueDeclare method.");
+        }
+
+        public static void BasicQos(object channel, ushort prefetchCount)
+        {
+            if (channel is null)
+                throw new ArgumentNullException(nameof(channel));
+
+            var channelType = channel.GetType();
+
+            var method = channelType.GetMethod("BasicQos", new[] { typeof(uint), typeof(ushort), typeof(bool) });
+            if (method is not null)
+            {
+                method.Invoke(channel, new object?[] { 0u, prefetchCount, false });
+                return;
+            }
+
+            var alternative = channelType.GetMethod("BasicQos", new[] { typeof(ushort), typeof(bool) });
+            if (alternative is not null)
+            {
+                alternative.Invoke(channel, new object?[] { prefetchCount, false });
+                return;
+            }
+
+            var asyncMethod = channelType.GetMethod("BasicQosAsync", new[] { typeof(uint), typeof(ushort), typeof(bool), typeof(CancellationToken) });
+            if (asyncMethod is not null)
+            {
+                var task = asyncMethod.Invoke(channel, new object?[] { 0u, prefetchCount, false, CancellationToken.None })
+                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicQosAsync.");
+                Await(task);
+            }
+        }
+
+        public static object CreateBasicProperties(object channel)
+        {
+            if (channel is null)
+                throw new ArgumentNullException(nameof(channel));
+
+            var channelType = channel.GetType();
+            var method = channelType.GetMethod("CreateBasicProperties", Type.EmptyTypes)
+                         ?? throw new InvalidOperationException("RabbitMQ channel does not expose CreateBasicProperties.");
+            var props = method.Invoke(channel, Array.Empty<object?>());
+            if (props is null)
+                throw new InvalidOperationException("RabbitMQ channel returned null basic properties.");
+            return props;
+        }
+
+        public static void SetPersistent(object basicProperties, bool persistent)
+        {
+            if (basicProperties is null)
+                return;
+
+            var type = basicProperties.GetType();
+            SetProperty(type, basicProperties, "Persistent", persistent, optional: true);
+            var deliveryMode = persistent ? (byte)2 : (byte)1;
+            SetProperty(type, basicProperties, "DeliveryMode", deliveryMode, optional: true);
+        }
+
+        public static void SetCorrelationId(object basicProperties, string? correlationId)
+        {
+            if (basicProperties is null)
+                return;
+
+            var type = basicProperties.GetType();
+            SetProperty(type, basicProperties, "CorrelationId", correlationId, optional: true);
+        }
+
+        public static void SetReplyTo(object basicProperties, string? replyTo)
+        {
+            if (basicProperties is null)
+                return;
+
+            var type = basicProperties.GetType();
+            SetProperty(type, basicProperties, "ReplyTo", replyTo, optional: true);
+        }
+
+        public static void BasicPublish(object channel, string exchange, string routingKey, object basicProperties, byte[] body)
+        {
+            if (channel is null)
+                throw new ArgumentNullException(nameof(channel));
+            if (body is null)
+                throw new ArgumentNullException(nameof(body));
+
+            var channelType = channel.GetType();
+            var bodyMemory = new ReadOnlyMemory<byte>(body);
+
+            foreach (var method in channelType.GetMethods().Where(m => m.Name == "BasicPublish"))
+            {
+                var parameters = method.GetParameters();
+                object?[] args;
+
+                switch (parameters.Length)
+                {
+                    case 4:
+                        args = new object?[]
+                        {
+                            exchange,
+                            routingKey,
+                            basicProperties,
+                            ConvertBodyArgument(parameters[3].ParameterType, body, bodyMemory)
+                        };
+                        break;
+                    case 5:
+                        args = new object?[]
+                        {
+                            exchange,
+                            routingKey,
+                            false,
+                            basicProperties,
+                            ConvertBodyArgument(parameters[4].ParameterType, body, bodyMemory)
+                        };
+                        break;
+                    default:
+                        continue;
+                }
+
+                method.Invoke(channel, args);
+                return;
+            }
+
+            foreach (var method in channelType.GetMethods().Where(m => m.Name == "BasicPublishAsync"))
+            {
+                var parameters = method.GetParameters();
+                object?[] args;
+
+                switch (parameters.Length)
+                {
+                    case 5:
+                        args = new object?[]
+                        {
+                            exchange,
+                            routingKey,
+                            false,
+                            basicProperties,
+                            ConvertBodyArgument(parameters[4].ParameterType, body, bodyMemory)
+                        };
+                        break;
+                    case 6:
+                        args = new object?[]
+                        {
+                            exchange,
+                            routingKey,
+                            false,
+                            basicProperties,
+                            ConvertBodyArgument(parameters[4].ParameterType, body, bodyMemory),
+                            CancellationToken.None
+                        };
+                        break;
+                    default:
+                        continue;
+                }
+
+                var task = method.Invoke(channel, args)
+                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicPublishAsync.");
+                Await(task);
+                return;
+            }
+
+            throw new InvalidOperationException("RabbitMQ channel does not expose a supported BasicPublish method.");
+        }
+
+        public static void BasicAck(object channel, ulong deliveryTag)
+        {
+            if (channel is null)
+                throw new ArgumentNullException(nameof(channel));
+
+            var channelType = channel.GetType();
+
+            var method = channelType.GetMethod("BasicAck", new[] { typeof(ulong), typeof(bool) });
+            if (method is not null)
+            {
+                method.Invoke(channel, new object?[] { deliveryTag, false });
+                return;
+            }
+
+            var asyncMethod = channelType.GetMethod("BasicAckAsync", new[] { typeof(ulong), typeof(bool), typeof(CancellationToken) });
+            if (asyncMethod is not null)
+            {
+                var task = asyncMethod.Invoke(channel, new object?[] { deliveryTag, false, CancellationToken.None })
+                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicAckAsync.");
+                Await(task);
+            }
+        }
+
+        public static string? GetCorrelationId(object? basicProperties)
+        {
+            if (basicProperties is null)
+                return null;
+
+            var type = basicProperties.GetType();
+            return type.GetProperty("CorrelationId")?.GetValue(basicProperties) as string;
+        }
+
+        public static async Task<RabbitMqMessage?> BasicGetAsync(object channel, string queueName, CancellationToken cancellationToken)
+        {
+            if (channel is null)
+                throw new ArgumentNullException(nameof(channel));
+
+            var channelType = channel.GetType();
+
+            var asyncWithToken = channelType.GetMethod("BasicGetAsync", new[] { typeof(string), typeof(bool), typeof(CancellationToken) });
+            if (asyncWithToken is not null)
+            {
+                var task = asyncWithToken.Invoke(channel, new object?[] { queueName, false, cancellationToken })
+                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicGetAsync.");
+                var result = await AwaitAsync(task, cancellationToken).ConfigureAwait(false);
+                return ConvertBasicGetResult(result);
+            }
+
+            var asyncMethod = channelType.GetMethod("BasicGetAsync", new[] { typeof(string), typeof(bool) });
+            if (asyncMethod is not null)
+            {
+                var task = asyncMethod.Invoke(channel, new object?[] { queueName, false })
+                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicGetAsync.");
+                var result = await AwaitAsync(task, cancellationToken).ConfigureAwait(false);
+                return ConvertBasicGetResult(result);
+            }
+
+            var method = channelType.GetMethod("BasicGet", new[] { typeof(string), typeof(bool) });
+            if (method is not null)
+            {
+                var result = method.Invoke(channel, new object?[] { queueName, false });
+                return ConvertBasicGetResult(result);
+            }
+
+            throw new InvalidOperationException("RabbitMQ channel does not expose a supported BasicGet method.");
+        }
+
+        private static RabbitMqMessage? ConvertBasicGetResult(object? result)
+        {
+            if (result is null)
+            {
+                return null;
+            }
+
+            var resultType = result.GetType();
+            var body = ExtractBodyBytes(resultType, result);
+            var deliveryTag = ExtractDeliveryTag(resultType, result);
+            var properties = resultType.GetProperty("BasicProperties")?.GetValue(result);
+
+            return new RabbitMqMessage(body, properties, deliveryTag);
+        }
+
+        private static byte[] ExtractBodyBytes(Type resultType, object result)
+        {
+            var bodyProperty = resultType.GetProperty("Body") ?? resultType.GetProperty("Memory") ?? resultType.GetProperty("BodyBytes");
+            if (bodyProperty is null)
+            {
+                throw new InvalidOperationException("RabbitMQ BasicGet result does not contain a Body property.");
+            }
+
+            var value = bodyProperty.GetValue(result);
+            return ConvertToBytes(value);
+        }
+
+        private static ulong ExtractDeliveryTag(Type resultType, object result)
+        {
+            var deliveryTagProperty = resultType.GetProperty("DeliveryTag");
+            if (deliveryTagProperty is not null)
+            {
+                var value = deliveryTagProperty.GetValue(result);
+                if (value is ulong ulongValue)
+                {
+                    return ulongValue;
+                }
+
+                if (value is long longValue)
+                {
+                    return unchecked((ulong)longValue);
+                }
+            }
+
+            var envelopeProperty = resultType.GetProperty("Envelope");
+            if (envelopeProperty is not null)
+            {
+                var envelope = envelopeProperty.GetValue(result);
+                if (envelope is not null)
+                {
+                    var envelopeType = envelope.GetType();
+                    var value = envelopeType.GetProperty("DeliveryTag")?.GetValue(envelope);
+                    if (value is ulong ulongEnvelope)
+                    {
+                        return ulongEnvelope;
+                    }
+
+                    if (value is long longEnvelope)
+                    {
+                        return unchecked((ulong)longEnvelope);
+                    }
+                }
+            }
+
+            throw new InvalidOperationException("RabbitMQ BasicGet result does not expose a DeliveryTag property.");
+        }
+
+        private static byte[] ConvertToBytes(object? body)
+        {
+            switch (body)
+            {
+                case null:
+                    return Array.Empty<byte>();
+                case byte[] bytes:
+                    return bytes;
+                case ReadOnlyMemory<byte> readOnlyMemory:
+                    return readOnlyMemory.ToArray();
+                case Memory<byte> memory:
+                    return memory.ToArray();
+            }
+
+            var type = body?.GetType();
+            if (type is null)
+            {
+                return Array.Empty<byte>();
+            }
+
+            if (type.FullName == "System.ReadOnlyMemory`1[System.Byte]")
+            {
+                var toArray = type.GetMethod("ToArray", Type.EmptyTypes);
+                if (toArray is not null)
+                {
+                    var result = toArray.Invoke(body, Array.Empty<object?>()) as byte[];
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            var spanProperty = type.GetProperty("Span");
+            if (spanProperty is not null)
+            {
+                var spanValue = spanProperty.GetValue(body);
+                switch (spanValue)
+                {
+                    case ReadOnlySpan<byte> ros:
+                        return ros.ToArray();
+                    case Span<byte> span:
+                        return span.ToArray();
+                }
+            }
+
+            throw new InvalidOperationException($"Unsupported RabbitMQ body type {type.FullName}.");
+        }
+
+        private static object ConvertBodyArgument(Type parameterType, byte[] body, ReadOnlyMemory<byte> bodyMemory)
+        {
+            if (parameterType == typeof(byte[]))
+            {
+                return body;
+            }
+
+            if (parameterType == typeof(ReadOnlyMemory<byte>) || parameterType.FullName == "System.ReadOnlyMemory`1[System.Byte]")
+            {
+                return bodyMemory;
+            }
+
+            if (parameterType == typeof(ReadOnlySpan<byte>) || parameterType.FullName == "System.ReadOnlySpan`1[System.Byte]")
+            {
+                return bodyMemory.Span;
+            }
+
+            return body;
+        }
+
+        private static object Await(object task)
+        {
+            var awaiter = task.GetType().GetMethod("GetAwaiter", Type.EmptyTypes)?.Invoke(task, Array.Empty<object?>())
+                           ?? throw new InvalidOperationException("Unable to obtain awaiter from asynchronous RabbitMQ method.");
+            return awaiter.GetType().GetMethod("GetResult", Type.EmptyTypes)?.Invoke(awaiter, Array.Empty<object?>())
+                   ?? throw new InvalidOperationException("RabbitMQ asynchronous method returned null result.");
+        }
+
+        private static async Task<object?> AwaitAsync(object task, CancellationToken cancellationToken)
+        {
+            switch (task)
+            {
+                case Task t:
+                    await t.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return GetTaskResult(t);
+                case ValueTask vt:
+                    await vt.AsTask().WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return null;
+            }
+
+            var type = task.GetType();
+            if (type.FullName?.StartsWith("System.Threading.Tasks.ValueTask`1", StringComparison.Ordinal) == true)
+            {
+                var asTaskMethod = type.GetMethod("AsTask", Type.EmptyTypes);
+                if (asTaskMethod is not null)
+                {
+                    var resultTask = asTaskMethod.Invoke(task, Array.Empty<object?>()) as Task;
+                    if (resultTask is not null)
+                    {
+                        await resultTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                        return GetTaskResult(resultTask);
+                    }
+                }
+            }
+
+            var awaiter = type.GetMethod("GetAwaiter", Type.EmptyTypes)?.Invoke(task, Array.Empty<object?>())
+                           ?? throw new InvalidOperationException("Unable to obtain awaiter from asynchronous RabbitMQ method.");
+            var awaiterType = awaiter.GetType();
+            var getResult = awaiterType.GetMethod("GetResult", Type.EmptyTypes)
+                            ?? throw new InvalidOperationException("RabbitMQ awaiter does not provide GetResult.");
+
+            var isCompletedProperty = awaiterType.GetProperty("IsCompleted");
+            if (isCompletedProperty is not null && isCompletedProperty.GetValue(awaiter) is bool completed && !completed)
+            {
+                var waitHandleProperty = awaiterType.GetProperty("WaitHandle");
+                if (waitHandleProperty?.GetValue(awaiter) is WaitHandle waitHandle)
+                {
+                    waitHandle.WaitOne();
+                }
+            }
+
+            return getResult.Invoke(awaiter, Array.Empty<object?>());
+        }
+
+        private static object? GetTaskResult(Task task)
+        {
+            if (task.GetType().IsGenericType)
+            {
+                return task.GetType().GetProperty("Result")?.GetValue(task);
+            }
+
+            return null;
+        }
+
+        private static Type GetRequiredType(string fullName)
+        {
+            var type = Type.GetType($"{fullName}, {ClientAssemblyName}", throwOnError: false, ignoreCase: false);
+            if (type is null)
+            {
+                throw new InvalidOperationException($"Required RabbitMQ type {fullName} could not be resolved.");
+            }
+
+            return type;
+        }
+
+        private static void SetProperty(Type type, object instance, string propertyName, object? value, bool optional = false)
+        {
+            var property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is null)
+            {
+                if (!optional)
+                {
+                    throw new InvalidOperationException($"Property {propertyName} was not found on type {type.FullName}.");
+                }
+
+                return;
+            }
+
+            if (property.CanWrite)
+            {
+                property.SetValue(instance, value);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a compatibility extension so the bot still works with ITelegramBotClient after the MakeRequestAsync API removal
- rework Telegram request construction to match the new request object initializers
- wrap RabbitMQ usage in a reflection-based compatibility layer and poll for responses instead of EventingBasicConsumer

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4a8768c308331a649cfd9e104e391