### PR TITLE
Switch Google OAuth token endpoint to www.googleapis.com

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -138,7 +138,8 @@ if (!string.IsNullOrWhiteSpace(googleClientId) && !string.IsNullOrWhiteSpace(goo
         // даже не открывается. Пробрасываем конфигурацию вручную и отключаем
         // ConfigurationManager, чтобы handler использовал статические URL.
         opts.AuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
-        opts.TokenEndpoint = "https://oauth2.googleapis.com/token";
+        // Fix for region-based block of oauth2.googleapis.com (Crimea). Using www.googleapis.com instead.
+        opts.TokenEndpoint = "https://www.googleapis.com/oauth2/v4/token";
         opts.UserInformationEndpoint = "https://www.googleapis.com/oauth2/v3/userinfo";
 
         // В некоторых окружениях Google может обрывать HTTP/2-соединения,


### PR DESCRIPTION
## Summary
- update the Google OAuth token endpoint to point at www.googleapis.com to avoid regional blocks
- document the regional block fix in-line with a comment

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_690b33c8afd88331acf7088a650455f2