### PR TITLE
Fix image editor fullscreen layout

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
@@ -1,7 +1,8 @@
 :host {
   display: flex;
   flex-direction: column;
-  width: min(960px, 100vw - 48px);
+  width: 100%;
+  max-width: 960px;
   max-height: 90vh;
   box-sizing: border-box;
 }

--- a/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.ts
+++ b/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.ts
@@ -213,8 +213,8 @@ export class PngToWebpComponent implements OnDestroy {
         name: this.originalFile()?.name ?? 'image.png',
       },
       panelClass: 'image-editor-panel',
-      width: '90vw',
-      maxWidth: '960px',
+      width: '100%',
+      maxWidth: 'calc(100vw - 48px)',
     });
 
     const result = await firstValueFrom(dialogRef.afterClosed());

--- a/Angular/youtube-downloader/src/styles.css
+++ b/Angular/youtube-downloader/src/styles.css
@@ -25,6 +25,15 @@ body {
 }
 
 .image-editor-panel.image-editor-dialog-fullscreen .mat-mdc-dialog-surface {
+  margin: 0;
+  overflow: hidden;
+}
+
+.image-editor-panel .mat-mdc-dialog-surface {
+  width: 100%;
+}
+
+.image-editor-panel.image-editor-dialog-fullscreen .mat-mdc-dialog-surface {
   height: 100%;
   width: 100%;
   max-width: none;


### PR DESCRIPTION
## Summary
- keep the image editor dialog within the viewport by relying on responsive max-widths
- ensure the fullscreen dialog surface drops default margins to prevent horizontal scrolling
- retain canvas interactivity by stretching the dialog content without overflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5492eddbc83319a3e53a39918201c