### PR TITLE
Handle explicit interface MakeRequestAsync on Telegram bot client

### DIFF
--- a/services/Telegram/TelegramBotClientExtensions.cs
+++ b/services/Telegram/TelegramBotClientExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Telegram.Bot;
@@ -30,9 +31,13 @@ namespace YandexSpeech.services.Telegram
                 throw new ArgumentNullException(nameof(request));
 
             var clientType = client.GetType();
+            var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
             foreach (var methodName in CandidateMethodNames)
             {
-                foreach (var method in clientType.GetMethods().Where(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase)))
+                foreach (var method in clientType
+                             .GetMethods(bindingFlags)
+                             .Where(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase)
+                                         || m.Name.EndsWith('.' + methodName, StringComparison.OrdinalIgnoreCase)))
                 {
                     var targetMethod = method;
                     if (method.IsGenericMethodDefinition)


### PR DESCRIPTION
## Summary
- include non-public methods when reflecting over the Telegram bot client implementation
- allow matching explicit interface implementations of MakeRequestAsync when searching for request executors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e5e8af0c8331bb990160ba8a2e01