### PR TITLE
feat: style action menus via directive

### DIFF
--- a/Angular/youtube-downloader/src/app/Markdown-converter/markdown-converter.component.html
+++ b/Angular/youtube-downloader/src/app/Markdown-converter/markdown-converter.component.html
@@ -45,7 +45,7 @@
     </div>
   </div>
 
-  <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
+  <mat-menu #downloadMenu="matMenu" actionMenuPanel>
     <button mat-menu-item (click)="onDownloadMd()" [disabled]="!hasContent">
       <mat-icon>article</mat-icon>
       <span>Markdown (.md)</span>
@@ -64,7 +64,7 @@
     </button>
   </mat-menu>
 
-  <mat-menu #copyMenu="matMenu" panelClass="action-menu">
+  <mat-menu #copyMenu="matMenu" actionMenuPanel>
     <button mat-menu-item (click)="onCopyHtml()" [disabled]="!hasContent">
       <mat-icon>code</mat-icon>
       <span>HTML</span>

--- a/Angular/youtube-downloader/src/app/Markdown-converter/markdown-converter.component.ts
+++ b/Angular/youtube-downloader/src/app/Markdown-converter/markdown-converter.component.ts
@@ -8,6 +8,7 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatMenuModule } from '@angular/material/menu';
 import { LMarkdownEditorModule } from 'ngx-markdown-editor';
 import { MatCardModule } from '@angular/material/card';
+import { ActionMenuPanelDirective } from '../shared/action-menu-panel.directive';
 import { SubtitleService } from '../services/subtitle.service';
 import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
 import { v4 as uuidv4 } from 'uuid';
@@ -24,7 +25,8 @@ import { YoutubeCaptionTaskDto } from '../services/subtitle.service';
     MatButtonModule,
     MatIconModule,
     MatSnackBarModule,
-    MatMenuModule
+    MatMenuModule,
+    ActionMenuPanelDirective
   ],
   templateUrl: './markdown-converter.component.html',
   styleUrls: ['./markdown-converter.component.css']

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.html
@@ -153,7 +153,7 @@
                       </button>
                     </div>
                  
-                    <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
+                    <mat-menu #downloadMenu="matMenu" actionMenuPanel>
                       <button
                         mat-menu-item
                         (click)="onDownload('md')"
@@ -187,7 +187,7 @@
                         <span>SRT субтитры</span>
                       </button>
                     </mat-menu>
-                    <mat-menu #copyMenu="matMenu" panelClass="action-menu">
+                    <mat-menu #copyMenu="matMenu" actionMenuPanel>
                       <button
                         mat-menu-item
                         (click)="onCopy('txt')"

--- a/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
+++ b/Angular/youtube-downloader/src/app/openai-transcription/openai-transcription.component.ts
@@ -22,6 +22,7 @@ import { LocalTimePipe } from '../pipe/local-time.pipe';
 import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
 import { MatDialog } from '@angular/material/dialog';
 import { OpenAiTranscriptionUploadDialogComponent } from './openai-transcription-upload-dialog.component';
+import { ActionMenuPanelDirective } from '../shared/action-menu-panel.directive';
 
 @Component({
   selector: 'app-openai-transcriptions',
@@ -36,6 +37,7 @@ import { OpenAiTranscriptionUploadDialogComponent } from './openai-transcription
     MatSnackBarModule,
     LocalTimePipe,
     RouterModule,
+    ActionMenuPanelDirective,
   ],
   templateUrl: './openai-transcription.component.html',
   styleUrls: ['./openai-transcription.component.css'],

--- a/Angular/youtube-downloader/src/app/shared/action-menu-panel.directive.ts
+++ b/Angular/youtube-downloader/src/app/shared/action-menu-panel.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, OnInit } from '@angular/core';
+import { MatMenu } from '@angular/material/menu';
+
+@Directive({
+  selector: 'mat-menu[actionMenuPanel]',
+  standalone: true,
+})
+export class ActionMenuPanelDirective implements OnInit {
+  constructor(private readonly matMenu: MatMenu) {}
+
+  ngOnInit(): void {
+    const existing = this.matMenu.panelClass;
+    const classes = new Set<string>();
+
+    if (Array.isArray(existing)) {
+      existing.filter(Boolean).forEach((value) => classes.add(value));
+    } else if (typeof existing === 'string' && existing.trim().length) {
+      existing
+        .split(/\s+/)
+        .filter(Boolean)
+        .forEach((value) => classes.add(value));
+    }
+
+    classes.add('action-menu-panel');
+    this.matMenu.panelClass = Array.from(classes);
+  }
+}

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.html
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.html
@@ -71,7 +71,7 @@
       </div>
     </div>
 
