### PR TITLE
Refine image editor layout and controls

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
@@ -30,22 +30,79 @@
 .content {
   flex: 1 1 auto;
   display: flex;
-  flex-direction: row;
-  gap: 24px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 16px;
   min-height: 0;
 }
 
 :host-context(.image-editor-dialog-fullscreen) .content {
-  gap: 32px;
+  gap: 20px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.controls .spacer {
   flex: 1 1 auto;
-  min-height: 0;
+}
+
+.zoom-select {
+  min-width: 180px;
+  flex: 0 0 auto;
+}
+
+.icon-button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.crop-group {
+  flex-wrap: nowrap;
+}
+
+.icon-button-group button.mat-mdc-icon-button {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: 8px;
+}
+
+.icon-button-group button.mat-mdc-icon-button .mat-mdc-button-touch-target {
+  width: 40px;
+  height: 40px;
+}
+
+.icon-button-group button.active {
+  background-color: rgba(63, 81, 181, 0.12);
+}
+
+.icon-button-group button[color='warn'] {
+  border-radius: 50%;
+}
+
+.crop-info {
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+  white-space: nowrap;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .canvas-area {
   position: relative;
-  flex: 1 1 60%;
+  flex: 1 1 auto;
   min-height: 420px;
+  width: 100%;
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(0, 0, 0, 0.12);
@@ -78,85 +135,16 @@
   pointer-events: none;
 }
 
-.toolbar {
-  flex: 1 1 40%;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-:host-context(.image-editor-dialog-fullscreen) .toolbar {
-  flex: 0 0 auto;
-}
-
-.toolbar section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.toolbar h3 {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.icon-button-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  align-items: center;
-}
-
-.icon-button-group button.mat-mdc-icon-button {
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  border-radius: 8px;
-}
-
-.icon-button-group button.mat-mdc-icon-button .mat-mdc-button-touch-target {
-  width: 40px;
-  height: 40px;
-}
-
-.icon-button-group button.active {
-  background-color: rgba(63, 81, 181, 0.12);
-}
-
-.icon-button-group button[color='warn'] {
-  border-radius: 50%;
-}
-
-.crop-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.crop-info {
-  font-size: 0.85rem;
-  color: rgba(0, 0, 0, 0.6);
-}
-
-.hint {
-  margin: 0;
-  font-size: 0.8rem;
-  color: rgba(0, 0, 0, 0.6);
-}
-
 .actions {
   padding-top: 16px;
 }
 
 @media (max-width: 900px) {
-  .content {
-    flex-direction: column;
+  .zoom-select {
+    min-width: 140px;
   }
 
   .canvas-area {
-    width: 100%;
     min-height: 360px;
   }
 }
@@ -168,6 +156,6 @@
   }
 
   :host-context(.image-editor-dialog-fullscreen) .content {
-    gap: 24px;
+    gap: 16px;
   }
 }

--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
@@ -12,127 +12,114 @@
   </button>
 </h2>
 <div mat-dialog-content class="content">
+  <div class="controls">
+    <mat-form-field appearance="outline" class="zoom-select">
+      <mat-label>Масштаб</mat-label>
+      <mat-select [value]="zoom()" (valueChange)="onZoomSelectionChange($event)">
+        <mat-option *ngFor="let option of zoomOptions()" [value]="option">
+          {{ formatZoomLabel(option) }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <div class="icon-button-group" aria-label="Поворот изображения">
+      <button
+        mat-icon-button
+        type="button"
+        (click)="rotateRight()"
+        matTooltip="Повернуть на 90° против часовой стрелки"
+        aria-label="Повернуть на 90 градусов против часовой стрелки"
+      >
+        <mat-icon>rotate_90_degrees_ccw</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        type="button"
+        (click)="rotate180()"
+        matTooltip="Повернуть на 180°"
+        aria-label="Повернуть на 180 градусов"
+      >
+        <mat-icon>rotate_left</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        type="button"
+        (click)="rotate270()"
+        matTooltip="Повернуть на 90° по часовой стрелке"
+        aria-label="Повернуть на 90 градусов по часовой стрелке"
+      >
+        <mat-icon>rotate_90_degrees_cw</mat-icon>
+      </button>
+    </div>
+
+    <div class="icon-button-group" aria-label="Отражение изображения">
+      <button
+        mat-icon-button
+        type="button"
+        (click)="flipHorizontally()"
+        matTooltip="Отразить по горизонтали"
+        aria-label="Отразить изображение по горизонтали"
+      >
+        <mat-icon>flip</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        type="button"
+        (click)="flipVertically()"
+        matTooltip="Отразить по вертикали"
+        aria-label="Отразить изображение по вертикали"
+      >
+        <mat-icon>swap_vert</mat-icon>
+      </button>
+    </div>
+
+    <div class="icon-button-group crop-group" aria-label="Обрезка изображения">
+      <button
+        mat-icon-button
+        type="button"
+        (click)="toggleCrop()"
+        [color]="isCropping() ? 'primary' : undefined"
+        [class.active]="isCropping()"
+        matTooltip="Выделить область для обрезки"
+        aria-label="Выделить область для обрезки"
+      >
+        <mat-icon>crop</mat-icon>
+      </button>
+      <button
+        *ngIf="isCropping()"
+        mat-icon-button
+        color="primary"
+        type="button"
+        (click)="applyCropSelection()"
+        matTooltip="Применить обрезку"
+        aria-label="Применить обрезку"
+      >
+        <mat-icon>done</mat-icon>
+      </button>
+    </div>
+
+    <div class="icon-button-group">
+      <button
+        mat-icon-button
+        color="warn"
+        type="button"
+        (click)="reset()"
+        matTooltip="Сбросить все изменения"
+        aria-label="Сбросить все изменения"
+      >
+        <mat-icon>refresh</mat-icon>
+      </button>
+    </div>
+
+    <span class="spacer"></span>
+    <div class="crop-info">{{ cropInfo() }}</div>
+  </div>
+
+  <p class="hint">Перемещайте изображение мышью для панорамирования. Обрезка работает при активной кнопке.</p>
+
   <div class="canvas-area" #canvasContainer>
     <div class="checkerboard"></div>
     <canvas #canvas></canvas>
-  </div>
-  <div class="toolbar">
-    <section>
-      <h3>Масштаб</h3>
-      <mat-button-toggle-group [value]="zoom()" (change)="onZoomChange($event)" name="zoom" [multiple]="false">
-        <mat-button-toggle
-          *ngFor="let option of zoomOptions(); trackBy: trackZoomOption"
-          [value]="option"
-        >
-          {{ formatZoomLabel(option) }}
-        </mat-button-toggle>
-      </mat-button-toggle-group>
-    </section>
-
-    <section>
-      <h3>Поворот</h3>
-      <div class="icon-button-group">
-        <button
-          mat-icon-button
-          type="button"
-          (click)="rotateRight()"
-          matTooltip="Повернуть на 90° против часовой стрелки"
-          aria-label="Повернуть на 90 градусов против часовой стрелки"
-        >
-          <mat-icon>rotate_90_degrees_ccw</mat-icon>
-        </button>
-        <button
-          mat-icon-button
-          type="button"
-          (click)="rotate180()"
-          matTooltip="Повернуть на 180°"
-          aria-label="Повернуть на 180 градусов"
-        >
-          <mat-icon>rotate_left</mat-icon>
-        </button>
-        <button
-          mat-icon-button
-          type="button"
-          (click)="rotate270()"
-          matTooltip="Повернуть на 90° по часовой стрелке"
-          aria-label="Повернуть на 90 градусов по часовой стрелке"
-        >
-          <mat-icon>rotate_90_degrees_cw</mat-icon>
-        </button>
-      </div>
-    </section>
-
-    <section>
-      <h3>Отражение</h3>
-      <div class="icon-button-group">
-        <button
-          mat-icon-button
-          type="button"
-          (click)="flipHorizontally()"
-          matTooltip="Отразить по горизонтали"
-          aria-label="Отразить изображение по горизонтали"
-        >
-          <mat-icon>flip</mat-icon>
-        </button>
-        <button
-          mat-icon-button
-          type="button"
-          (click)="flipVertically()"
-          matTooltip="Отразить по вертикали"
-          aria-label="Отразить изображение по вертикали"
-        >
-          <mat-icon>swap_vert</mat-icon>
-        </button>
-      </div>
-    </section>
-
-    <section>
-      <h3>Обрезка</h3>
-      <div class="crop-controls">
-        <div class="icon-button-group">
-          <button
-            mat-icon-button
-            type="button"
-            (click)="toggleCrop()"
-            [color]="isCropping() ? 'primary' : undefined"
-            [class.active]="isCropping()"
-            matTooltip="Выделить область для обрезки"
-            aria-label="Выделить область для обрезки"
-          >
-            <mat-icon>crop</mat-icon>
-          </button>
-          <button
-            *ngIf="isCropping()"
-            mat-icon-button
-            color="primary"
-            type="button"
-            (click)="applyCropSelection()"
-            matTooltip="Применить обрезку"
-            aria-label="Применить обрезку"
-          >
-            <mat-icon>done</mat-icon>
-          </button>
-        </div>
-        <div class="crop-info">{{ cropInfo() }}</div>
-      </div>
-    </section>
-
-    <section>
-      <h3>Прочее</h3>
-      <div class="icon-button-group">
-        <button
-          mat-icon-button
-          color="warn"
-          type="button"
-          (click)="reset()"
-          matTooltip="Сбросить все изменения"
-          aria-label="Сбросить все изменения"
-        >
-          <mat-icon>refresh</mat-icon>
-        </button>
-      </div>
-      <p class="hint">Перемещайте изображение мышью для панорамирования. Обрезка работает при активной кнопке.</p>
-    </section>
   </div>
 </div>
 <div mat-dialog-actions align="end" class="actions">

--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.ts
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.ts
@@ -12,9 +12,10 @@ import {
   signal,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MatButtonToggleChange, MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 export interface CropRect {
@@ -72,7 +73,8 @@ interface ActiveCropHandle {
     MatDialogModule,
     MatButtonModule,
     MatIconModule,
-    MatButtonToggleModule,
+    MatFormFieldModule,
+    MatSelectModule,
     MatTooltipModule,
   ],
   templateUrl: './image-editor-dialog.component.html',
@@ -113,8 +115,6 @@ export class ImageEditorDialogComponent implements AfterViewInit, OnDestroy {
 
   readonly isCropping: WritableSignal<boolean> = signal(false);
   readonly isFullscreen: WritableSignal<boolean> = signal(false);
-  protected readonly trackZoomOption = (_: number, option: number): number => option;
-
   private image: ImageBitmap | HTMLImageElement | null = null;
   private resizeObserver?: ResizeObserver;
   private pointerActive = false;
@@ -261,8 +261,7 @@ export class ImageEditorDialogComponent implements AfterViewInit, OnDestroy {
     this.focusOnCropArea(crop);
   }
 
-  onZoomChange(event: MatButtonToggleChange): void {
-    const value = event.value as number;
+  onZoomSelectionChange(value: number): void {
     if (typeof value !== 'number') return;
     this.updateZoom(value, { resetPan: true });
   }


### PR DESCRIPTION
## Summary
- replace the zoom toggle group with a dropdown and align all editor controls in a single toolbar row above the canvas
- update the dialog styling so the canvas spans the dialog width and remains responsive, including fullscreen mode
- add the required Angular Material form field and select modules along with the updated zoom change handler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54dbd2b2083319e251f5e0e1cf3ab