### PR TITLE
Fix action menu panel directive panelClass assignment

### DIFF
--- a/Angular/youtube-downloader/src/app/shared/action-menu-panel.directive.ts
+++ b/Angular/youtube-downloader/src/app/shared/action-menu-panel.directive.ts
@@ -22,6 +22,6 @@ export class ActionMenuPanelDirective implements OnInit {
     }
 
     classes.add('action-menu-panel');
-    this.matMenu.panelClass = Array.from(classes);
+    this.matMenu.panelClass = Array.from(classes).join(' ');
   }
 }


### PR DESCRIPTION
## Summary
- ensure the action menu panel directive assigns a space-delimited string to `panelClass`
- preserve collected class names when setting the menu panel class

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e603dd7148833196531b1f21e3f7e5