### PR TITLE
Refactor FasterWhisper queue client to use RabbitMQ client types

### DIFF
--- a/services/Whisper/FasterWhisperQueueClient.cs
+++ b/services/Whisper/FasterWhisperQueueClient.cs
@@ -1,17 +1,14 @@
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Impl;
 using YandexSpeech.services.Options;
-using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace YandexSpeech.services.Whisper
 {
@@ -22,8 +19,8 @@ namespace YandexSpeech.services.Whisper
         private readonly ILogger<FasterWhisperQueueClient> _logger;
         private readonly EventBusOptions _options;
         private readonly ConcurrentDictionary<string, TaskCompletionSource<FasterWhisperQueueResponse>> _pending = new();
-        private readonly object _connection;
-        private readonly object _channel;
+        private readonly AutorecoveringConnection _connection;
+        private readonly AutorecoveringChannel _channel;
         private readonly object _channelLock = new();
         private readonly CancellationTokenSource _receiverCts = new();
         private readonly Task _receiverTask;
@@ -36,13 +33,13 @@ namespace YandexSpeech.services.Whisper
 
             var access = _options.BusAccess ?? throw new InvalidOperationException("Event bus access options are not configured.");
 
-            var factory = RabbitMqCompat.CreateFactory(access, _options.Broker);
-            _connection = RabbitMqCompat.CreateConnection(factory);
-            _channel = RabbitMqCompat.CreateChannel(_connection);
+            var factory = CreateFactory(access, _options.Broker);
+            _connection = CreateConnection(factory);
+            _channel = CreateChannel(_connection);
 
-            RabbitMqCompat.QueueDeclare(_channel, _options.CommandQueueName, durable: true);
-            RabbitMqCompat.QueueDeclare(_channel, _options.QueueName, durable: true);
-            RabbitMqCompat.BasicQos(_channel, prefetchCount: 1);
+            _channel.QueueDeclare(_options.CommandQueueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
+            _channel.QueueDeclare(_options.QueueName, durable: true, exclusive: false, autoDelete: false, arguments: null);
+            _channel.BasicQos(prefetchSize: 0, prefetchCount: 1, global: false);
 
             _receiverTask = Task.Run(() => PollResponsesAsync(_receiverCts.Token));
 
@@ -59,10 +56,11 @@ namespace YandexSpeech.services.Whisper
 
             var correlationId = Guid.NewGuid().ToString("N");
             var body = JsonSerializer.SerializeToUtf8Bytes(request, JsonOptions);
-            var props = RabbitMqCompat.CreateBasicProperties(_channel);
-            RabbitMqCompat.SetPersistent(props, true);
-            RabbitMqCompat.SetCorrelationId(props, correlationId);
-            RabbitMqCompat.SetReplyTo(props, _options.QueueName);
+            var props = _channel.CreateBasicProperties();
+            props.Persistent = true;
+            props.DeliveryMode = 2;
+            props.CorrelationId = correlationId;
+            props.ReplyTo = _options.QueueName;
 
             var tcs = new TaskCompletionSource<FasterWhisperQueueResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             if (!_pending.TryAdd(correlationId, tcs))
@@ -72,8 +70,7 @@ namespace YandexSpeech.services.Whisper
             {
                 lock (_channelLock)
                 {
-                    RabbitMqCompat.BasicPublish(
-                        _channel,
+                    _channel.BasicPublish(
                         exchange: string.Empty,
                         routingKey: _options.CommandQueueName,
                         basicProperties: props,
@@ -102,7 +99,12 @@ namespace YandexSpeech.services.Whisper
                 RabbitMqMessage? message = null;
                 try
                 {
-                    message = await RabbitMqCompat.BasicGetAsync(_channel, _options.QueueName, cancellationToken).ConfigureAwait(false);
+                    var result = _channel.BasicGet(_options.QueueName, autoAck: false);
+                    if (result is not null)
+                    {
+                        var body = result.Body.ToArray();
+                        message = new RabbitMqMessage(body, result.BasicProperties, result.DeliveryTag);
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -131,7 +133,7 @@ namespace YandexSpeech.services.Whisper
             string? correlationId = null;
             try
             {
-                correlationId = RabbitMqCompat.GetCorrelationId(delivery.Properties);
+                correlationId = delivery.Properties?.CorrelationId;
                 if (string.IsNullOrEmpty(correlationId) || !_pending.TryRemove(correlationId, out pending))
                 {
                     _logger.LogWarning("Received unexpected FasterWhisper response with correlation id {CorrelationId}", correlationId);
@@ -152,7 +154,7 @@ namespace YandexSpeech.services.Whisper
             {
                 lock (_channelLock)
                 {
-                    RabbitMqCompat.BasicAck(_channel, delivery.DeliveryTag);
+                    _channel.BasicAck(delivery.DeliveryTag, multiple: false);
                 }
             }
         }
@@ -180,777 +182,62 @@ namespace YandexSpeech.services.Whisper
             await DisposeSafelyAsync(_connection).ConfigureAwait(false);
         }
 
-        private static async ValueTask DisposeSafelyAsync(object? disposable)
+        private static ConnectionFactory CreateFactory(EventBusAccessOptions access, string? brokerName)
         {
-            switch (disposable)
+            var factory = new ConnectionFactory
             {
-                case null:
-                    return;
-                case IAsyncDisposable asyncDisposable:
-                    try
-                    {
-                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
-                    }
-                    catch
-                    {
-                        // ignore dispose exceptions
-                    }
-                    break;
-                case IDisposable syncDisposable:
-                    try
-                    {
-                        syncDisposable.Dispose();
-                    }
-                    catch
-                    {
-                        // ignore dispose exceptions
-                    }
-                    break;
-            }
-        }
-    }
-
-    internal sealed record RabbitMqMessage(byte[] Body, object? Properties, ulong DeliveryTag);
-
-    internal static class RabbitMqCompat
-    {
-        private const string ClientAssemblyName = "RabbitMQ.Client";
-
-        public static object CreateFactory(EventBusAccessOptions access, string? brokerName)
-        {
-            if (access is null)
-                throw new ArgumentNullException(nameof(access));
-
-            var factoryType = GetRequiredType("RabbitMQ.Client.ConnectionFactory");
-            var factory = Activator.CreateInstance(factoryType)
-                          ?? throw new InvalidOperationException("Failed to create RabbitMQ connection factory instance.");
-
-            SetProperty(factoryType, factory, "HostName", access.Host);
-            SetProperty(factoryType, factory, "UserName", access.UserName);
-            SetProperty(factoryType, factory, "Password", access.Password);
-            SetProperty(factoryType, factory, "AutomaticRecoveryEnabled", true);
-            SetProperty(factoryType, factory, "NetworkRecoveryInterval", TimeSpan.FromSeconds(5));
+                HostName = access.Host,
+                UserName = access.UserName,
+                Password = access.Password,
+                AutomaticRecoveryEnabled = true,
+                NetworkRecoveryInterval = TimeSpan.FromSeconds(5)
+            };
 
             var clientName = string.IsNullOrWhiteSpace(brokerName) ? "faster-whisper" : brokerName;
-            SetProperty(factoryType, factory, "ClientProvidedName", clientName, optional: true);
+            factory.ClientProvidedName = clientName;
 
             return factory;
         }
 
-        public static object CreateConnection(object factory)
+        private static AutorecoveringConnection CreateConnection(ConnectionFactory factory)
         {
-            if (factory is null)
-                throw new ArgumentNullException(nameof(factory));
+            var connection = factory.CreateConnection();
+            if (connection is not AutorecoveringConnection autorecoveringConnection)
+                throw new InvalidOperationException("RabbitMQ factory did not create an autorecovering connection.");
 
-            var factoryType = factory.GetType();
-
-            foreach (var methodName in new[] { "CreateConnectionAsync", "CreateAutorecoveringConnectionAsync" })
-            {
-                foreach (var asyncMethod in factoryType.GetMethods().Where(m => m.Name == methodName))
-                {
-                    if (!TryInvokeWithOptionalParameters(factory, asyncMethod, out var result))
-                    {
-                        continue;
-                    }
-
-                    var task = result ?? throw new InvalidOperationException($"RabbitMQ factory method {methodName} returned null.");
-                    return Await(task);
-                }
-            }
-
-            foreach (var method in factoryType.GetMethods().Where(m => m.Name == "CreateConnection"))
-            {
-                if (!TryInvokeWithOptionalParameters(factory, method, out var result))
-                {
-                    continue;
-                }
-
-                if (result is not null)
-                {
-                    return result;
-                }
-            }
-
-            throw new InvalidOperationException("RabbitMQ connection factory does not expose a supported CreateConnection method.");
+            return autorecoveringConnection;
         }
 
-        public static object CreateChannel(object connection)
+        private static AutorecoveringChannel CreateChannel(AutorecoveringConnection connection)
         {
-            if (connection is null)
-                throw new ArgumentNullException(nameof(connection));
+            var model = connection.CreateModel();
+            if (model is not AutorecoveringChannel channel)
+                throw new InvalidOperationException("RabbitMQ connection did not create an autorecovering channel.");
 
-            var connectionType = connection.GetType();
-
-            foreach (var methodName in new[] { "CreateChannelAsync", "CreateModelAsync" })
-            {
-                foreach (var asyncMethod in connectionType.GetMethods().Where(m => m.Name == methodName))
-                {
-                    if (!TryInvokeWithOptionalParameters(connection, asyncMethod, out var result))
-                    {
-                        continue;
-                    }
-
-                    var task = result ?? throw new InvalidOperationException($"RabbitMQ connection method {methodName} returned null.");
-                    return Await(task);
-                }
-            }
-
-            foreach (var methodName in new[] { "CreateChannel", "CreateModel" })
-            {
-                foreach (var method in connectionType.GetMethods().Where(m => m.Name == methodName))
-                {
-                    if (!TryInvokeWithOptionalParameters(connection, method, out var result))
-                    {
-                        continue;
-                    }
-
-                    if (result is not null)
-                    {
-                        return result;
-                    }
-                }
-            }
-
-            throw new InvalidOperationException("RabbitMQ connection does not expose a supported channel creation method.");
+            return channel;
         }
 
-        public static void QueueDeclare(object channel, string queueName, bool durable)
+        private static ValueTask DisposeSafelyAsync(IDisposable? disposable)
         {
-            if (channel is null)
-                throw new ArgumentNullException(nameof(channel));
-            if (string.IsNullOrEmpty(queueName))
-                throw new ArgumentException("Queue name is required.", nameof(queueName));
-
-            var channelType = channel.GetType();
-            var declareArgs = new object?[] { queueName, durable, false, false, null };
-
-            var method = GetQueueDeclareMethod(channelType, async: false);
-            if (method is not null)
+            if (disposable is null)
             {
-                method.Invoke(channel, declareArgs);
-                return;
+                return ValueTask.CompletedTask;
             }
 
-            var asyncMethod = GetQueueDeclareMethod(channelType, async: true);
-            if (asyncMethod is not null)
+            try
             {
-                var args = declareArgs.Concat(new object?[] { CancellationToken.None }).ToArray();
-                var task = asyncMethod.Invoke(channel, args)
-                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from QueueDeclareAsync.");
-                Await(task);
-                return;
+                disposable.Dispose();
+            }
+            catch
+            {
+                // ignore dispose exceptions
             }
 
-            var argsType = Type.GetType("RabbitMQ.Client.QueueDeclareArgs, " + ClientAssemblyName);
-            if (argsType is not null)
-            {
-                var argsInstance = Activator.CreateInstance(argsType)
-                                   ?? throw new InvalidOperationException("Failed to create QueueDeclareArgs instance.");
-                SetProperty(argsType, argsInstance, "Queue", queueName, optional: true);
-                SetProperty(argsType, argsInstance, "Durable", durable, optional: true);
-                SetProperty(argsType, argsInstance, "Exclusive", false, optional: true);
-                SetProperty(argsType, argsInstance, "AutoDelete", false, optional: true);
-
-                var methodWithArgs = channelType.GetMethod("QueueDeclare", new[] { argsType });
-                if (methodWithArgs is not null)
-                {
-                    methodWithArgs.Invoke(channel, new[] { argsInstance });
-                    return;
-                }
-
-                var asyncMethodWithArgs = channelType.GetMethod("QueueDeclareAsync", new[] { argsType, typeof(CancellationToken) });
-                if (asyncMethodWithArgs is not null)
-                {
-                    var task = asyncMethodWithArgs.Invoke(channel, new object?[] { argsInstance, CancellationToken.None })
-                               ?? throw new InvalidOperationException("RabbitMQ channel returned null from QueueDeclareAsync.");
-                    Await(task);
-                    return;
-                }
-            }
-
-            throw new InvalidOperationException("RabbitMQ channel does not expose a supported QueueDeclare method.");
-        }
-
-        private static MethodInfo? GetQueueDeclareMethod(Type channelType, bool async)
-        {
-            var candidates = channelType.GetMethods().Where(m => m.Name == (async ? "QueueDeclareAsync" : "QueueDeclare"));
-
-            foreach (var candidate in candidates)
-            {
-                var parameters = candidate.GetParameters();
-
-                if (!TryMatchQueueDeclareParameters(parameters, async))
-                {
-                    continue;
-                }
-
-                return candidate;
-            }
-
-            return null;
-        }
-
-        private static bool TryMatchQueueDeclareParameters(IReadOnlyList<ParameterInfo> parameters, bool async)
-        {
-            if (async)
-            {
-                if (parameters.Count != 6)
-                {
-                    return false;
-                }
-
-                if (parameters[^1].ParameterType != typeof(CancellationToken))
-                {
-                    return false;
-                }
-
-                parameters = parameters.Take(parameters.Count - 1).ToArray();
-            }
-            else if (parameters.Count != 5)
-            {
-                return false;
-            }
-
-            return parameters[0].ParameterType == typeof(string)
-                   && parameters[1].ParameterType == typeof(bool)
-                   && parameters[2].ParameterType == typeof(bool)
-                   && parameters[3].ParameterType == typeof(bool)
-                   && IsDictionaryParameter(parameters[4].ParameterType);
-        }
-
-        private static bool IsDictionaryParameter(Type parameterType)
-        {
-            if (typeof(IDictionary).IsAssignableFrom(parameterType))
-            {
-                return true;
-            }
-
-            if (parameterType.IsGenericType)
-            {
-                var genericType = parameterType.GetGenericTypeDefinition();
-
-                if (genericType == typeof(IDictionary<,>) || genericType == typeof(IReadOnlyDictionary<,>))
-                {
-                    var genericArguments = parameterType.GetGenericArguments();
-                    return genericArguments[0] == typeof(string);
-                }
-            }
-
-            return false;
-        }
-
-        public static void BasicQos(object channel, ushort prefetchCount)
-        {
-            if (channel is null)
-                throw new ArgumentNullException(nameof(channel));
-
-            var channelType = channel.GetType();
-
-            var method = channelType.GetMethod("BasicQos", new[] { typeof(uint), typeof(ushort), typeof(bool) });
-            if (method is not null)
-            {
-                method.Invoke(channel, new object?[] { 0u, prefetchCount, false });
-                return;
-            }
-
-            var alternative = channelType.GetMethod("BasicQos", new[] { typeof(ushort), typeof(bool) });
-            if (alternative is not null)
-            {
-                alternative.Invoke(channel, new object?[] { prefetchCount, false });
-                return;
-            }
-
-            var asyncMethod = channelType.GetMethod("BasicQosAsync", new[] { typeof(uint), typeof(ushort), typeof(bool), typeof(CancellationToken) });
-            if (asyncMethod is not null)
-            {
-                var task = asyncMethod.Invoke(channel, new object?[] { 0u, prefetchCount, false, CancellationToken.None })
-                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicQosAsync.");
-                Await(task);
-            }
-        }
-
-        public static object CreateBasicProperties(object channel)
-        {
-            if (channel is null)
-                throw new ArgumentNullException(nameof(channel));
-
-            var channelType = channel.GetType();
-            var method = channelType.GetMethod("CreateBasicProperties", Type.EmptyTypes)
-                         ?? throw new InvalidOperationException("RabbitMQ channel does not expose CreateBasicProperties.");
-            var props = method.Invoke(channel, Array.Empty<object?>());
-            if (props is null)
-                throw new InvalidOperationException("RabbitMQ channel returned null basic properties.");
-            return props;
-        }
-
-        public static void SetPersistent(object basicProperties, bool persistent)
-        {
-            if (basicProperties is null)
-                return;
-
-            var type = basicProperties.GetType();
-            SetProperty(type, basicProperties, "Persistent", persistent, optional: true);
-            var deliveryMode = persistent ? (byte)2 : (byte)1;
-            SetProperty(type, basicProperties, "DeliveryMode", deliveryMode, optional: true);
-        }
-
-        public static void SetCorrelationId(object basicProperties, string? correlationId)
-        {
-            if (basicProperties is null)
-                return;
-
-            var type = basicProperties.GetType();
-            SetProperty(type, basicProperties, "CorrelationId", correlationId, optional: true);
-        }
-
-        public static void SetReplyTo(object basicProperties, string? replyTo)
-        {
-            if (basicProperties is null)
-                return;
-
-            var type = basicProperties.GetType();
-            SetProperty(type, basicProperties, "ReplyTo", replyTo, optional: true);
-        }
-
-        public static void BasicPublish(object channel, string exchange, string routingKey, object basicProperties, byte[] body)
-        {
-            if (channel is null)
-                throw new ArgumentNullException(nameof(channel));
-            if (body is null)
-                throw new ArgumentNullException(nameof(body));
-
-            var channelType = channel.GetType();
-            var bodyMemory = new ReadOnlyMemory<byte>(body);
-
-            foreach (var method in channelType.GetMethods().Where(m => m.Name == "BasicPublish"))
-            {
-                var parameters = method.GetParameters();
-                object?[] args;
-
-                switch (parameters.Length)
-                {
-                    case 4:
-                        args = new object?[]
-                        {
-                            exchange,
-                            routingKey,
-                            basicProperties,
-                            ConvertBodyArgument(parameters[3].ParameterType, body, bodyMemory)
-                        };
-                        break;
-                    case 5:
-                        args = new object?[]
-                        {
-                            exchange,
-                            routingKey,
-                            false,
-                            basicProperties,
-                            ConvertBodyArgument(parameters[4].ParameterType, body, bodyMemory)
-                        };
-                        break;
-                    default:
-                        continue;
-                }
-
-                method.Invoke(channel, args);
-                return;
-            }
-
-            foreach (var method in channelType.GetMethods().Where(m => m.Name == "BasicPublishAsync"))
-            {
-                var parameters = method.GetParameters();
-                object?[] args;
-
-                switch (parameters.Length)
-                {
-                    case 5:
-                        args = new object?[]
-                        {
-                            exchange,
-                            routingKey,
-                            false,
-                            basicProperties,
-                            ConvertBodyArgument(parameters[4].ParameterType, body, bodyMemory)
-                        };
-                        break;
-                    case 6:
-                        args = new object?[]
-                        {
-                            exchange,
-                            routingKey,
-                            false,
-                            basicProperties,
-                            ConvertBodyArgument(parameters[4].ParameterType, body, bodyMemory),
-                            CancellationToken.None
-                        };
-                        break;
-                    default:
-                        continue;
-                }
-
-                var task = method.Invoke(channel, args)
-                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicPublishAsync.");
-                Await(task);
-                return;
-            }
-
-            throw new InvalidOperationException("RabbitMQ channel does not expose a supported BasicPublish method.");
-        }
-
-        public static void BasicAck(object channel, ulong deliveryTag)
-        {
-            if (channel is null)
-                throw new ArgumentNullException(nameof(channel));
-
-            var channelType = channel.GetType();
-
-            var method = channelType.GetMethod("BasicAck", new[] { typeof(ulong), typeof(bool) });
-            if (method is not null)
-            {
-                method.Invoke(channel, new object?[] { deliveryTag, false });
-                return;
-            }
-
-            var asyncMethod = channelType.GetMethod("BasicAckAsync", new[] { typeof(ulong), typeof(bool), typeof(CancellationToken) });
-            if (asyncMethod is not null)
-            {
-                var task = asyncMethod.Invoke(channel, new object?[] { deliveryTag, false, CancellationToken.None })
-                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicAckAsync.");
-                Await(task);
-            }
-        }
-
-        public static string? GetCorrelationId(object? basicProperties)
-        {
-            if (basicProperties is null)
-                return null;
-
-            var type = basicProperties.GetType();
-            return type.GetProperty("CorrelationId")?.GetValue(basicProperties) as string;
-        }
-
-        public static async Task<RabbitMqMessage?> BasicGetAsync(object channel, string queueName, CancellationToken cancellationToken)
-        {
-            if (channel is null)
-                throw new ArgumentNullException(nameof(channel));
-
-            var channelType = channel.GetType();
-
-            var asyncWithToken = channelType.GetMethod("BasicGetAsync", new[] { typeof(string), typeof(bool), typeof(CancellationToken) });
-            if (asyncWithToken is not null)
-            {
-                var task = asyncWithToken.Invoke(channel, new object?[] { queueName, false, cancellationToken })
-                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicGetAsync.");
-                var result = await AwaitAsync(task, cancellationToken).ConfigureAwait(false);
-                return ConvertBasicGetResult(result);
-            }
-
-            var asyncMethod = channelType.GetMethod("BasicGetAsync", new[] { typeof(string), typeof(bool) });
-            if (asyncMethod is not null)
-            {
-                var task = asyncMethod.Invoke(channel, new object?[] { queueName, false })
-                           ?? throw new InvalidOperationException("RabbitMQ channel returned null from BasicGetAsync.");
-                var result = await AwaitAsync(task, cancellationToken).ConfigureAwait(false);
-                return ConvertBasicGetResult(result);
-            }
-
-            var method = channelType.GetMethod("BasicGet", new[] { typeof(string), typeof(bool) });
-            if (method is not null)
-            {
-                var result = method.Invoke(channel, new object?[] { queueName, false });
-                return ConvertBasicGetResult(result);
-            }
-
-            throw new InvalidOperationException("RabbitMQ channel does not expose a supported BasicGet method.");
-        }
-
-        private static RabbitMqMessage? ConvertBasicGetResult(object? result)
-        {
-            if (result is null)
-            {
-                return null;
-            }
-
-            var resultType = result.GetType();
-            var body = ExtractBodyBytes(resultType, result);
-            var deliveryTag = ExtractDeliveryTag(resultType, result);
-            var properties = resultType.GetProperty("BasicProperties")?.GetValue(result);
-
-            return new RabbitMqMessage(body, properties, deliveryTag);
-        }
-
-        private static byte[] ExtractBodyBytes(Type resultType, object result)
-        {
-            var bodyProperty = resultType.GetProperty("Body") ?? resultType.GetProperty("Memory") ?? resultType.GetProperty("BodyBytes");
-            if (bodyProperty is null)
-            {
-                throw new InvalidOperationException("RabbitMQ BasicGet result does not contain a Body property.");
-            }
-
-            var value = bodyProperty.GetValue(result);
-            return ConvertToBytes(value);
-        }
-
-        private static ulong ExtractDeliveryTag(Type resultType, object result)
-        {
-            var deliveryTagProperty = resultType.GetProperty("DeliveryTag");
-            if (deliveryTagProperty is not null)
-            {
-                var value = deliveryTagProperty.GetValue(result);
-                if (value is ulong ulongValue)
-                {
-                    return ulongValue;
-                }
-
-                if (value is long longValue)
-                {
-                    return unchecked((ulong)longValue);
-                }
-            }
-
-            var envelopeProperty = resultType.GetProperty("Envelope");
-            if (envelopeProperty is not null)
-            {
-                var envelope = envelopeProperty.GetValue(result);
-                if (envelope is not null)
-                {
-                    var envelopeType = envelope.GetType();
-                    var value = envelopeType.GetProperty("DeliveryTag")?.GetValue(envelope);
-                    if (value is ulong ulongEnvelope)
-                    {
-                        return ulongEnvelope;
-                    }
-
-                    if (value is long longEnvelope)
-                    {
-                        return unchecked((ulong)longEnvelope);
-                    }
-                }
-            }
-
-            throw new InvalidOperationException("RabbitMQ BasicGet result does not expose a DeliveryTag property.");
-        }
-
-        private static byte[] ConvertToBytes(object? body)
-        {
-            switch (body)
-            {
-                case null:
-                    return Array.Empty<byte>();
-                case byte[] bytes:
-                    return bytes;
-                case ReadOnlyMemory<byte> readOnlyMemory:
-                    return readOnlyMemory.ToArray();
-                case Memory<byte> memory:
-                    return memory.ToArray();
-            }
-
-            var type = body?.GetType();
-            if (type is null)
-            {
-                return Array.Empty<byte>();
-            }
-
-            if (type.FullName == "System.ReadOnlyMemory`1[System.Byte]")
-            {
-                var toArray = type.GetMethod("ToArray", Type.EmptyTypes);
-                if (toArray is not null)
-                {
-                    var result = toArray.Invoke(body, Array.Empty<object?>()) as byte[];
-                    if (result is not null)
-                    {
-                        return result;
-                    }
-                }
-            }
-
-            var toArrayMethod = type.GetMethod("ToArray", Type.EmptyTypes);
-            if (toArrayMethod is not null)
-            {
-                if (toArrayMethod.Invoke(body, Array.Empty<object?>()) is byte[] result)
-                {
-                    return result;
-                }
-            }
-
-            var spanProperty = type.GetProperty("Span");
-            if (spanProperty is not null)
-            {
-                var spanType = spanProperty.PropertyType;
-                if (spanType.FullName == "System.ReadOnlySpan`1[System.Byte]" || spanType.FullName == "System.Span`1[System.Byte]")
-                {
-                    var spanValue = spanProperty.GetValue(body);
-                    var toArray = typeof(MemoryMarshal).GetMethods(BindingFlags.Public | BindingFlags.Static)
-                        .FirstOrDefault(m => m.Name == "ToArray" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)
-                        ?.MakeGenericMethod(typeof(byte));
-                    if (toArray is not null && toArray.Invoke(null, new[] { spanValue }) is byte[] spanResult)
-                    {
-                        return spanResult;
-                    }
-                }
-            }
-
-            throw new InvalidOperationException($"Unsupported RabbitMQ body type {type.FullName}.");
-        }
-
-        private static object ConvertBodyArgument(Type parameterType, byte[] body, ReadOnlyMemory<byte> bodyMemory)
-        {
-            if (parameterType == typeof(byte[]))
-            {
-                return body;
-            }
-
-            if (parameterType == typeof(ReadOnlyMemory<byte>) ||
-                parameterType.FullName == "System.ReadOnlyMemory`1[System.Byte]")
-            {
-                return bodyMemory;
-            }
-
-            return body;
-        }
-
-        private static bool TryInvokeWithOptionalParameters(object instance, MethodInfo method, out object? result)
-        {
-            if (instance is null)
-                throw new ArgumentNullException(nameof(instance));
-            if (method is null)
-                throw new ArgumentNullException(nameof(method));
-
-            var parameters = method.GetParameters();
-            if (parameters.Length == 0)
-            {
-                result = method.Invoke(instance, Array.Empty<object?>());
-                return true;
-            }
-
-            var args = new object?[parameters.Length];
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                var parameter = parameters[i];
-
-                if (parameter.HasDefaultValue)
-                {
-                    args[i] = parameter.DefaultValue;
-                }
-                else if (parameter.ParameterType == typeof(string))
-                {
-                    args[i] = null;
-                }
-                else if (parameter.ParameterType == typeof(CancellationToken))
-                {
-                    args[i] = CancellationToken.None;
-                }
-                else if (parameter.IsOptional)
-                {
-                    args[i] = parameter.ParameterType.IsValueType
-                        ? Activator.CreateInstance(parameter.ParameterType)
-                        : null;
-                }
-                else
-                {
-                    result = null;
-                    return false;
-                }
-            }
-
-            result = method.Invoke(instance, args);
-            return true;
-        }
-
-        private static object Await(object task)
-        {
-            var awaiter = task.GetType().GetMethod("GetAwaiter", Type.EmptyTypes)?.Invoke(task, Array.Empty<object?>())
-                           ?? throw new InvalidOperationException("Unable to obtain awaiter from asynchronous RabbitMQ method.");
-            return awaiter.GetType().GetMethod("GetResult", Type.EmptyTypes)?.Invoke(awaiter, Array.Empty<object?>())
-                   ?? throw new InvalidOperationException("RabbitMQ asynchronous method returned null result.");
-        }
-
-        private static async Task<object?> AwaitAsync(object task, CancellationToken cancellationToken)
-        {
-            switch (task)
-            {
-                case Task t:
-                    await t.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    return GetTaskResult(t);
-                case ValueTask vt:
-                    await vt.AsTask().WaitAsync(cancellationToken).ConfigureAwait(false);
-                    return null;
-            }
-
-            var type = task.GetType();
-            if (type.FullName?.StartsWith("System.Threading.Tasks.ValueTask`1", StringComparison.Ordinal) == true)
-            {
-                var asTaskMethod = type.GetMethod("AsTask", Type.EmptyTypes);
-                if (asTaskMethod is not null)
-                {
-                    var resultTask = asTaskMethod.Invoke(task, Array.Empty<object?>()) as Task;
-                    if (resultTask is not null)
-                    {
-                        await resultTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        return GetTaskResult(resultTask);
-                    }
-                }
-            }
-
-            var awaiter = type.GetMethod("GetAwaiter", Type.EmptyTypes)?.Invoke(task, Array.Empty<object?>())
-                           ?? throw new InvalidOperationException("Unable to obtain awaiter from asynchronous RabbitMQ method.");
-            var awaiterType = awaiter.GetType();
-            var getResult = awaiterType.GetMethod("GetResult", Type.EmptyTypes)
-                            ?? throw new InvalidOperationException("RabbitMQ awaiter does not provide GetResult.");
-
-            var isCompletedProperty = awaiterType.GetProperty("IsCompleted");
-            if (isCompletedProperty is not null && isCompletedProperty.GetValue(awaiter) is bool completed && !completed)
-            {
-                var waitHandleProperty = awaiterType.GetProperty("WaitHandle");
-                if (waitHandleProperty?.GetValue(awaiter) is WaitHandle waitHandle)
-                {
-                    waitHandle.WaitOne();
-                }
-            }
-
-            return getResult.Invoke(awaiter, Array.Empty<object?>());
-        }
-
-        private static object? GetTaskResult(Task task)
-        {
-            if (task.GetType().IsGenericType)
-            {
-                return task.GetType().GetProperty("Result")?.GetValue(task);
-            }
-
-            return null;
-        }
-
-        private static Type GetRequiredType(string fullName)
-        {
-            var type = Type.GetType($"{fullName}, {ClientAssemblyName}", throwOnError: false, ignoreCase: false);
-            if (type is null)
-            {
-                throw new InvalidOperationException($"Required RabbitMQ type {fullName} could not be resolved.");
-            }
-
-            return type;
-        }
-
-        private static void SetProperty(Type type, object instance, string propertyName, object? value, bool optional = false)
-        {
-            var property = type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (property is null)
-            {
-                if (!optional)
-                {
-                    throw new InvalidOperationException($"Property {propertyName} was not found on type {type.FullName}.");
-                }
-
-                return;
-            }
-
-            if (property.CanWrite)
-            {
-                property.SetValue(instance, value);
-            }
+            return ValueTask.CompletedTask;
         }
     }
+
+    internal sealed record RabbitMqMessage(byte[] Body, IBasicProperties? Properties, ulong DeliveryTag);
 
     public sealed record FasterWhisperQueueRequest
     {


### PR DESCRIPTION
## Summary
- replace the reflection-driven RabbitMqCompat helper with direct usage of RabbitMQ.Client types
- configure the connection factory and autorecovering channel explicitly during client initialization
- keep the request/response DTOs alongside the queue client implementation

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4d364b4408331ac907ce101baf4db