-    <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
+    <mat-menu #downloadMenu="matMenu" actionMenuPanel>
       <button mat-menu-item (click)="downloadAsPdf()" [disabled]="isDownloading || !canDownloadFromServer">
         <mat-icon>picture_as_pdf</mat-icon>
         <span>PDF</span>
@@ -94,7 +94,7 @@
       </button>
     </mat-menu>
 
-    <mat-menu #copyMenu="matMenu" panelClass="action-menu">
+    <mat-menu #copyMenu="matMenu" actionMenuPanel>
       <button mat-menu-item (click)="copyToClipboard()" [disabled]="isCopying || !hasResultText">
         <mat-icon>notes</mat-icon>
         <span>Текст (plain)</span>

--- a/Angular/youtube-downloader/src/app/task-result/task-result.component.ts
+++ b/Angular/youtube-downloader/src/app/task-result/task-result.component.ts
@@ -15,6 +15,7 @@ import { YandexAdComponent } from '../ydx-ad/yandex-ad.component';
 import { RouterModule } from '@angular/router'; // ⬅️ Добавить
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AuthService } from '../services/AuthService.service';
+import { ActionMenuPanelDirective } from '../shared/action-menu-panel.directive';
 
 @Component({
   selector: 'app-task-result',
@@ -27,7 +28,8 @@ import { AuthService } from '../services/AuthService.service';
     MatDialogModule,
     MatMenuModule,
     LocalTimePipe,
-    YandexAdComponent
+    YandexAdComponent,
+    ActionMenuPanelDirective
   ],
   templateUrl: './task-result.component.html',
   styleUrls: ['./task-result.component.css']

--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.html
@@ -22,7 +22,7 @@
       Скачать
     </button>
 
-    <mat-menu #downloadMenu="matMenu" panelClass="action-menu">
+    <mat-menu #downloadMenu="matMenu" actionMenuPanel>
       <button
         mat-menu-item
         (click)="onDownload('md')"
@@ -67,7 +67,7 @@
       Копировать
     </button>
 
-    <mat-menu #copyMenu="matMenu" panelClass="action-menu">
+    <mat-menu #copyMenu="matMenu" actionMenuPanel>
       <button
         mat-menu-item
         (click)="onCopy('txt')"

--- a/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.ts
+++ b/Angular/youtube-downloader/src/app/transcription-editor/transcription-editor.component.ts
@@ -16,6 +16,7 @@ import {
   OpenAiTranscriptionTaskDetailsDto
 } from '../services/openai-transcription.service';
 import { MarkdownRendererService1 } from '../task-result/markdown-renderer.service';
+import { ActionMenuPanelDirective } from '../shared/action-menu-panel.directive';
 
 @Component({
   selector: 'app-transcription-editor',
@@ -29,7 +30,8 @@ import { MarkdownRendererService1 } from '../task-result/markdown-renderer.servi
     MatIconModule,
     MatSnackBarModule,
     MatProgressSpinnerModule,
-    MatMenuModule
+    MatMenuModule,
+    ActionMenuPanelDirective
   ],
   templateUrl: './transcription-editor.component.html',
   styleUrls: ['./transcription-editor.component.css']

--- a/Angular/youtube-downloader/src/styles.css
+++ b/Angular/youtube-downloader/src/styles.css
@@ -14,55 +14,54 @@ body {
 }
 
 
-.mat-mdc-menu-panel.action-menu {
-  --action-menu-radius: 18px;
-  --action-menu-accent: #2563eb;
-  border-radius: var(--action-menu-radius);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(241, 245, 249, 0.92) 100%);
+.mat-mdc-menu-panel.action-menu-panel {
+  --action-menu-panel-accent: #2563eb;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(180deg, #ffffff 0%, #f3f6ff 100%);
   box-shadow:
-    0 22px 48px rgba(15, 23, 42, 0.18),
-    0 4px 18px rgba(15, 23, 42, 0.12);
-  padding: 10px 0;
+    0 18px 40px rgba(15, 23, 42, 0.16),
+    0 4px 14px rgba(15, 23, 42, 0.12);
+  padding-block: 8px;
+  padding-inline: 0;
+  min-width: 232px;
   overflow: hidden;
-  backdrop-filter: blur(14px);
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-content {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-content {
   padding: 0;
-  min-width: 236px;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item {
-  min-height: 46px;
-  margin: 0 12px;
-  padding: 0 16px;
-  border-radius: 12px;
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
+  margin-inline: 10px;
+  padding-inline: 14px;
+  min-height: 44px;
+  border-radius: 12px;
+  color: #0f172a;
   font-weight: 500;
   font-size: 0.95rem;
   letter-spacing: 0.01em;
-  color: #0f172a;
   transition:
     background-color 0.18s ease,
     box-shadow 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
+    color 0.18s ease;
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item .mat-mdc-menu-item-text {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item .mat-mdc-menu-item-text,
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item .mdc-list-item__primary-text {
   flex: 1;
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
 }
 
-.mat-mdc-menu-panel.action-menu .mat-icon {
+.mat-mdc-menu-panel.action-menu-panel .mat-icon {
   font-size: 22px;
   width: 22px;
   height: 22px;
@@ -70,56 +69,50 @@ body {
   transition: color 0.18s ease;
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:hover:not([disabled]),
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item.cdk-focused:not([disabled]),
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item.cdk-program-focused:not([disabled]) {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item:not([disabled]):hover,
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item.cdk-focused:not([disabled]),
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item.cdk-program-focused:not([disabled]) {
   background-color: rgba(37, 99, 235, 0.12);
-  color: var(--action-menu-accent);
   box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.15);
-  transform: translateX(2px);
+  color: var(--action-menu-panel-accent);
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:hover:not([disabled]) .mat-icon,
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item.cdk-focused:not([disabled]) .mat-icon,
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item.cdk-program-focused:not([disabled]) .mat-icon {
-  color: var(--action-menu-accent);
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item:not([disabled]):hover .mat-icon,
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item.cdk-focused:not([disabled]) .mat-icon,
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item.cdk-program-focused:not([disabled]) .mat-icon {
+  color: var(--action-menu-panel-accent);
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item:active:not([disabled]) {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item:active:not([disabled]) {
   background-color: rgba(37, 99, 235, 0.2);
   box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25);
-  transform: translateX(1px);
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled] {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item[disabled] {
   color: #94a3b8;
-  opacity: 0.7;
+  opacity: 0.72;
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled] .mat-icon {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item[disabled] .mat-icon {
   color: #cbd5f5;
 }
 
-.mat-mdc-menu-panel.action-menu .mat-mdc-menu-item[disabled]:hover {
+.mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item[disabled]:hover {
   background-color: transparent;
   box-shadow: none;
-  transform: none;
+  color: #94a3b8;
 }
 
 @media (max-width: 600px) {
-  .mat-mdc-menu-panel.action-menu {
-    --action-menu-radius: 16px;
-  }
-
-  .mat-mdc-menu-panel.action-menu .mat-mdc-menu-content {
+  .mat-mdc-menu-panel.action-menu-panel {
+    border-radius: 14px;
     min-width: 210px;
-    gap: 2px;
   }
 
-  .mat-mdc-menu-panel.action-menu .mat-mdc-menu-item {
-    margin: 0 8px;
-    min-height: 44px;
-    padding: 0 14px;
+  .mat-mdc-menu-panel.action-menu-panel .mat-mdc-menu-item {
+    margin-inline: 8px;
+    min-height: 42px;
+    padding-inline: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable `actionMenuPanel` directive that attaches the shared styling class to Material menus
- apply the directive to download and copy menus across markdown, transcription, and task result flows
- refresh the global action-menu styling for a consistent panel look

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e601b1046083318dee8e546221c6d2