### PR TITLE
Log plain text Telegram messages

### DIFF
--- a/services/Telegram/TelegramTranscriptionBot.cs
+++ b/services/Telegram/TelegramTranscriptionBot.cs
@@ -251,10 +251,15 @@ namespace YandexSpeech.services.Telegram
 
             try
             {
-                if (message.Text is string text && text.StartsWith("/"))
+                if (message.Text is string text)
                 {
-                    await HandleCommandAsync(message, text, cancellationToken).ConfigureAwait(false);
-                    return;
+                    if (text.StartsWith("/"))
+                    {
+                        await HandleCommandAsync(message, text, cancellationToken).ConfigureAwait(false);
+                        return;
+                    }
+
+                    LogEvent("text", message, text, extra: null);
                 }
 
                 var audioPayload = FindAudioPayload(message);


### PR DESCRIPTION
## Summary
- log non-command text messages from Telegram conversations so they are captured in the bot's log file

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e61648517883319c08f9b75721b399