### PR TITLE
Fix Telegram bot build errors after dependency update

### DIFF
--- a/services/Telegram/TelegramBotClientExtensions.cs
+++ b/services/Telegram/TelegramBotClientExtensions.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Telegram.Bot;
 using Telegram.Bot.Requests;
+using Telegram.Bot.Requests.Abstractions;
 
 namespace YandexSpeech.services.Telegram
 {

--- a/services/Telegram/TelegramTranscriptionBot.cs
+++ b/services/Telegram/TelegramTranscriptionBot.cs
@@ -905,7 +905,7 @@ namespace YandexSpeech.services.Telegram
             await RequireClient().MakeRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        private Task<Telegram.Bot.Types.File> GetFileAsync(string fileId, CancellationToken cancellationToken)
+        private Task<global::Telegram.Bot.Types.File> GetFileAsync(string fileId, CancellationToken cancellationToken)
         {
             var request = new GetFileRequest
             {
@@ -915,7 +915,7 @@ namespace YandexSpeech.services.Telegram
             return RequireClient().MakeRequestAsync(request, cancellationToken);
         }
 
-        private async Task DownloadFileAsync(Telegram.Bot.Types.File file, Stream destination, CancellationToken cancellationToken)
+        private async Task DownloadFileAsync(global::Telegram.Bot.Types.File file, Stream destination, CancellationToken cancellationToken)
         {
             if (file.FilePath is null)
             {


### PR DESCRIPTION
## Summary
- import the Telegram.Bot request abstraction interface needed by IRequest<T>
- use the global Telegram namespace when referencing the File type to avoid collisions with the project namespace

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b1a337ac8331ab3b145525ad370a