### PR TITLE
Refine image editor toolbar layout

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
@@ -1,14 +1,15 @@
 :host {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 960px;
-  max-height: 90vh;
   box-sizing: border-box;
+  max-height: 90vh;
+  width: min(960px, calc(100vw - 32px));
+  max-width: 100%;
 }
 
 :host-context(.image-editor-dialog-fullscreen) {
   width: 100vw;
+  max-width: none;
   height: 100vh;
   max-height: 100vh;
   padding: 32px;
@@ -43,7 +44,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .controls .spacer {
@@ -55,35 +56,46 @@
   flex: 0 0 auto;
 }
 
-.icon-button-group {
+.toolbar-group {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
   align-items: center;
+  gap: 8px;
+}
+
+.toolbar-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 0 12px;
+  border-radius: 8px;
+  text-transform: none;
+}
+
+.toolbar-action mat-icon {
+  font-size: 20px;
+}
+
+.toolbar-action.active,
+.toolbar-action[color='primary'] {
+  background-color: rgba(63, 81, 181, 0.08);
+}
+
+.toolbar-action[color='warn'] {
+  background-color: rgba(244, 67, 54, 0.08);
+}
+
+.toolbar-divider {
+  width: 1px;
+  height: 32px;
+  background-color: rgba(0, 0, 0, 0.12);
+  margin: 0 4px;
+  align-self: center;
 }
 
 .crop-group {
   flex-wrap: nowrap;
-}
-
-.icon-button-group button.mat-mdc-icon-button {
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  border-radius: 8px;
-}
-
-.icon-button-group button.mat-mdc-icon-button .mat-mdc-button-touch-target {
-  width: 40px;
-  height: 40px;
-}
-
-.icon-button-group button.active {
-  background-color: rgba(63, 81, 181, 0.12);
-}
-
-.icon-button-group button[color='warn'] {
-  border-radius: 50%;
 }
 
 .crop-info {

--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.html
@@ -22,61 +22,78 @@
       </mat-select>
     </mat-form-field>
 
-    <div class="icon-button-group" aria-label="Поворот изображения">
+    <div class="toolbar-divider" role="separator" aria-orientation="vertical"></div>
+
+    <div class="toolbar-group" aria-label="Поворот изображения">
       <button
-        mat-icon-button
+        mat-button
         type="button"
+        class="toolbar-action"
         (click)="rotateRight()"
         matTooltip="Повернуть на 90° против часовой стрелки"
         aria-label="Повернуть на 90 градусов против часовой стрелки"
       >
         <mat-icon>rotate_90_degrees_ccw</mat-icon>
+        <span>90° влево</span>
       </button>
       <button
-        mat-icon-button
+        mat-button
         type="button"
+        class="toolbar-action"
         (click)="rotate180()"
         matTooltip="Повернуть на 180°"
         aria-label="Повернуть на 180 градусов"
       >
         <mat-icon>rotate_left</mat-icon>
+        <span>180°</span>
       </button>
       <button
-        mat-icon-button
+        mat-button
         type="button"
+        class="toolbar-action"
         (click)="rotate270()"
         matTooltip="Повернуть на 90° по часовой стрелке"
         aria-label="Повернуть на 90 градусов по часовой стрелке"
       >
         <mat-icon>rotate_90_degrees_cw</mat-icon>
+        <span>90° вправо</span>
       </button>
     </div>
 
-    <div class="icon-button-group" aria-label="Отражение изображения">
+    <div class="toolbar-divider" role="separator" aria-orientation="vertical"></div>
+
+    <div class="toolbar-group" aria-label="Отражение изображения">
       <button
-        mat-icon-button
+        mat-button
         type="button"
+        class="toolbar-action"
         (click)="flipHorizontally()"
         matTooltip="Отразить по горизонтали"
         aria-label="Отразить изображение по горизонтали"
       >
         <mat-icon>flip</mat-icon>
+        <span>Отразить по горизонтали</span>
       </button>
       <button
-        mat-icon-button
+        mat-button
         type="button"
+        class="toolbar-action"
         (click)="flipVertically()"
         matTooltip="Отразить по вертикали"
         aria-label="Отразить изображение по вертикали"
       >
         <mat-icon>swap_vert</mat-icon>
+        <span>Отразить по вертикали</span>
       </button>
     </div>
 
-    <div class="icon-button-group crop-group" aria-label="Обрезка изображения">
+    <div class="toolbar-divider" role="separator" aria-orientation="vertical"></div>
+
+    <div class="toolbar-group crop-group" aria-label="Обрезка изображения">
       <button
-        mat-icon-button
+        mat-button
         type="button"
+        class="toolbar-action"
         (click)="toggleCrop()"
         [color]="isCropping() ? 'primary' : undefined"
         [class.active]="isCropping()"
@@ -84,30 +101,37 @@
         aria-label="Выделить область для обрезки"
       >
         <mat-icon>crop</mat-icon>
+        <span>Обрезка</span>
       </button>
       <button
         *ngIf="isCropping()"
-        mat-icon-button
+        mat-button
         color="primary"
         type="button"
+        class="toolbar-action"
         (click)="applyCropSelection()"
         matTooltip="Применить обрезку"
         aria-label="Применить обрезку"
       >
         <mat-icon>done</mat-icon>
+        <span>Применить</span>
       </button>
     </div>
 
-    <div class="icon-button-group">
+    <div class="toolbar-divider" role="separator" aria-orientation="vertical"></div>
+
+    <div class="toolbar-group">
       <button
-        mat-icon-button
+        mat-button
         color="warn"
         type="button"
+        class="toolbar-action"
         (click)="reset()"
         matTooltip="Сбросить все изменения"
         aria-label="Сбросить все изменения"
       >
         <mat-icon>refresh</mat-icon>
+        <span>Сбросить</span>
       </button>
     </div>
 

--- a/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.ts
+++ b/Angular/youtube-downloader/src/app/png-to-webp/png-to-webp.component.ts
@@ -213,8 +213,8 @@ export class PngToWebpComponent implements OnDestroy {
         name: this.originalFile()?.name ?? 'image.png',
       },
       panelClass: 'image-editor-panel',
-      width: '100%',
-      maxWidth: 'calc(100vw - 48px)',
+      width: 'auto',
+      maxWidth: '100vw',
     });
 
     const result = await firstValueFrom(dialogRef.afterClosed());


### PR DESCRIPTION
## Summary
- restyle the image editor toolbar with labeled Material buttons grouped by separators for clarity
- adjust dialog sizing rules so the fullscreen mode spans the viewport without awkward margins
- open the editor dialog with automatic width constraints to avoid the initial overly wide layout

## Testing
- CI=1 npm run build -- --configuration production

------
https://chatgpt.com/codex/tasks/task_e_68e551a2c6308331ab8caae6de701fe0