### PR TITLE
Adjust fullscreen image editor layout

### DIFF
--- a/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
+++ b/Angular/youtube-downloader/src/app/png-to-webp/image-editor-dialog.component.css
@@ -40,6 +40,11 @@
   gap: 20px;
 }
 
+:host-context(.image-editor-dialog-fullscreen) .content.mat-mdc-dialog-content {
+  max-height: none;
+  overflow: visible;
+}
+
 .controls {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- remove the max-height restriction from the image editor dialog content when fullscreen
- allow the dialog body to stretch so the canvas occupies the full height in fullscreen mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e55b1a4c988331a28b40a8dec9c521