### PR TITLE
Style OpenAI transcription action menus

### DIFF
--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.css
@@ -504,6 +504,57 @@ section {
   gap: 12px;
 }
 
+:host ::ng-deep .mat-mdc-menu-panel.action-menu {
+  --menu-radius: 18px;
+  border-radius: var(--menu-radius);
+  background: #ffffff;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  overflow: hidden;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-content {
+  padding: 6px 0;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item {
+  height: 44px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: #0f172a;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item .mdc-list-item__primary-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-icon {
+  font-size: 22px;
+  color: #475569;
+  margin-right: 12px;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:hover:not([disabled]) {
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:hover:not([disabled]) .mat-icon {
+  color: #1d4ed8;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled] {
+  opacity: 0.45;
+  color: #64748b;
+}
+
+:host ::ng-deep .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled] .mat-icon {
+  color: #94a3b8;
+}
+
 .markdown-content {
   border-radius: 18px;
   padding: 24px;

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -153,7 +153,7 @@
                       </button>
                     </div>
                  
-                    <mat-menu #downloadMenu="matMenu">
+                    <mat-menu #downloadMenu="matMenu" class="action-menu">
                       <button
                         mat-menu-item
                         (click)="onDownload('md')"
@@ -187,7 +187,7 @@
                         <span>SRT субтитры</span>
                       </button>
                     </mat-menu>
-                    <mat-menu #copyMenu="matMenu">
+                    <mat-menu #copyMenu="matMenu" class="action-menu">
                       <button
                         mat-menu-item
                         (click)="onCopy('txt')"


### PR DESCRIPTION
## Summary
- apply a dedicated action-menu panel style to download and copy menus in the transcription workspace
- polish menu appearance with rounded panels, balanced spacing, hover accents, and refined disabled states to fit the app aesthetic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5eeb760288331bdb0215c280e5e50