### PR TITLE
Style transcription menus with shared action menu theme

### DIFF
--- a/Angular/youtube-downloader/src/app/Markdown-converter/markdown-converter.component.html
+++ b/Angular/youtube-downloader/src/app/Markdown-converter/markdown-converter.component.html
@@ -45,7 +45,7 @@
     </div>
   </div>
 
-  <mat-menu #downloadMenu="matMenu">
+  <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
     <button mat-menu-item (click)="onDownloadMd()" [disabled]="!hasContent">
       <mat-icon>article</mat-icon>
       <span>Markdown (.md)</span>
@@ -64,7 +64,7 @@
     </button>
   </mat-menu>
 
-  <mat-menu #copyMenu="matMenu">
+  <mat-menu #copyMenu="matMenu" panelClass="action-menu">
     <button mat-menu-item (click)="onCopyHtml()" [disabled]="!hasContent">
       <mat-icon>code</mat-icon>
       <span>HTML</span>

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -153,7 +153,7 @@
                       </button>
                     </div>
                  
-                    <mat-menu #downloadMenu="matMenu">
+                    <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
                       <button
                         mat-menu-item
                         (click)="onDownload('md')"
@@ -187,7 +187,7 @@
                         <span>SRT субтитры</span>
                       </button>
                     </mat-menu>
-                    <mat-menu #copyMenu="matMenu">
+                    <mat-menu #copyMenu="matMenu" panelClass="action-menu">
                       <button
                         mat-menu-item
                         (click)="onCopy('txt')"

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -71,7 +71,7 @@
       </div>
     </div>
 
-    <mat-menu #downloadMenu="matMenu">
+    <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
       <button mat-menu-item (click)="downloadAsPdf()" [disabled]="isDownloading || !canDownloadFromServer">
         <mat-icon>picture_as_pdf</mat-icon>
         <span>PDF</span>
@@ -94,7 +94,7 @@
       </button>
     </mat-menu>
 
-    <mat-menu #copyMenu="matMenu">
+    <mat-menu #copyMenu="matMenu" panelClass="action-menu">
       <button mat-menu-item (click)="copyToClipboard()" [disabled]="isCopying || !hasResultText">
         <mat-icon>notes</mat-icon>
         <span>Текст (plain)</span>

--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
@@ -22,7 +22,7 @@
       Скачать
     </button>
 
-    <mat-menu #downloadMenu="matMenu">
+    <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
       <button
         mat-menu-item
         (click)="onDownload('md')"
@@ -67,7 +67,7 @@
       Копировать
     </button>
 
-    <mat-menu #copyMenu="matMenu">
+    <mat-menu #copyMenu="matMenu" panelClass="action-menu">
       <button
         mat-menu-item
         (click)="onCopy('txt')"

--- a/Angular/youtube-downloader/src/styles.css
+++ b/Angular/youtube-downloader/src/styles.css
@@ -13,6 +13,76 @@ body {
   background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
 }
 
+.mat-mdc-menu-panel.action-menu {
+  --action-menu-radius: 18px;
+  border-radius: var(--action-menu-radius);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow:
+    0 18px 40px rgba(15, 23, 42, 0.18),
+    0 2px 8px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-content {
+  padding: 8px 0;
+  min-width: 232px;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item {
+  height: 44px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  color: #0f172a;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item .mat-mdc-menu-item-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 4px;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-icon {
+  font-size: 20px;
+  color: #475569;
+  width: 20px;
+  height: 20px;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:hover:not([disabled]),
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item.cdk-focused:not([disabled]) {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:hover:not([disabled]) .mat-icon,
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item.cdk-focused:not([disabled]) .mat-icon {
+  color: #1d4ed8;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:active:not([disabled]) {
+  background: rgba(59, 130, 246, 0.22);
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled] {
+  color: #94a3b8;
+  opacity: 0.55;
+}
+
+.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled] .mat-icon {
+  color: #cbd5f5;
+}
+
+@media (max-width: 600px) {
+  .mat-mdc-menu-panel.action-menu .mat-mdc-menu-content {
+    min-width: 200px;
+  }
+}
+
 .image-editor-panel.image-editor-dialog-fullscreen {
   top: 0 !important;
   right: 0 !important;


### PR DESCRIPTION
## Summary
- move the action menu styling into the global stylesheet and enhance its visual treatment to better mirror the YouScriptor aesthetic
- attach the shared action menu panel class to download and copy menus across the transcription pages so every overlay picks up the refreshed look

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5eeb760288331bdb0215c280e5e50