### PR TITLE
Fix MemoryMarshal reflection for ToArray lookup

### DIFF
--- a/services/Whisper/FasterWhisperQueueClient.cs
+++ b/services/Whisper/FasterWhisperQueueClient.cs
@@ -714,7 +714,7 @@ namespace YandexSpeech.services.Whisper
                 {
                     var spanValue = spanProperty.GetValue(body);
                     var toArray = typeof(MemoryMarshal).GetMethods(BindingFlags.Public | BindingFlags.Static)
-                        .FirstOrDefault(m => m.Name == nameof(MemoryMarshal.ToArray) && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)
+                        .FirstOrDefault(m => m.Name == "ToArray" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)
                         ?.MakeGenericMethod(typeof(byte));
                     if (toArray is not null && toArray.Invoke(null, new[] { spanValue }) is byte[] spanResult)
                     {


### PR DESCRIPTION
## Summary
- avoid using nameof(MemoryMarshal.ToArray) when reflecting for ToArray to support frameworks where the API is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b56bf64c833187f05ba68ba14b8c