### PR TITLE
Fix image editor fullscreen dialog layout

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
@@ -3,12 +3,17 @@
   flex-direction: column;
   width: min(960px, 100vw - 48px);
   max-height: 90vh;
+  box-sizing: border-box;
 }
 
 :host-context(.image-editor-dialog-fullscreen) {
   width: 100vw;
   height: 100vh;
   max-height: 100vh;
+  padding: 32px;
+  gap: 24px;
+  background: rgba(248, 250, 255, 0.96);
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.35);
 }
 
 .dialog-title {
@@ -32,6 +37,8 @@
 
 :host-context(.image-editor-dialog-fullscreen) .content {
   gap: 32px;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .canvas-area {
@@ -45,7 +52,7 @@
 }
 
 :host-context(.image-editor-dialog-fullscreen) .canvas-area {
-  min-height: 60vh;
+  min-height: 0;
 }
 
 .canvas-area canvas {
@@ -75,6 +82,10 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+:host-context(.image-editor-dialog-fullscreen) .toolbar {
+  flex: 0 0 auto;
 }
 
 .toolbar section {
@@ -146,5 +157,16 @@
   .canvas-area {
     width: 100%;
     min-height: 360px;
+  }
+}
+
+@media (max-width: 1024px) {
+  :host-context(.image-editor-dialog-fullscreen) {
+    padding: 24px;
+    gap: 20px;
+  }
+
+  :host-context(.image-editor-dialog-fullscreen) .content {
+    gap: 24px;
   }
 }

--- a/Angular/youtube-downloader/src/styles.css
+++ b/Angular/youtube-downloader/src/styles.css
@@ -13,6 +13,35 @@ body {
   background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
 }
 
+.image-editor-panel.image-editor-dialog-fullscreen {
+  top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  max-width: 100vw !important;
+  max-height: 100vh !important;
+}
+
+.image-editor-panel.image-editor-dialog-fullscreen .mat-mdc-dialog-surface {
+  height: 100%;
+  width: 100%;
+  max-width: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+.image-editor-panel.image-editor-dialog-fullscreen mat-dialog-container {
+  padding: 0;
+}
+
+@media (max-width: 1024px) {
+  .image-editor-panel.image-editor-dialog-fullscreen {
+    inset: 0 !important;
+  }
+}
+
 @media (max-width: 600px) {
   :root {
     --app-header-height: 56px;


### PR DESCRIPTION
## Summary
- restyle the image editor dialog to expand with padding and responsive spacing when fullscreen mode is enabled
- adjust global dialog pane styles so the fullscreen image editor overlay occupies the entire viewport without leftover margins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5451e970083319658537444170cbb